### PR TITLE
Change slot range names of crafting table

### DIFF
--- a/enums/windows.json
+++ b/enums/windows.json
@@ -90,11 +90,11 @@
     "name": "Workbench",
     "slots": [
       {
-        "name": "result",
+        "name": "craft result",
         "index": 0
       },
       {
-        "name": "grid",
+        "name": "craft grid",
         "index": 1,
         "size": 10
       }


### PR DESCRIPTION
    grid -> craft grid
    result -> craft result

It makes no sense to name them differently than in the player inventory.