### PR TITLE
Clean up protocol.json formatting a bit

### DIFF
--- a/data/1.9/protocol.json
+++ b/data/1.9/protocol.json
@@ -2442,15 +2442,27 @@
         "set_cooldown": {
           "id": "0x17",
           "fields": [
-            { "name": "itemID", "type": "varint" },
-            { "name": "cooldownTicks", "type": "varint" }
+            {
+              "name": "itemID",
+              "type": "varint"
+            },
+            {
+              "name": "cooldownTicks",
+              "type": "varint"
+            }
           ]
         },
         "unload_chunk": {
           "id": "0x1c",
           "fields": [
-            { "name": "chunkX", "type": "int" },
-            { "name": "chunkZ", "type": "int" }
+            {
+              "name": "chunkX",
+              "type": "int"
+            },
+            { 
+              "name": "chunkZ",
+              "type": "int"
+            }
           ]
         }
       },
@@ -2928,7 +2940,10 @@
         "use_item": {
           "id": "0x1a",
           "fields": [
-            { "name": "hand", "type": "varint" }
+            {
+              "name": "hand",
+              "type": "varint"
+            }
           ]
         }
       }


### PR DESCRIPTION
Some minor formatting inconsistencies I noticed while using protocol.json as a reference.