### PR TITLE
16w04a update

### DIFF
--- a/data/1.9/protocol.json
+++ b/data/1.9/protocol.json
@@ -295,7 +295,7 @@
             }
           ]
         },
-        "join_game": {
+        "login": {
           "id": "0x23",
           "fields": [
             {
@@ -328,7 +328,7 @@
             }
           ]
         },
-        "chat_message": {
+        "chat": {
           "id": "0x0f",
           "fields": [
             {
@@ -341,7 +341,7 @@
             }
           ]
         },
-        "time_update": {
+        "update_time": {
           "id": "0x44",
           "fields": [
             {
@@ -418,7 +418,7 @@
             }
           ]
         },
-        "player_position_and_look": {
+        "position": {
           "id": "0x2e",
           "fields": [
             {
@@ -451,7 +451,7 @@
             }
           ]
         },
-        "held_item_change": {
+        "held_item_slot": {
           "id": "0x37",
           "fields": [
             {
@@ -460,7 +460,7 @@
             }
           ]
         },
-        "use_bed": {
+        "bed": {
           "id": "0x2f",
           "fields": [
             {
@@ -482,7 +482,7 @@
             }
           ]
         },
-        "spawn_player": {
+        "named_entity_spawn": {
           "id": "0x05",
           "fields": [
             {
@@ -519,7 +519,7 @@
             }
           ]
         },
-        "collect_item": {
+        "collect": {
           "id": "0x49",
           "fields": [
             {
@@ -532,7 +532,7 @@
             }
           ]
         },
-        "spawn_object": {
+        "spawn_entity": {
           "id": "0x00",
           "fields": [
             {
@@ -585,7 +585,7 @@
             }
           ]
         },
-        "spawn_mob": {
+        "spawn_entity_living": {
           "id": "0x03",
           "fields": [
             {
@@ -642,7 +642,7 @@
             }
           ]
         },
-        "spawn_painting": {
+        "spawn_entity_painting": {
           "id": "0x04",
           "fields": [
             {
@@ -663,7 +663,7 @@
             }
           ]
         },
-        "spawn_experience_orb": {
+        "spawn_entity_experience_orb": {
           "id": "0x01",
           "fields": [
             {
@@ -709,7 +709,7 @@
             }
           ]
         },
-        "destroy_entities": {
+        "entity_destroy": {
           "id": "0x30",
           "fields": [
             {
@@ -758,7 +758,7 @@
             }
           ]
         },
-        "entity_relative_move": {
+        "rel_entity_move": {
           "id": "0x25",
           "fields": [
             {
@@ -804,7 +804,7 @@
             }
           ]
         },
-        "entity_look_and_relative_move": {
+        "entity_move_look": {
           "id": "0x26",
           "fields": [
             {
@@ -870,7 +870,7 @@
             }
           ]
         },
-        "entity_properties": {
+        "entity_head_rotation": {
           "id": "0x4b",
           "fields": [
             {
@@ -1021,7 +1021,7 @@
             }
           ]
         },
-        "set_experience": {
+        "experience": {
           "id": "0x3d",
           "fields": [
             {
@@ -1038,7 +1038,7 @@
             }
           ]
         },
-        "chunk_data": {
+        "map_chunk": {
           "id": "0x20",
           "fields": [
             {
@@ -1217,7 +1217,7 @@
             }
           ]
         },
-        "effect": {
+        "world_event": {
           "id": "0x21",
           "fields": [
             {
@@ -1271,7 +1271,7 @@
             }
           ]
         },
-        "particle": {
+        "world_particle": {
           "id": "0x22",
           "fields": [
             {
@@ -1334,7 +1334,7 @@
             }
           ]
         },
-        "change_game_state": {
+        "game_state_change": {
           "id": "0x1e",
           "fields": [
             {
@@ -1347,7 +1347,7 @@
             }
           ]
         },
-        "spawn_global_entity": {
+        "spawn_entity_weather": {
           "id": "0x02",
           "fields": [
             {
@@ -1451,7 +1451,7 @@
             }
           ]
         },
-        "window_property": {
+        "craft_progress_bar": {
           "id": "0x15",
           "fields": [
             {
@@ -1468,7 +1468,7 @@
             }
           ]
         },
-        "confirm_transaction": {
+        "transaction": {
           "id": "0x11",
           "fields": [
             {
@@ -1647,7 +1647,7 @@
             }
           ]
         },
-        "update_block_entity": {
+        "tile_entity_data": {
           "id": "0x09",
           "fields": [
             {
@@ -1664,7 +1664,7 @@
             }
           ]
         },
-        "open_sign_editor": {
+        "open_sign_entity": {
           "id": "0x2a",
           "fields": [
             {
@@ -1700,7 +1700,7 @@
             }
           ]
         },
-        "player_list_item": {
+        "player_info": {
           "id": "0x2d",
           "fields": [
             {
@@ -1826,7 +1826,7 @@
             }
           ]
         },
-        "player_abilities": {
+        "abilities": {
           "id": "0x2b",
           "fields": [
             {
@@ -1899,7 +1899,7 @@
             }
           ]
         },
-        "update_score": {
+        "scoreboard_score": {
           "id": "0x42",
           "fields": [
             {
@@ -1929,7 +1929,7 @@
             }
           ]
         },
-        "display_scoreboard": {
+        "scoreboard_display_objective": {
           "id": "0x38",
           "fields": [
             {
@@ -2105,7 +2105,7 @@
             }
           ]
         },
-        "plugin_message": {
+        "custom_payload": {
           "id": "0x18",
           "fields": [
             {
@@ -2118,7 +2118,7 @@
             }
           ]
         },
-        "disconnect": {
+        "kick_disconnect": {
           "id": "0x1a",
           "fields": [
             {
@@ -2127,7 +2127,7 @@
             }
           ]
         },
-        "server_difficulty": {
+        "difficulty": {
           "id": "0x0d",
           "fields": [
             {
@@ -2402,7 +2402,7 @@
             }
           ]
         },
-        "player_list_header_and_footer": {
+        "playerlist_header": {
           "id": "0x48",
           "fields": [
             {
@@ -2557,7 +2557,7 @@
             }
           ]
         },
-        "chat_message": {
+        "chat": {
           "id": "0x02",
           "fields": [
             {
@@ -2632,7 +2632,7 @@
             }
           ]
         },
-        "player": {
+        "flying": {
           "id": "0x0f",
           "fields": [
             {
@@ -2641,7 +2641,7 @@
             }
           ]
         },
-        "player_position": {
+        "position": {
           "id": "0x0c",
           "fields": [
             {
@@ -2662,7 +2662,7 @@
             }
           ]
         },
-        "player_look": {
+        "look": {
           "id": "0x0e",
           "fields": [
             {
@@ -2679,7 +2679,7 @@
             }
           ]
         },
-        "player_position_look": {
+        "position_look": {
           "id": "0x0d",
           "fields": [
             {
@@ -2708,7 +2708,7 @@
             }
           ]
         },
-        "player_digging": {
+        "block_dig": {
           "id": "0x13",
           "fields": [
             {
@@ -2725,7 +2725,7 @@
             }
           ]
         },
-        "player_block_placement": {
+        "block_place": {
           "id": "0x1c",
           "fields": [
             {
@@ -2754,7 +2754,7 @@
             }
           ]
         },
-        "held_item_change": {
+        "held_item_slot": {
           "id": "0x14",
           "fields": [
             {
@@ -2763,7 +2763,7 @@
             }
           ]
         },
-        "animation": {
+        "arm_animation": {
           "id": "0x1a",
           "fields": [
             {
@@ -2815,7 +2815,7 @@
             }
           ]
         },
-        "click_window": {
+        "window_click": {
           "id": "0x07",
           "fields": [
             {
@@ -2844,7 +2844,7 @@
             }
           ]
         },
-        "confirm_transaction": {
+        "transaction": {
           "id": "0x05",
           "fields": [
             {
@@ -2861,7 +2861,7 @@
             }
           ]
         },
-        "creative_inventory_action": {
+        "set_creative_slot": {
           "id": "0x18",
           "fields": [
             {
@@ -2887,7 +2887,7 @@
             }
           ]
         },
-        "player_abilities": {
+        "abilities": {
           "id": "0x12",
           "fields": [
             {
@@ -2928,7 +2928,7 @@
             }
           ]
         },
-        "client_settings": {
+        "settings": {
           "id": "0x04",
           "fields": [
             {
@@ -2957,7 +2957,7 @@
             }
           ]
         },
-        "client_status": {
+        "client_command": {
           "id": "0x03",
           "fields": [
             {
@@ -2966,7 +2966,7 @@
             }
           ]
         },
-        "plugin_message": {
+        "custom_payload": {
           "id": "0x09",
           "fields": [
             {
@@ -2988,7 +2988,7 @@
             }
           ]
         },
-        "resource_pack_status": {
+        "resource_pack_receive": {
           "id": "0x16",
           "fields": [
             {

--- a/data/1.9/protocol.json
+++ b/data/1.9/protocol.json
@@ -3026,6 +3026,44 @@
             }
           ]
         },
+        "vehicle_move": {
+          "id": "0x29",
+          "fields": [
+            {
+              "name": "x",
+              "type": "double"
+            },
+            {
+              "name": "y",
+              "type": "double"
+            },
+            {
+              "name": "z",
+              "type": "double"
+            },
+            {
+              "name": "yaw",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "float"
+            }
+          ]
+        },
+        "steer_boat": {
+          "id": "0x11",
+          "fields": [
+            {
+              "name": "unknown1",
+              "type": "bool"
+            },
+            {
+              "name": "unknown2",
+              "type": "bool"
+            }
+          ]
+        },
         "use_item": {
           "id": "0x1d",
           "fields": [

--- a/data/1.9/protocol.json
+++ b/data/1.9/protocol.json
@@ -372,7 +372,7 @@
           ]
         },
         "spawn_position": {
-          "id": "0x42",
+          "id": "0x43",
           "fields": [
             {
               "name": "location",
@@ -867,6 +867,63 @@
             {
               "name": "onGround",
               "type": "bool"
+            }
+          ]
+        },
+        "entity_properties": {
+          "id": "0x4b",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "properties",
+              "type": [
+                "array",
+                {
+                  "countType": "int",
+                  "type": [
+                    "container",
+                    [
+                      {
+                        "name": "key",
+                        "type": "string"
+                      },
+                      {
+                        "name": "value",
+                        "type": "double"
+                      },
+                      {
+                        "name": "modifiers",
+                        "type": [
+                          "array",
+                          {
+                            "countType": "varint",
+                            "type": [
+                              "container",
+                              [
+                                {
+                                  "name": "uuid",
+                                  "type": "UUID"
+                                },
+                                {
+                                  "name": "amount",
+                                  "type": "double"
+                                },
+                                {
+                                  "name": "operation",
+                                  "type": "byte"
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              ]
             }
           ]
         },
@@ -1453,6 +1510,39 @@
             }
           ]
         },
+        "sound_effect": {
+          "id": "0x47",
+          "fields": [
+            {
+              "name": "soundId",
+              "type": "varint"
+            },
+            {
+              "name": "soundCatagory",
+              "type": "varint"
+            },
+            {
+              "name": "x",
+              "type": "int"
+            },
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "z",
+              "type": "int"
+            },
+            {
+              "name": "volume",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "ubyte"
+            }
+          ]
+        },
         "map": {
           "id": "0x24",
           "fields": [
@@ -1852,6 +1942,25 @@
             }
           ]
         },
+        "set_passengers": {
+          "id": "0x40",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "passengers",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": "varint"
+                }
+              ]
+            }
+          ]
+        },
         "teams": {
           "id": "0x41",
           "fields": [
@@ -2018,7 +2127,7 @@
             }
           ]
         },
-        "difficulty": {
+        "server_difficulty": {
           "id": "0x0d",
           "fields": [
             {
@@ -2430,8 +2539,17 @@
         }
       },
       "toServer": {
+        "teleport_confirm": {
+          "id": "0x00",
+          "fields": [
+            {
+              "name": "teleportId",
+              "type": "varint"
+            }
+          ]
+        },
         "keep_alive": {
-          "id": "0x0a",
+          "id": "0x0b",
           "fields": [
             {
               "name": "keepAliveId",
@@ -2439,8 +2557,8 @@
             }
           ]
         },
-        "chat": {
-          "id": "0x01",
+        "chat_message": {
+          "id": "0x02",
           "fields": [
             {
               "name": "message",
@@ -2449,7 +2567,7 @@
           ]
         },
         "use_entity": {
-          "id": "0x09",
+          "id": "0x0a",
           "fields": [
             {
               "name": "target",
@@ -2514,8 +2632,8 @@
             }
           ]
         },
-        "flying": {
-          "id": "0x0e",
+        "player": {
+          "id": "0x0f",
           "fields": [
             {
               "name": "onGround",
@@ -2523,45 +2641,7 @@
             }
           ]
         },
-        "position": {
-          "id": "0x0b",
-          "fields": [
-            {
-              "name": "x",
-              "type": "double"
-            },
-            {
-              "name": "y",
-              "type": "double"
-            },
-            {
-              "name": "z",
-              "type": "double"
-            },
-            {
-              "name": "onGround",
-              "type": "bool"
-            }
-          ]
-        },
-        "look": {
-          "id": "0x0d",
-          "fields": [
-            {
-              "name": "yaw",
-              "type": "float"
-            },
-            {
-              "name": "pitch",
-              "type": "float"
-            },
-            {
-              "name": "onGround",
-              "type": "bool"
-            }
-          ]
-        },
-        "position_look": {
+        "player_position": {
           "id": "0x0c",
           "fields": [
             {
@@ -2577,6 +2657,15 @@
               "type": "double"
             },
             {
+              "name": "onGround",
+              "type": "bool"
+            }
+          ]
+        },
+        "player_look": {
+          "id": "0x0e",
+          "fields": [
+            {
               "name": "yaw",
               "type": "float"
             },
@@ -2590,8 +2679,37 @@
             }
           ]
         },
-        "block_dig": {
-          "id": "0x10",
+        "player_position_look": {
+          "id": "0x0d",
+          "fields": [
+            {
+              "name": "x",
+              "type": "double"
+            },
+            {
+              "name": "y",
+              "type": "double"
+            },
+            {
+              "name": "z",
+              "type": "double"
+            },
+            {
+              "name": "yaw",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "float"
+            },
+            {
+              "name": "onGround",
+              "type": "bool"
+            }
+          ]
+        },
+        "player_digging": {
+          "id": "0x13",
           "fields": [
             {
               "name": "status",
@@ -2607,8 +2725,8 @@
             }
           ]
         },
-        "block_place": {
-          "id": "0x19",
+        "player_block_placement": {
+          "id": "0x1c",
           "fields": [
             {
               "name": "location",
@@ -2636,7 +2754,7 @@
             }
           ]
         },
-        "held_item_slot": {
+        "held_item_change": {
           "id": "0x14",
           "fields": [
             {
@@ -2645,8 +2763,8 @@
             }
           ]
         },
-        "arm_animation": {
-          "id": "0x17",
+        "animation": {
+          "id": "0x1a",
           "fields": [
             {
               "name": "hand",
@@ -2655,7 +2773,7 @@
           ]
         },
         "entity_action": {
-          "id": "0x11",
+          "id": "0x14",
           "fields": [
             {
               "name": "entityId",
@@ -2672,7 +2790,7 @@
           ]
         },
         "steer_vehicle": {
-          "id": "0x12",
+          "id": "0x15",
           "fields": [
             {
               "name": "sideways",
@@ -2689,7 +2807,7 @@
           ]
         },
         "close_window": {
-          "id": "0x07",
+          "id": "0x08",
           "fields": [
             {
               "name": "windowId",
@@ -2697,8 +2815,8 @@
             }
           ]
         },
-        "window_click": {
-          "id": "0x06",
+        "click_window": {
+          "id": "0x07",
           "fields": [
             {
               "name": "windowId",
@@ -2726,8 +2844,8 @@
             }
           ]
         },
-        "transaction": {
-          "id": "0x04",
+        "confirm_transaction": {
+          "id": "0x05",
           "fields": [
             {
               "name": "windowId",
@@ -2743,8 +2861,8 @@
             }
           ]
         },
-        "set_creative_slot": {
-          "id": "0x15",
+        "creative_inventory_action": {
+          "id": "0x18",
           "fields": [
             {
               "name": "slot",
@@ -2757,7 +2875,7 @@
           ]
         },
         "enchant_item": {
-          "id": "0x05",
+          "id": "0x06",
           "fields": [
             {
               "name": "windowId",
@@ -2769,33 +2887,8 @@
             }
           ]
         },
-        "update_sign": {
-          "id": "0x16",
-          "fields": [
-            {
-              "name": "location",
-              "type": "position"
-            },
-            {
-              "name": "text1",
-              "type": "string"
-            },
-            {
-              "name": "text2",
-              "type": "string"
-            },
-            {
-              "name": "text3",
-              "type": "string"
-            },
-            {
-              "name": "text4",
-              "type": "string"
-            }
-          ]
-        },
-        "abilities": {
-          "id": "0x0f",
+        "player_abilities": {
+          "id": "0x12",
           "fields": [
             {
               "name": "flags",
@@ -2812,14 +2905,22 @@
           ]
         },
         "tab_complete": {
-          "id": "0x00",
+          "id": "0x01",
           "fields": [
             {
               "name": "text",
               "type": "string"
             },
             {
-              "name": "block",
+              "name": "assumeCommand",
+              "type": "bool"
+            },
+            {
+              "name": "hasPosition",
+              "type": "bool"
+            },
+            {
+              "name": "lookedAtBlock",
               "type": [
                 "option",
                 "position"
@@ -2827,8 +2928,8 @@
             }
           ]
         },
-        "settings": {
-          "id": "0x03",
+        "client_settings": {
+          "id": "0x04",
           "fields": [
             {
               "name": "locale",
@@ -2856,17 +2957,17 @@
             }
           ]
         },
-        "client_command": {
-          "id": "0x02",
+        "client_status": {
+          "id": "0x03",
           "fields": [
             {
-              "name": "payload",
+              "name": "actionId",
               "type": "varint"
             }
           ]
         },
-        "custom_payload": {
-          "id": "0x08",
+        "plugin_message": {
+          "id": "0x09",
           "fields": [
             {
               "name": "channel",
@@ -2879,7 +2980,7 @@
           ]
         },
         "spectate": {
-          "id": "0x18",
+          "id": "0x1b",
           "fields": [
             {
               "name": "target",
@@ -2887,8 +2988,8 @@
             }
           ]
         },
-        "resource_pack_receive": {
-          "id": "0x13",
+        "resource_pack_status": {
+          "id": "0x16",
           "fields": [
             {
               "name": "hash",
@@ -2900,8 +3001,33 @@
             }
           ]
         },
+        "update_sign": {
+          "id": "0x19",
+          "fields": [
+            {
+              "name": "location",
+              "type": "position"
+            },
+            {
+              "name": "text1",
+              "type": "string"
+            },
+            {
+              "name": "text2",
+              "type": "string"
+            },
+            {
+              "name": "text3",
+              "type": "string"
+            },
+            {
+              "name": "text4",
+              "type": "string"
+            }
+          ]
+        },
         "use_item": {
-          "id": "0x1a",
+          "id": "0x1d",
           "fields": [
             {
               "name": "hand",

--- a/data/1.9/protocol.json
+++ b/data/1.9/protocol.json
@@ -295,8 +295,8 @@
             }
           ]
         },
-        "login": {
-          "id": "0x24",
+        "join_game": {
+          "id": "0x23",
           "fields": [
             {
               "name": "entityId",
@@ -328,7 +328,7 @@
             }
           ]
         },
-        "chat": {
+        "chat_message": {
           "id": "0x0f",
           "fields": [
             {
@@ -341,8 +341,8 @@
             }
           ]
         },
-        "update_time": {
-          "id": "0x43",
+        "time_update": {
+          "id": "0x44",
           "fields": [
             {
               "name": "age",
@@ -418,7 +418,7 @@
             }
           ]
         },
-        "position": {
+        "player_position_and_look": {
           "id": "0x2e",
           "fields": [
             {
@@ -444,10 +444,14 @@
             {
               "name": "flags",
               "type": "byte"
+            },
+            {
+              "name": "teleportId",
+              "type": "varint"
             }
           ]
         },
-        "held_item_slot": {
+        "held_item_change": {
           "id": "0x37",
           "fields": [
             {
@@ -456,7 +460,7 @@
             }
           ]
         },
-        "bed": {
+        "use_bed": {
           "id": "0x2f",
           "fields": [
             {
@@ -473,16 +477,12 @@
           "id": "0x06",
           "fields": [
             {
-              "name": "entityId",
+              "name": "hand",
               "type": "varint"
-            },
-            {
-              "name": "animation",
-              "type": "ubyte"
             }
           ]
         },
-        "named_entity_spawn": {
+        "spawn_player": {
           "id": "0x05",
           "fields": [
             {
@@ -519,8 +519,8 @@
             }
           ]
         },
-        "collect": {
-          "id": "0x47",
+        "collect_item": {
+          "id": "0x49",
           "fields": [
             {
               "name": "collectedEntityId",
@@ -532,7 +532,7 @@
             }
           ]
         },
-        "spawn_entity": {
+        "spawn_object": {
           "id": "0x00",
           "fields": [
             {
@@ -540,7 +540,7 @@
               "type": "varint"
             },
             {
-              "name": "entityUUID",
+              "name": "objectUUID",
               "type": "UUID"
             },
             {
@@ -585,7 +585,7 @@
             }
           ]
         },
-        "spawn_entity_living": {
+        "spawn_mob": {
           "id": "0x03",
           "fields": [
             {
@@ -642,7 +642,7 @@
             }
           ]
         },
-        "spawn_entity_painting": {
+        "spawn_painting": {
           "id": "0x04",
           "fields": [
             {
@@ -663,7 +663,7 @@
             }
           ]
         },
-        "spawn_entity_experience_orb": {
+        "spawn_experience_orb": {
           "id": "0x01",
           "fields": [
             {
@@ -709,7 +709,7 @@
             }
           ]
         },
-        "entity_destroy": {
+        "destroy_entities": {
           "id": "0x30",
           "fields": [
             {
@@ -725,7 +725,7 @@
           ]
         },
         "entity": {
-          "id": "0x29",
+          "id": "0x28",
           "fields": [
             {
               "name": "entityId",
@@ -733,8 +733,33 @@
             }
           ]
         },
-        "rel_entity_move": {
-          "id": "0x26",
+        "vehicle_move": {
+          "id": "0x29",
+          "fields": [
+            {
+              "name": "x",
+              "type": "double"
+            },
+            {
+              "name": "y",
+              "type": "double"
+            },
+            {
+              "name": "z",
+              "type": "double"
+            },
+            {
+              "name": "yaw",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "float"
+            }
+          ]
+        },
+        "entity_relative_move": {
+          "id": "0x25",
           "fields": [
             {
               "name": "entityId",
@@ -759,7 +784,7 @@
           ]
         },
         "entity_look": {
-          "id": "0x28",
+          "id": "0x27",
           "fields": [
             {
               "name": "entityId",
@@ -779,8 +804,8 @@
             }
           ]
         },
-        "entity_move_look": {
-          "id": "0x27",
+        "entity_look_and_relative_move": {
+          "id": "0x26",
           "fields": [
             {
               "name": "entityId",
@@ -813,7 +838,7 @@
           ]
         },
         "entity_teleport": {
-          "id": "0x48",
+          "id": "0x4a",
           "fields": [
             {
               "name": "entityId",
@@ -845,7 +870,7 @@
             }
           ]
         },
-        "entity_head_rotation": {
+        "entity_head_look": {
           "id": "0x34",
           "fields": [
             {
@@ -859,7 +884,7 @@
           ]
         },
         "entity_status": {
-          "id": "0x1a",
+          "id": "0x1b",
           "fields": [
             {
               "name": "entityId",
@@ -902,7 +927,7 @@
           ]
         },
         "entity_effect": {
-          "id": "0x4a",
+          "id": "0x4c",
           "fields": [
             {
               "name": "entityId",
@@ -939,7 +964,7 @@
             }
           ]
         },
-        "experience": {
+        "set_experience": {
           "id": "0x3d",
           "fields": [
             {
@@ -956,64 +981,7 @@
             }
           ]
         },
-        "update_attributes": {
-          "id": "0x49",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "properties",
-              "type": [
-                "array",
-                {
-                  "countType": "int",
-                  "type": [
-                    "container",
-                    [
-                      {
-                        "name": "key",
-                        "type": "string"
-                      },
-                      {
-                        "name": "value",
-                        "type": "double"
-                      },
-                      {
-                        "name": "modifiers",
-                        "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
-                                {
-                                  "name": "UUID",
-                                  "type": "UUID"
-                                },
-                                {
-                                  "name": "amount",
-                                  "type": "double"
-                                },
-                                {
-                                  "name": "operation",
-                                  "type": "byte"
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "map_chunk": {
+        "chunk_data": {
           "id": "0x20",
           "fields": [
             {
@@ -1134,7 +1102,7 @@
           ]
         },
         "explosion": {
-          "id": "0x1b",
+          "id": "0x1c",
           "fields": [
             {
               "name": "x",
@@ -1192,7 +1160,7 @@
             }
           ]
         },
-        "world_event": {
+        "effect": {
           "id": "0x21",
           "fields": [
             {
@@ -1214,11 +1182,15 @@
           ]
         },
         "named_sound_effect": {
-          "id": "0x23",
+          "id": "0x19",
           "fields": [
             {
               "name": "soundName",
               "type": "string"
+            },
+            {
+              "name": "soundCategory",
+              "type": "varint"
             },
             {
               "name": "x",
@@ -1242,7 +1214,7 @@
             }
           ]
         },
-        "world_particles": {
+        "particle": {
           "id": "0x22",
           "fields": [
             {
@@ -1305,7 +1277,7 @@
             }
           ]
         },
-        "game_state_change": {
+        "change_game_state": {
           "id": "0x1e",
           "fields": [
             {
@@ -1318,7 +1290,7 @@
             }
           ]
         },
-        "spawn_entity_weather": {
+        "spawn_global_entity": {
           "id": "0x02",
           "fields": [
             {
@@ -1422,7 +1394,7 @@
             }
           ]
         },
-        "craft_progress_bar": {
+        "window_property": {
           "id": "0x15",
           "fields": [
             {
@@ -1439,7 +1411,7 @@
             }
           ]
         },
-        "transaction": {
+        "confirm_transaction": {
           "id": "0x11",
           "fields": [
             {
@@ -1457,7 +1429,7 @@
           ]
         },
         "update_sign": {
-          "id": "0x45",
+          "id": "0x46",
           "fields": [
             {
               "name": "location",
@@ -1482,7 +1454,7 @@
           ]
         },
         "map": {
-          "id": "0x25",
+          "id": "0x24",
           "fields": [
             {
               "name": "itemDamage",
@@ -1585,7 +1557,7 @@
             }
           ]
         },
-        "tile_entity_data": {
+        "update_block_entity": {
           "id": "0x09",
           "fields": [
             {
@@ -1602,7 +1574,7 @@
             }
           ]
         },
-        "open_sign_entity": {
+        "open_sign_editor": {
           "id": "0x2a",
           "fields": [
             {
@@ -1638,7 +1610,7 @@
             }
           ]
         },
-        "player_info": {
+        "player_list_item": {
           "id": "0x2d",
           "fields": [
             {
@@ -1764,7 +1736,7 @@
             }
           ]
         },
-        "abilities": {
+        "player_abilities": {
           "id": "0x2b",
           "fields": [
             {
@@ -1837,8 +1809,8 @@
             }
           ]
         },
-        "scoreboard_score": {
-          "id": "0x41",
+        "update_score": {
+          "id": "0x42",
           "fields": [
             {
               "name": "itemName",
@@ -1867,7 +1839,7 @@
             }
           ]
         },
-        "scoreboard_display_objective": {
+        "display_scoreboard": {
           "id": "0x38",
           "fields": [
             {
@@ -1880,8 +1852,8 @@
             }
           ]
         },
-        "scoreboard_team": {
-          "id": "0x40",
+        "teams": {
+          "id": "0x41",
           "fields": [
             {
               "name": "team",
@@ -2024,7 +1996,7 @@
             }
           ]
         },
-        "custom_payload": {
+        "plugin_message": {
           "id": "0x18",
           "fields": [
             {
@@ -2037,8 +2009,8 @@
             }
           ]
         },
-        "kick_disconnect": {
-          "id": "0x19",
+        "disconnect": {
+          "id": "0x1a",
           "fields": [
             {
               "name": "reason",
@@ -2260,7 +2232,7 @@
           ]
         },
         "title": {
-          "id": "0x44",
+          "id": "0x45",
           "fields": [
             {
               "name": "action",
@@ -2321,17 +2293,8 @@
             }
           ]
         },
-        "set_compression": {
-          "id": "0x1d",
-          "fields": [
-            {
-              "name": "threshold",
-              "type": "varint"
-            }
-          ]
-        },
-        "playerlist_header": {
-          "id": "0x46",
+        "player_list_header_and_footer": {
+          "id": "0x48",
           "fields": [
             {
               "name": "header",
@@ -2453,7 +2416,7 @@
           ]
         },
         "unload_chunk": {
-          "id": "0x1c",
+          "id": "0x1d",
           "fields": [
             {
               "name": "chunkX",

--- a/data/1.9/protocol.json
+++ b/data/1.9/protocol.json
@@ -1271,7 +1271,7 @@
             }
           ]
         },
-        "world_particle": {
+        "world_particles": {
           "id": "0x22",
           "fields": [
             {


### PR DESCRIPTION
As far as I my eyes can tell, protocol.json is now synced up with the [pre-release protocol page](http://wiki.vg/Pre-release_protocol). This includes the names of the packets so that developers can grep for packets in the json based on the names used on the wiki. Changing packet names might not be desirable for projects directly using protocol.json and are expecting to packets to maintain a stable name, even if the name is out of sync from the wiki. I can switch it back if it turns out to be more trouble than it's worth.

This pull request does not include the reordering of the packets in protocol.json based on packet IDs. This would be quite a bit of work, but it will help readers orient themselves and could result in spotting duplicate packet ID uses.