### PR TITLE
Reordered 1.9 protocol packets

### DIFF
--- a/data/1.9/protocol.json
+++ b/data/1.9/protocol.json
@@ -286,252 +286,6 @@
     },
     "play": {
       "toClient": {
-        "keep_alive": {
-          "id": "0x1f",
-          "fields": [
-            {
-              "name": "keepAliveId",
-              "type": "varint"
-            }
-          ]
-        },
-        "login": {
-          "id": "0x23",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "int"
-            },
-            {
-              "name": "gameMode",
-              "type": "ubyte"
-            },
-            {
-              "name": "dimension",
-              "type": "byte"
-            },
-            {
-              "name": "difficulty",
-              "type": "ubyte"
-            },
-            {
-              "name": "maxPlayers",
-              "type": "ubyte"
-            },
-            {
-              "name": "levelType",
-              "type": "string"
-            },
-            {
-              "name": "reducedDebugInfo",
-              "type": "bool"
-            }
-          ]
-        },
-        "chat": {
-          "id": "0x0f",
-          "fields": [
-            {
-              "name": "message",
-              "type": "string"
-            },
-            {
-              "name": "position",
-              "type": "byte"
-            }
-          ]
-        },
-        "update_time": {
-          "id": "0x44",
-          "fields": [
-            {
-              "name": "age",
-              "type": "long"
-            },
-            {
-              "name": "time",
-              "type": "long"
-            }
-          ]
-        },
-        "entity_equipment": {
-          "id": "0x3c",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "slot",
-              "type": "varint"
-            },
-            {
-              "name": "item",
-              "type": "slot"
-            }
-          ]
-        },
-        "spawn_position": {
-          "id": "0x43",
-          "fields": [
-            {
-              "name": "location",
-              "type": "position"
-            }
-          ]
-        },
-        "update_health": {
-          "id": "0x3e",
-          "fields": [
-            {
-              "name": "health",
-              "type": "float"
-            },
-            {
-              "name": "food",
-              "type": "varint"
-            },
-            {
-              "name": "foodSaturation",
-              "type": "float"
-            }
-          ]
-        },
-        "respawn": {
-          "id": "0x33",
-          "fields": [
-            {
-              "name": "dimension",
-              "type": "int"
-            },
-            {
-              "name": "difficulty",
-              "type": "ubyte"
-            },
-            {
-              "name": "gamemode",
-              "type": "ubyte"
-            },
-            {
-              "name": "levelType",
-              "type": "string"
-            }
-          ]
-        },
-        "position": {
-          "id": "0x2e",
-          "fields": [
-            {
-              "name": "x",
-              "type": "double"
-            },
-            {
-              "name": "y",
-              "type": "double"
-            },
-            {
-              "name": "z",
-              "type": "double"
-            },
-            {
-              "name": "yaw",
-              "type": "float"
-            },
-            {
-              "name": "pitch",
-              "type": "float"
-            },
-            {
-              "name": "flags",
-              "type": "byte"
-            },
-            {
-              "name": "teleportId",
-              "type": "varint"
-            }
-          ]
-        },
-        "held_item_slot": {
-          "id": "0x37",
-          "fields": [
-            {
-              "name": "slot",
-              "type": "byte"
-            }
-          ]
-        },
-        "bed": {
-          "id": "0x2f",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "location",
-              "type": "position"
-            }
-          ]
-        },
-        "animation": {
-          "id": "0x06",
-          "fields": [
-            {
-              "name": "hand",
-              "type": "varint"
-            }
-          ]
-        },
-        "named_entity_spawn": {
-          "id": "0x05",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "playerUUID",
-              "type": "UUID"
-            },
-            {
-              "name": "x",
-              "type": "int"
-            },
-            {
-              "name": "y",
-              "type": "int"
-            },
-            {
-              "name": "z",
-              "type": "int"
-            },
-            {
-              "name": "yaw",
-              "type": "byte"
-            },
-            {
-              "name": "pitch",
-              "type": "byte"
-            },
-            {
-              "name": "metadata",
-              "type": "entityMetadata"
-            }
-          ]
-        },
-        "collect": {
-          "id": "0x49",
-          "fields": [
-            {
-              "name": "collectedEntityId",
-              "type": "varint"
-            },
-            {
-              "name": "collectorEntityId",
-              "type": "varint"
-            }
-          ]
-        },
         "spawn_entity": {
           "id": "0x00",
           "fields": [
@@ -582,6 +336,56 @@
             {
               "name": "velocityZ",
               "type": "short"
+            }
+          ]
+        },
+        "spawn_entity_experience_orb": {
+          "id": "0x01",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "x",
+              "type": "int"
+            },
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "z",
+              "type": "int"
+            },
+            {
+              "name": "count",
+              "type": "short"
+            }
+          ]
+        },
+        "spawn_entity_weather": {
+          "id": "0x02",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "type",
+              "type": "byte"
+            },
+            {
+              "name": "x",
+              "type": "int"
+            },
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "z",
+              "type": "int"
             }
           ]
         },
@@ -663,12 +467,16 @@
             }
           ]
         },
-        "spawn_entity_experience_orb": {
-          "id": "0x01",
+        "named_entity_spawn": {
+          "id": "0x05",
           "fields": [
             {
               "name": "entityId",
               "type": "varint"
+            },
+            {
+              "name": "playerUUID",
+              "type": "UUID"
             },
             {
               "name": "x",
@@ -683,242 +491,47 @@
               "type": "int"
             },
             {
-              "name": "count",
-              "type": "short"
+              "name": "yaw",
+              "type": "byte"
+            },
+            {
+              "name": "pitch",
+              "type": "byte"
+            },
+            {
+              "name": "metadata",
+              "type": "entityMetadata"
             }
           ]
         },
-        "entity_velocity": {
-          "id": "0x3b",
+        "animation": {
+          "id": "0x06",
           "fields": [
             {
-              "name": "entityId",
+              "name": "hand",
               "type": "varint"
-            },
-            {
-              "name": "velocityX",
-              "type": "short"
-            },
-            {
-              "name": "velocityY",
-              "type": "short"
-            },
-            {
-              "name": "velocityZ",
-              "type": "short"
             }
           ]
         },
-        "entity_destroy": {
-          "id": "0x30",
+        "statistics": {
+          "id": "0x07",
           "fields": [
             {
-              "name": "entityIds",
+              "name": "entries",
               "type": [
                 "array",
                 {
                   "countType": "varint",
-                  "type": "varint"
-                }
-              ]
-            }
-          ]
-        },
-        "entity": {
-          "id": "0x28",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            }
-          ]
-        },
-        "vehicle_move": {
-          "id": "0x29",
-          "fields": [
-            {
-              "name": "x",
-              "type": "double"
-            },
-            {
-              "name": "y",
-              "type": "double"
-            },
-            {
-              "name": "z",
-              "type": "double"
-            },
-            {
-              "name": "yaw",
-              "type": "float"
-            },
-            {
-              "name": "pitch",
-              "type": "float"
-            }
-          ]
-        },
-        "rel_entity_move": {
-          "id": "0x25",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "dX",
-              "type": "byte"
-            },
-            {
-              "name": "dY",
-              "type": "byte"
-            },
-            {
-              "name": "dZ",
-              "type": "byte"
-            },
-            {
-              "name": "onGround",
-              "type": "bool"
-            }
-          ]
-        },
-        "entity_look": {
-          "id": "0x27",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "yaw",
-              "type": "byte"
-            },
-            {
-              "name": "pitch",
-              "type": "byte"
-            },
-            {
-              "name": "onGround",
-              "type": "bool"
-            }
-          ]
-        },
-        "entity_move_look": {
-          "id": "0x26",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "dX",
-              "type": "byte"
-            },
-            {
-              "name": "dY",
-              "type": "byte"
-            },
-            {
-              "name": "dZ",
-              "type": "byte"
-            },
-            {
-              "name": "yaw",
-              "type": "byte"
-            },
-            {
-              "name": "pitch",
-              "type": "byte"
-            },
-            {
-              "name": "onGround",
-              "type": "bool"
-            }
-          ]
-        },
-        "entity_teleport": {
-          "id": "0x4a",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "x",
-              "type": "int"
-            },
-            {
-              "name": "y",
-              "type": "int"
-            },
-            {
-              "name": "z",
-              "type": "int"
-            },
-            {
-              "name": "yaw",
-              "type": "byte"
-            },
-            {
-              "name": "pitch",
-              "type": "byte"
-            },
-            {
-              "name": "onGround",
-              "type": "bool"
-            }
-          ]
-        },
-        "entity_head_rotation": {
-          "id": "0x4b",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "properties",
-              "type": [
-                "array",
-                {
-                  "countType": "int",
                   "type": [
                     "container",
                     [
                       {
-                        "name": "key",
+                        "name": "name",
                         "type": "string"
                       },
                       {
                         "name": "value",
-                        "type": "double"
-                      },
-                      {
-                        "name": "modifiers",
-                        "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
-                                {
-                                  "name": "uuid",
-                                  "type": "UUID"
-                                },
-                                {
-                                  "name": "amount",
-                                  "type": "double"
-                                },
-                                {
-                                  "name": "operation",
-                                  "type": "byte"
-                                }
-                              ]
-                            ]
-                          }
-                        ]
+                        "type": "varint"
                       }
                     ]
                   ]
@@ -927,144 +540,191 @@
             }
           ]
         },
-        "entity_head_look": {
-          "id": "0x34",
+        "block_break_animation": {
+          "id": "0x08",
           "fields": [
             {
               "name": "entityId",
               "type": "varint"
             },
             {
-              "name": "headYaw",
+              "name": "location",
+              "type": "position"
+            },
+            {
+              "name": "destroyStage",
               "type": "byte"
             }
           ]
         },
-        "entity_status": {
-          "id": "0x1b",
+        "tile_entity_data": {
+          "id": "0x09",
           "fields": [
             {
-              "name": "entityId",
-              "type": "int"
+              "name": "location",
+              "type": "position"
             },
             {
-              "name": "entityStatus",
-              "type": "byte"
+              "name": "action",
+              "type": "ubyte"
+            },
+            {
+              "name": "nbtData",
+              "type": "optionalNbt"
             }
           ]
         },
-        "attach_entity": {
-          "id": "0x3a",
+        "block_action": {
+          "id": "0x0a",
           "fields": [
             {
-              "name": "entityId",
-              "type": "int"
+              "name": "location",
+              "type": "position"
             },
             {
-              "name": "vehicleId",
-              "type": "int"
+              "name": "byte1",
+              "type": "ubyte"
             },
             {
-              "name": "leash",
-              "type": "bool"
-            }
-          ]
-        },
-        "entity_metadata": {
-          "id": "0x39",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
+              "name": "byte2",
+              "type": "ubyte"
             },
             {
-              "name": "metadata",
-              "type": "entityMetadata"
-            }
-          ]
-        },
-        "entity_effect": {
-          "id": "0x4c",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "effectId",
-              "type": "byte"
-            },
-            {
-              "name": "amplifier",
-              "type": "byte"
-            },
-            {
-              "name": "duration",
-              "type": "varint"
-            },
-            {
-              "name": "hideParticles",
-              "type": "bool"
-            }
-          ]
-        },
-        "remove_entity_effect": {
-          "id": "0x31",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "effectId",
-              "type": "byte"
-            }
-          ]
-        },
-        "experience": {
-          "id": "0x3d",
-          "fields": [
-            {
-              "name": "experienceBar",
-              "type": "float"
-            },
-            {
-              "name": "level",
-              "type": "varint"
-            },
-            {
-              "name": "totalExperience",
+              "name": "blockId",
               "type": "varint"
             }
           ]
         },
-        "map_chunk": {
-          "id": "0x20",
+        "block_change": {
+          "id": "0x0b",
           "fields": [
             {
-              "name": "x",
-              "type": "int"
+              "name": "location",
+              "type": "position"
             },
             {
-              "name": "z",
-              "type": "int"
+              "name": "type",
+              "type": "varint"
+            }
+          ]
+        },
+        "boss_bar": {
+          "id": "0x0c",
+          "fields": [
+            {
+              "name": "entityUUID",
+              "type": "UUID"
             },
             {
-              "name": "groundUp",
-              "type": "bool"
-            },
-            {
-              "name": "bitMap",
+              "name": "action",
               "type": "varint"
             },
             {
-              "name": "chunkData",
+              "name": "title",
               "type": [
-                "buffer",
+                "switch",
                 {
-                  "countType": "varint"
+                  "compareTo": "action",
+                  "fields": {
+                    "0": "string",
+                    "3": "string"
+                  },
+                  "default": "void"
                 }
               ]
+            },
+            {
+              "name": "health",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "0": "float",
+                    "2": "float"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "color",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "0": "varint",
+                    "4": "varint"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "dividers",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "0": "varint",
+                    "4": "varint"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "flags",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "0": "ubyte",
+                    "5": "ubyte"
+                  },
+                  "default": "void"
+                }
+              ]
+            }
+          ]
+        },
+        "difficulty": {
+          "id": "0x0d",
+          "fields": [
+            {
+              "name": "difficulty",
+              "type": "ubyte"
+            }
+          ]
+        },
+        "tab_complete": {
+          "id": "0x0e",
+          "fields": [
+            {
+              "name": "matches",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": "string"
+                }
+              ]
+            }
+          ]
+        },
+        "chat": {
+          "id": "0x0f",
+          "fields": [
+            {
+              "name": "message",
+              "type": "string"
+            },
+            {
+              "name": "position",
+              "type": "byte"
             }
           ]
         },
@@ -1107,53 +767,196 @@
             }
           ]
         },
-        "block_change": {
-          "id": "0x0b",
+        "transaction": {
+          "id": "0x11",
           "fields": [
             {
-              "name": "location",
-              "type": "position"
+              "name": "windowId",
+              "type": "byte"
             },
             {
-              "name": "type",
+              "name": "action",
+              "type": "short"
+            },
+            {
+              "name": "accepted",
+              "type": "bool"
+            }
+          ]
+        },
+        "close_window": {
+          "id": "0x12",
+          "fields": [
+            {
+              "name": "windowId",
+              "type": "ubyte"
+            }
+          ]
+        },
+        "open_window": {
+          "id": "0x13",
+          "fields": [
+            {
+              "name": "windowId",
+              "type": "ubyte"
+            },
+            {
+              "name": "inventoryType",
+              "type": "string"
+            },
+            {
+              "name": "windowTitle",
+              "type": "string"
+            },
+            {
+              "name": "slotCount",
+              "type": "ubyte"
+            },
+            {
+              "name": "entityId",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "inventoryType",
+                  "fields": {
+                    "EntityHorse": "int"
+                  },
+                  "default": "void"
+                }
+              ]
+            }
+          ]
+        },
+        "window_items": {
+          "id": "0x14",
+          "fields": [
+            {
+              "name": "windowId",
+              "type": "ubyte"
+            },
+            {
+              "name": "items",
+              "type": [
+                "array",
+                {
+                  "countType": "short",
+                  "type": "slot"
+                }
+              ]
+            }
+          ]
+        },
+        "craft_progress_bar": {
+          "id": "0x15",
+          "fields": [
+            {
+              "name": "windowId",
+              "type": "ubyte"
+            },
+            {
+              "name": "property",
+              "type": "short"
+            },
+            {
+              "name": "value",
+              "type": "short"
+            }
+          ]
+        },
+        "set_slot": {
+          "id": "0x16",
+          "fields": [
+            {
+              "name": "windowId",
+              "type": "byte"
+            },
+            {
+              "name": "slot",
+              "type": "short"
+            },
+            {
+              "name": "item",
+              "type": "slot"
+            }
+          ]
+        },
+        "set_cooldown": {
+          "id": "0x17",
+          "fields": [
+            {
+              "name": "itemID",
+              "type": "varint"
+            },
+            {
+              "name": "cooldownTicks",
               "type": "varint"
             }
           ]
         },
-        "block_action": {
-          "id": "0x0a",
+        "custom_payload": {
+          "id": "0x18",
           "fields": [
             {
-              "name": "location",
-              "type": "position"
+              "name": "channel",
+              "type": "string"
             },
             {
-              "name": "byte1",
-              "type": "ubyte"
-            },
-            {
-              "name": "byte2",
-              "type": "ubyte"
-            },
-            {
-              "name": "blockId",
-              "type": "varint"
+              "name": "data",
+              "type": "restBuffer"
             }
           ]
         },
-        "block_break_animation": {
-          "id": "0x08",
+        "named_sound_effect": {
+          "id": "0x19",
+          "fields": [
+            {
+              "name": "soundName",
+              "type": "string"
+            },
+            {
+              "name": "soundCategory",
+              "type": "varint"
+            },
+            {
+              "name": "x",
+              "type": "int"
+            },
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "z",
+              "type": "int"
+            },
+            {
+              "name": "volume",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "ubyte"
+            }
+          ]
+        },
+        "kick_disconnect": {
+          "id": "0x1a",
+          "fields": [
+            {
+              "name": "reason",
+              "type": "string"
+            }
+          ]
+        },
+        "entity_status": {
+          "id": "0x1b",
           "fields": [
             {
               "name": "entityId",
-              "type": "varint"
+              "type": "int"
             },
             {
-              "name": "location",
-              "type": "position"
-            },
-            {
-              "name": "destroyStage",
+              "name": "entityStatus",
               "type": "byte"
             }
           ]
@@ -1217,6 +1020,71 @@
             }
           ]
         },
+        "unload_chunk": {
+          "id": "0x1d",
+          "fields": [
+            {
+              "name": "chunkX",
+              "type": "int"
+            },
+            {
+              "name": "chunkZ",
+              "type": "int"
+            }
+          ]
+        },
+        "game_state_change": {
+          "id": "0x1e",
+          "fields": [
+            {
+              "name": "reason",
+              "type": "ubyte"
+            },
+            {
+              "name": "gameMode",
+              "type": "float"
+            }
+          ]
+        },
+        "keep_alive": {
+          "id": "0x1f",
+          "fields": [
+            {
+              "name": "keepAliveId",
+              "type": "varint"
+            }
+          ]
+        },
+        "map_chunk": {
+          "id": "0x20",
+          "fields": [
+            {
+              "name": "x",
+              "type": "int"
+            },
+            {
+              "name": "z",
+              "type": "int"
+            },
+            {
+              "name": "groundUp",
+              "type": "bool"
+            },
+            {
+              "name": "bitMap",
+              "type": "varint"
+            },
+            {
+              "name": "chunkData",
+              "type": [
+                "buffer",
+                {
+                  "countType": "varint"
+                }
+              ]
+            }
+          ]
+        },
         "world_event": {
           "id": "0x21",
           "fields": [
@@ -1235,39 +1103,6 @@
             {
               "name": "global",
               "type": "bool"
-            }
-          ]
-        },
-        "named_sound_effect": {
-          "id": "0x19",
-          "fields": [
-            {
-              "name": "soundName",
-              "type": "string"
-            },
-            {
-              "name": "soundCategory",
-              "type": "varint"
-            },
-            {
-              "name": "x",
-              "type": "int"
-            },
-            {
-              "name": "y",
-              "type": "int"
-            },
-            {
-              "name": "z",
-              "type": "int"
-            },
-            {
-              "name": "volume",
-              "type": "float"
-            },
-            {
-              "name": "pitch",
-              "type": "ubyte"
             }
           ]
         },
@@ -1334,212 +1169,36 @@
             }
           ]
         },
-        "game_state_change": {
-          "id": "0x1e",
+        "login": {
+          "id": "0x23",
           "fields": [
             {
-              "name": "reason",
-              "type": "ubyte"
+              "name": "entityId",
+              "type": "int"
             },
             {
               "name": "gameMode",
-              "type": "float"
-            }
-          ]
-        },
-        "spawn_entity_weather": {
-          "id": "0x02",
-          "fields": [
-            {
-              "name": "entityId",
-              "type": "varint"
-            },
-            {
-              "name": "type",
-              "type": "byte"
-            },
-            {
-              "name": "x",
-              "type": "int"
-            },
-            {
-              "name": "y",
-              "type": "int"
-            },
-            {
-              "name": "z",
-              "type": "int"
-            }
-          ]
-        },
-        "open_window": {
-          "id": "0x13",
-          "fields": [
-            {
-              "name": "windowId",
               "type": "ubyte"
             },
             {
-              "name": "inventoryType",
+              "name": "dimension",
+              "type": "byte"
+            },
+            {
+              "name": "difficulty",
+              "type": "ubyte"
+            },
+            {
+              "name": "maxPlayers",
+              "type": "ubyte"
+            },
+            {
+              "name": "levelType",
               "type": "string"
             },
             {
-              "name": "windowTitle",
-              "type": "string"
-            },
-            {
-              "name": "slotCount",
-              "type": "ubyte"
-            },
-            {
-              "name": "entityId",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "inventoryType",
-                  "fields": {
-                    "EntityHorse": "int"
-                  },
-                  "default": "void"
-                }
-              ]
-            }
-          ]
-        },
-        "close_window": {
-          "id": "0x12",
-          "fields": [
-            {
-              "name": "windowId",
-              "type": "ubyte"
-            }
-          ]
-        },
-        "set_slot": {
-          "id": "0x16",
-          "fields": [
-            {
-              "name": "windowId",
-              "type": "byte"
-            },
-            {
-              "name": "slot",
-              "type": "short"
-            },
-            {
-              "name": "item",
-              "type": "slot"
-            }
-          ]
-        },
-        "window_items": {
-          "id": "0x14",
-          "fields": [
-            {
-              "name": "windowId",
-              "type": "ubyte"
-            },
-            {
-              "name": "items",
-              "type": [
-                "array",
-                {
-                  "countType": "short",
-                  "type": "slot"
-                }
-              ]
-            }
-          ]
-        },
-        "craft_progress_bar": {
-          "id": "0x15",
-          "fields": [
-            {
-              "name": "windowId",
-              "type": "ubyte"
-            },
-            {
-              "name": "property",
-              "type": "short"
-            },
-            {
-              "name": "value",
-              "type": "short"
-            }
-          ]
-        },
-        "transaction": {
-          "id": "0x11",
-          "fields": [
-            {
-              "name": "windowId",
-              "type": "byte"
-            },
-            {
-              "name": "action",
-              "type": "short"
-            },
-            {
-              "name": "accepted",
+              "name": "reducedDebugInfo",
               "type": "bool"
-            }
-          ]
-        },
-        "update_sign": {
-          "id": "0x46",
-          "fields": [
-            {
-              "name": "location",
-              "type": "position"
-            },
-            {
-              "name": "text1",
-              "type": "string"
-            },
-            {
-              "name": "text2",
-              "type": "string"
-            },
-            {
-              "name": "text3",
-              "type": "string"
-            },
-            {
-              "name": "text4",
-              "type": "string"
-            }
-          ]
-        },
-        "sound_effect": {
-          "id": "0x47",
-          "fields": [
-            {
-              "name": "soundId",
-              "type": "varint"
-            },
-            {
-              "name": "soundCatagory",
-              "type": "varint"
-            },
-            {
-              "name": "x",
-              "type": "int"
-            },
-            {
-              "name": "y",
-              "type": "int"
-            },
-            {
-              "name": "z",
-              "type": "int"
-            },
-            {
-              "name": "volume",
-              "type": "float"
-            },
-            {
-              "name": "pitch",
-              "type": "ubyte"
             }
           ]
         },
@@ -1647,20 +1306,116 @@
             }
           ]
         },
-        "tile_entity_data": {
-          "id": "0x09",
+        "rel_entity_move": {
+          "id": "0x25",
           "fields": [
             {
-              "name": "location",
-              "type": "position"
+              "name": "entityId",
+              "type": "varint"
             },
             {
-              "name": "action",
-              "type": "ubyte"
+              "name": "dX",
+              "type": "byte"
             },
             {
-              "name": "nbtData",
-              "type": "optionalNbt"
+              "name": "dY",
+              "type": "byte"
+            },
+            {
+              "name": "dZ",
+              "type": "byte"
+            },
+            {
+              "name": "onGround",
+              "type": "bool"
+            }
+          ]
+        },
+        "entity_move_look": {
+          "id": "0x26",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "dX",
+              "type": "byte"
+            },
+            {
+              "name": "dY",
+              "type": "byte"
+            },
+            {
+              "name": "dZ",
+              "type": "byte"
+            },
+            {
+              "name": "yaw",
+              "type": "byte"
+            },
+            {
+              "name": "pitch",
+              "type": "byte"
+            },
+            {
+              "name": "onGround",
+              "type": "bool"
+            }
+          ]
+        },
+        "entity_look": {
+          "id": "0x27",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "yaw",
+              "type": "byte"
+            },
+            {
+              "name": "pitch",
+              "type": "byte"
+            },
+            {
+              "name": "onGround",
+              "type": "bool"
+            }
+          ]
+        },
+        "entity": {
+          "id": "0x28",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            }
+          ]
+        },
+        "vehicle_move": {
+          "id": "0x29",
+          "fields": [
+            {
+              "name": "x",
+              "type": "double"
+            },
+            {
+              "name": "y",
+              "type": "double"
+            },
+            {
+              "name": "z",
+              "type": "double"
+            },
+            {
+              "name": "yaw",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "float"
             }
           ]
         },
@@ -1673,28 +1428,80 @@
             }
           ]
         },
-        "statistics": {
-          "id": "0x07",
+        "abilities": {
+          "id": "0x2b",
           "fields": [
             {
-              "name": "entries",
+              "name": "flags",
+              "type": "byte"
+            },
+            {
+              "name": "flyingSpeed",
+              "type": "float"
+            },
+            {
+              "name": "walkingSpeed",
+              "type": "float"
+            }
+          ]
+        },
+        "combat_event": {
+          "id": "0x2c",
+          "fields": [
+            {
+              "name": "event",
+              "type": "varint"
+            },
+            {
+              "name": "duration",
               "type": [
-                "array",
+                "switch",
                 {
-                  "countType": "varint",
-                  "type": [
-                    "container",
-                    [
-                      {
-                        "name": "name",
-                        "type": "string"
-                      },
-                      {
-                        "name": "value",
-                        "type": "varint"
-                      }
-                    ]
-                  ]
+                  "compareTo": "event",
+                  "fields": {
+                    "1": "varint"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "playerId",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "event",
+                  "fields": {
+                    "2": "varint"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "entityId",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "event",
+                  "fields": {
+                    "1": "int",
+                    "2": "int"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "message",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "event",
+                  "fields": {
+                    "2": "string"
+                  },
+                  "default": "void"
                 }
               ]
             }
@@ -1826,35 +1633,390 @@
             }
           ]
         },
-        "abilities": {
-          "id": "0x2b",
+        "position": {
+          "id": "0x2e",
           "fields": [
+            {
+              "name": "x",
+              "type": "double"
+            },
+            {
+              "name": "y",
+              "type": "double"
+            },
+            {
+              "name": "z",
+              "type": "double"
+            },
+            {
+              "name": "yaw",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "float"
+            },
             {
               "name": "flags",
               "type": "byte"
             },
             {
-              "name": "flyingSpeed",
-              "type": "float"
-            },
-            {
-              "name": "walkingSpeed",
-              "type": "float"
+              "name": "teleportId",
+              "type": "varint"
             }
           ]
         },
-        "tab_complete": {
-          "id": "0x0e",
+        "bed": {
+          "id": "0x2f",
           "fields": [
             {
-              "name": "matches",
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "location",
+              "type": "position"
+            }
+          ]
+        },
+        "entity_destroy": {
+          "id": "0x30",
+          "fields": [
+            {
+              "name": "entityIds",
               "type": [
                 "array",
                 {
                   "countType": "varint",
-                  "type": "string"
+                  "type": "varint"
                 }
               ]
+            }
+          ]
+        },
+        "remove_entity_effect": {
+          "id": "0x31",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "effectId",
+              "type": "byte"
+            }
+          ]
+        },
+        "resource_pack_send": {
+          "id": "0x32",
+          "fields": [
+            {
+              "name": "url",
+              "type": "string"
+            },
+            {
+              "name": "hash",
+              "type": "string"
+            }
+          ]
+        },
+        "respawn": {
+          "id": "0x33",
+          "fields": [
+            {
+              "name": "dimension",
+              "type": "int"
+            },
+            {
+              "name": "difficulty",
+              "type": "ubyte"
+            },
+            {
+              "name": "gamemode",
+              "type": "ubyte"
+            },
+            {
+              "name": "levelType",
+              "type": "string"
+            }
+          ]
+        },
+        "entity_head_look": {
+          "id": "0x34",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "headYaw",
+              "type": "byte"
+            }
+          ]
+        },
+        "world_border": {
+          "id": "0x35",
+          "fields": [
+            {
+              "name": "action",
+              "type": "varint"
+            },
+            {
+              "name": "radius",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "0": "double"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "x",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "2": "double",
+                    "3": "double"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "z",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "2": "double",
+                    "3": "double"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "old_radius",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "1": "double",
+                    "3": "double"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "new_radius",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "1": "double",
+                    "3": "double"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "speed",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "1": "varint",
+                    "3": "varint"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "portalBoundary",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "3": "varint"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "warning_time",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "3": "varint",
+                    "4": "varint"
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
+              "name": "warning_blocks",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "action",
+                  "fields": {
+                    "3": "varint",
+                    "5": "varint"
+                  },
+                  "default": "void"
+                }
+              ]
+            }
+          ]
+        },
+        "camera": {
+          "id": "0x36",
+          "fields": [
+            {
+              "name": "cameraId",
+              "type": "varint"
+            }
+          ]
+        },
+        "held_item_slot": {
+          "id": "0x37",
+          "fields": [
+            {
+              "name": "slot",
+              "type": "byte"
+            }
+          ]
+        },
+        "scoreboard_display_objective": {
+          "id": "0x38",
+          "fields": [
+            {
+              "name": "position",
+              "type": "byte"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            }
+          ]
+        },
+        "entity_metadata": {
+          "id": "0x39",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "metadata",
+              "type": "entityMetadata"
+            }
+          ]
+        },
+        "attach_entity": {
+          "id": "0x3a",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "int"
+            },
+            {
+              "name": "vehicleId",
+              "type": "int"
+            },
+            {
+              "name": "leash",
+              "type": "bool"
+            }
+          ]
+        },
+        "entity_velocity": {
+          "id": "0x3b",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "velocityX",
+              "type": "short"
+            },
+            {
+              "name": "velocityY",
+              "type": "short"
+            },
+            {
+              "name": "velocityZ",
+              "type": "short"
+            }
+          ]
+        },
+        "entity_equipment": {
+          "id": "0x3c",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "slot",
+              "type": "varint"
+            },
+            {
+              "name": "item",
+              "type": "slot"
+            }
+          ]
+        },
+        "experience": {
+          "id": "0x3d",
+          "fields": [
+            {
+              "name": "experienceBar",
+              "type": "float"
+            },
+            {
+              "name": "level",
+              "type": "varint"
+            },
+            {
+              "name": "totalExperience",
+              "type": "varint"
+            }
+          ]
+        },
+        "update_health": {
+          "id": "0x3e",
+          "fields": [
+            {
+              "name": "health",
+              "type": "float"
+            },
+            {
+              "name": "food",
+              "type": "varint"
+            },
+            {
+              "name": "foodSaturation",
+              "type": "float"
             }
           ]
         },
@@ -1896,49 +2058,6 @@
                   "default": "void"
                 }
               ]
-            }
-          ]
-        },
-        "scoreboard_score": {
-          "id": "0x42",
-          "fields": [
-            {
-              "name": "itemName",
-              "type": "string"
-            },
-            {
-              "name": "action",
-              "type": "byte"
-            },
-            {
-              "name": "scoreName",
-              "type": "string"
-            },
-            {
-              "name": "value",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "1": "void"
-                  },
-                  "default": "varint"
-                }
-              ]
-            }
-          ]
-        },
-        "scoreboard_display_objective": {
-          "id": "0x38",
-          "fields": [
-            {
-              "name": "position",
-              "type": "byte"
-            },
-            {
-              "name": "name",
-              "type": "string"
             }
           ]
         },
@@ -2105,238 +2224,55 @@
             }
           ]
         },
-        "custom_payload": {
-          "id": "0x18",
+        "scoreboard_score": {
+          "id": "0x42",
           "fields": [
             {
-              "name": "channel",
+              "name": "itemName",
               "type": "string"
             },
-            {
-              "name": "data",
-              "type": "restBuffer"
-            }
-          ]
-        },
-        "kick_disconnect": {
-          "id": "0x1a",
-          "fields": [
-            {
-              "name": "reason",
-              "type": "string"
-            }
-          ]
-        },
-        "difficulty": {
-          "id": "0x0d",
-          "fields": [
-            {
-              "name": "difficulty",
-              "type": "ubyte"
-            }
-          ]
-        },
-        "combat_event": {
-          "id": "0x2c",
-          "fields": [
-            {
-              "name": "event",
-              "type": "varint"
-            },
-            {
-              "name": "duration",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "event",
-                  "fields": {
-                    "1": "varint"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "playerId",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "event",
-                  "fields": {
-                    "2": "varint"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "entityId",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "event",
-                  "fields": {
-                    "1": "int",
-                    "2": "int"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "message",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "event",
-                  "fields": {
-                    "2": "string"
-                  },
-                  "default": "void"
-                }
-              ]
-            }
-          ]
-        },
-        "camera": {
-          "id": "0x36",
-          "fields": [
-            {
-              "name": "cameraId",
-              "type": "varint"
-            }
-          ]
-        },
-        "world_border": {
-          "id": "0x35",
-          "fields": [
             {
               "name": "action",
-              "type": "varint"
+              "type": "byte"
             },
             {
-              "name": "radius",
+              "name": "scoreName",
+              "type": "string"
+            },
+            {
+              "name": "value",
               "type": [
                 "switch",
                 {
                   "compareTo": "action",
                   "fields": {
-                    "0": "double"
+                    "1": "void"
                   },
-                  "default": "void"
+                  "default": "varint"
                 }
               ]
+            }
+          ]
+        },
+        "spawn_position": {
+          "id": "0x43",
+          "fields": [
+            {
+              "name": "location",
+              "type": "position"
+            }
+          ]
+        },
+        "update_time": {
+          "id": "0x44",
+          "fields": [
+            {
+              "name": "age",
+              "type": "long"
             },
             {
-              "name": "x",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "2": "double",
-                    "3": "double"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "z",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "2": "double",
-                    "3": "double"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "old_radius",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "1": "double",
-                    "3": "double"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "new_radius",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "1": "double",
-                    "3": "double"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "speed",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "1": "varint",
-                    "3": "varint"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "portalBoundary",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "3": "varint"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "warning_time",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "3": "varint",
-                    "4": "varint"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "warning_blocks",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "3": "varint",
-                    "5": "varint"
-                  },
-                  "default": "void"
-                }
-              ]
+              "name": "time",
+              "type": "long"
             }
           ]
         },
@@ -2402,6 +2338,64 @@
             }
           ]
         },
+        "update_sign": {
+          "id": "0x46",
+          "fields": [
+            {
+              "name": "location",
+              "type": "position"
+            },
+            {
+              "name": "text1",
+              "type": "string"
+            },
+            {
+              "name": "text2",
+              "type": "string"
+            },
+            {
+              "name": "text3",
+              "type": "string"
+            },
+            {
+              "name": "text4",
+              "type": "string"
+            }
+          ]
+        },
+        "sound_effect": {
+          "id": "0x47",
+          "fields": [
+            {
+              "name": "soundId",
+              "type": "varint"
+            },
+            {
+              "name": "soundCatagory",
+              "type": "varint"
+            },
+            {
+              "name": "x",
+              "type": "int"
+            },
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "z",
+              "type": "int"
+            },
+            {
+              "name": "volume",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "ubyte"
+            }
+          ]
+        },
         "playerlist_header": {
           "id": "0x48",
           "fields": [
@@ -2415,125 +2409,131 @@
             }
           ]
         },
-        "resource_pack_send": {
-          "id": "0x32",
+        "collect": {
+          "id": "0x49",
           "fields": [
             {
-              "name": "url",
-              "type": "string"
-            },
-            {
-              "name": "hash",
-              "type": "string"
-            }
-          ]
-        },
-        "boss_bar": {
-          "id": "0x0c",
-          "fields": [
-            {
-              "name": "entityUUID",
-              "type": "UUID"
-            },
-            {
-              "name": "action",
+              "name": "collectedEntityId",
               "type": "varint"
             },
             {
-              "name": "title",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "0": "string",
-                    "3": "string"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "health",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "0": "float",
-                    "2": "float"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "color",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "0": "varint",
-                    "4": "varint"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "dividers",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "0": "varint",
-                    "4": "varint"
-                  },
-                  "default": "void"
-                }
-              ]
-            },
-            {
-              "name": "flags",
-              "type": [
-                "switch",
-                {
-                  "compareTo": "action",
-                  "fields": {
-                    "0": "ubyte",
-                    "5": "ubyte"
-                  },
-                  "default": "void"
-                }
-              ]
-            }
-          ]
-        },
-        "set_cooldown": {
-          "id": "0x17",
-          "fields": [
-            {
-              "name": "itemID",
-              "type": "varint"
-            },
-            {
-              "name": "cooldownTicks",
+              "name": "collectorEntityId",
               "type": "varint"
             }
           ]
         },
-        "unload_chunk": {
-          "id": "0x1d",
+        "entity_teleport": {
+          "id": "0x4a",
           "fields": [
             {
-              "name": "chunkX",
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "x",
               "type": "int"
             },
-            { 
-              "name": "chunkZ",
+            {
+              "name": "y",
               "type": "int"
+            },
+            {
+              "name": "z",
+              "type": "int"
+            },
+            {
+              "name": "yaw",
+              "type": "byte"
+            },
+            {
+              "name": "pitch",
+              "type": "byte"
+            },
+            {
+              "name": "onGround",
+              "type": "bool"
+            }
+          ]
+        },
+        "entity_head_rotation": {
+          "id": "0x4b",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "properties",
+              "type": [
+                "array",
+                {
+                  "countType": "int",
+                  "type": [
+                    "container",
+                    [
+                      {
+                        "name": "key",
+                        "type": "string"
+                      },
+                      {
+                        "name": "value",
+                        "type": "double"
+                      },
+                      {
+                        "name": "modifiers",
+                        "type": [
+                          "array",
+                          {
+                            "countType": "varint",
+                            "type": [
+                              "container",
+                              [
+                                {
+                                  "name": "uuid",
+                                  "type": "UUID"
+                                },
+                                {
+                                  "name": "amount",
+                                  "type": "double"
+                                },
+                                {
+                                  "name": "operation",
+                                  "type": "byte"
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "entity_effect": {
+          "id": "0x4c",
+          "fields": [
+            {
+              "name": "entityId",
+              "type": "varint"
+            },
+            {
+              "name": "effectId",
+              "type": "byte"
+            },
+            {
+              "name": "amplifier",
+              "type": "byte"
+            },
+            {
+              "name": "duration",
+              "type": "varint"
+            },
+            {
+              "name": "hideParticles",
+              "type": "bool"
             }
           ]
         }
@@ -2548,12 +2548,27 @@
             }
           ]
         },
-        "keep_alive": {
-          "id": "0x0b",
+        "tab_complete": {
+          "id": "0x01",
           "fields": [
             {
-              "name": "keepAliveId",
-              "type": "varint"
+              "name": "text",
+              "type": "string"
+            },
+            {
+              "name": "assumeCommand",
+              "type": "bool"
+            },
+            {
+              "name": "hasPosition",
+              "type": "bool"
+            },
+            {
+              "name": "lookedAtBlock",
+              "type": [
+                "option",
+                "position"
+              ]
             }
           ]
         },
@@ -2563,6 +2578,125 @@
             {
               "name": "message",
               "type": "string"
+            }
+          ]
+        },
+        "client_command": {
+          "id": "0x03",
+          "fields": [
+            {
+              "name": "actionId",
+              "type": "varint"
+            }
+          ]
+        },
+        "settings": {
+          "id": "0x04",
+          "fields": [
+            {
+              "name": "locale",
+              "type": "string"
+            },
+            {
+              "name": "viewDistance",
+              "type": "byte"
+            },
+            {
+              "name": "chatFlags",
+              "type": "varint"
+            },
+            {
+              "name": "chatColors",
+              "type": "bool"
+            },
+            {
+              "name": "skinParts",
+              "type": "ubyte"
+            },
+            {
+              "name": "mainHand",
+              "type": "varint"
+            }
+          ]
+        },
+        "transaction": {
+          "id": "0x05",
+          "fields": [
+            {
+              "name": "windowId",
+              "type": "byte"
+            },
+            {
+              "name": "action",
+              "type": "short"
+            },
+            {
+              "name": "accepted",
+              "type": "bool"
+            }
+          ]
+        },
+        "enchant_item": {
+          "id": "0x06",
+          "fields": [
+            {
+              "name": "windowId",
+              "type": "byte"
+            },
+            {
+              "name": "enchantment",
+              "type": "byte"
+            }
+          ]
+        },
+        "window_click": {
+          "id": "0x07",
+          "fields": [
+            {
+              "name": "windowId",
+              "type": "ubyte"
+            },
+            {
+              "name": "slot",
+              "type": "short"
+            },
+            {
+              "name": "mouseButton",
+              "type": "byte"
+            },
+            {
+              "name": "action",
+              "type": "short"
+            },
+            {
+              "name": "mode",
+              "type": "byte"
+            },
+            {
+              "name": "item",
+              "type": "slot"
+            }
+          ]
+        },
+        "close_window": {
+          "id": "0x08",
+          "fields": [
+            {
+              "name": "windowId",
+              "type": "ubyte"
+            }
+          ]
+        },
+        "custom_payload": {
+          "id": "0x09",
+          "fields": [
+            {
+              "name": "channel",
+              "type": "string"
+            },
+            {
+              "name": "data",
+              "type": "restBuffer"
             }
           ]
         },
@@ -2632,12 +2766,12 @@
             }
           ]
         },
-        "flying": {
-          "id": "0x0f",
+        "keep_alive": {
+          "id": "0x0b",
           "fields": [
             {
-              "name": "onGround",
-              "type": "bool"
+              "name": "keepAliveId",
+              "type": "varint"
             }
           ]
         },
@@ -2655,23 +2789,6 @@
             {
               "name": "z",
               "type": "double"
-            },
-            {
-              "name": "onGround",
-              "type": "bool"
-            }
-          ]
-        },
-        "look": {
-          "id": "0x0e",
-          "fields": [
-            {
-              "name": "yaw",
-              "type": "float"
-            },
-            {
-              "name": "pitch",
-              "type": "float"
             },
             {
               "name": "onGround",
@@ -2708,6 +2825,87 @@
             }
           ]
         },
+        "look": {
+          "id": "0x0e",
+          "fields": [
+            {
+              "name": "yaw",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "float"
+            },
+            {
+              "name": "onGround",
+              "type": "bool"
+            }
+          ]
+        },
+        "flying": {
+          "id": "0x0f",
+          "fields": [
+            {
+              "name": "onGround",
+              "type": "bool"
+            }
+          ]
+        },
+        "vehicle_move": {
+          "id": "0x10",
+          "fields": [
+            {
+              "name": "x",
+              "type": "double"
+            },
+            {
+              "name": "y",
+              "type": "double"
+            },
+            {
+              "name": "z",
+              "type": "double"
+            },
+            {
+              "name": "yaw",
+              "type": "float"
+            },
+            {
+              "name": "pitch",
+              "type": "float"
+            }
+          ]
+        },
+        "steer_boat": {
+          "id": "0x11",
+          "fields": [
+            {
+              "name": "unknown1",
+              "type": "bool"
+            },
+            {
+              "name": "unknown2",
+              "type": "bool"
+            }
+          ]
+        },
+        "abilities": {
+          "id": "0x12",
+          "fields": [
+            {
+              "name": "flags",
+              "type": "byte"
+            },
+            {
+              "name": "flyingSpeed",
+              "type": "float"
+            },
+            {
+              "name": "walkingSpeed",
+              "type": "float"
+            }
+          ]
+        },
         "block_dig": {
           "id": "0x13",
           "fields": [
@@ -2722,53 +2920,6 @@
             {
               "name": "face",
               "type": "byte"
-            }
-          ]
-        },
-        "block_place": {
-          "id": "0x1c",
-          "fields": [
-            {
-              "name": "location",
-              "type": "position"
-            },
-            {
-              "name": "direction",
-              "type": "varint"
-            },
-            {
-              "name": "hand",
-              "type": "varint"
-            },
-            {
-              "name": "cursorX",
-              "type": "byte"
-            },
-            {
-              "name": "cursorY",
-              "type": "byte"
-            },
-            {
-              "name": "cursorZ",
-              "type": "byte"
-            }
-          ]
-        },
-        "held_item_slot": {
-          "id": "0x17",
-          "fields": [
-            {
-              "name": "slotId",
-              "type": "short"
-            }
-          ]
-        },
-        "arm_animation": {
-          "id": "0x1a",
-          "fields": [
-            {
-              "name": "hand",
-              "type": "varint"
             }
           ]
         },
@@ -2806,58 +2957,25 @@
             }
           ]
         },
-        "close_window": {
-          "id": "0x08",
+        "resource_pack_receive": {
+          "id": "0x16",
           "fields": [
             {
-              "name": "windowId",
-              "type": "ubyte"
+              "name": "hash",
+              "type": "string"
+            },
+            {
+              "name": "result",
+              "type": "varint"
             }
           ]
         },
-        "window_click": {
-          "id": "0x07",
+        "held_item_slot": {
+          "id": "0x17",
           "fields": [
             {
-              "name": "windowId",
-              "type": "ubyte"
-            },
-            {
-              "name": "slot",
+              "name": "slotId",
               "type": "short"
-            },
-            {
-              "name": "mouseButton",
-              "type": "byte"
-            },
-            {
-              "name": "action",
-              "type": "short"
-            },
-            {
-              "name": "mode",
-              "type": "byte"
-            },
-            {
-              "name": "item",
-              "type": "slot"
-            }
-          ]
-        },
-        "transaction": {
-          "id": "0x05",
-          "fields": [
-            {
-              "name": "windowId",
-              "type": "byte"
-            },
-            {
-              "name": "action",
-              "type": "short"
-            },
-            {
-              "name": "accepted",
-              "type": "bool"
             }
           ]
         },
@@ -2871,133 +2989,6 @@
             {
               "name": "item",
               "type": "slot"
-            }
-          ]
-        },
-        "enchant_item": {
-          "id": "0x06",
-          "fields": [
-            {
-              "name": "windowId",
-              "type": "byte"
-            },
-            {
-              "name": "enchantment",
-              "type": "byte"
-            }
-          ]
-        },
-        "abilities": {
-          "id": "0x12",
-          "fields": [
-            {
-              "name": "flags",
-              "type": "byte"
-            },
-            {
-              "name": "flyingSpeed",
-              "type": "float"
-            },
-            {
-              "name": "walkingSpeed",
-              "type": "float"
-            }
-          ]
-        },
-        "tab_complete": {
-          "id": "0x01",
-          "fields": [
-            {
-              "name": "text",
-              "type": "string"
-            },
-            {
-              "name": "assumeCommand",
-              "type": "bool"
-            },
-            {
-              "name": "hasPosition",
-              "type": "bool"
-            },
-            {
-              "name": "lookedAtBlock",
-              "type": [
-                "option",
-                "position"
-              ]
-            }
-          ]
-        },
-        "settings": {
-          "id": "0x04",
-          "fields": [
-            {
-              "name": "locale",
-              "type": "string"
-            },
-            {
-              "name": "viewDistance",
-              "type": "byte"
-            },
-            {
-              "name": "chatFlags",
-              "type": "varint"
-            },
-            {
-              "name": "chatColors",
-              "type": "bool"
-            },
-            {
-              "name": "skinParts",
-              "type": "ubyte"
-            },
-            {
-              "name": "mainHand",
-              "type": "varint"
-            }
-          ]
-        },
-        "client_command": {
-          "id": "0x03",
-          "fields": [
-            {
-              "name": "actionId",
-              "type": "varint"
-            }
-          ]
-        },
-        "custom_payload": {
-          "id": "0x09",
-          "fields": [
-            {
-              "name": "channel",
-              "type": "string"
-            },
-            {
-              "name": "data",
-              "type": "restBuffer"
-            }
-          ]
-        },
-        "spectate": {
-          "id": "0x1b",
-          "fields": [
-            {
-              "name": "target",
-              "type": "UUID"
-            }
-          ]
-        },
-        "resource_pack_receive": {
-          "id": "0x16",
-          "fields": [
-            {
-              "name": "hash",
-              "type": "string"
-            },
-            {
-              "name": "result",
-              "type": "varint"
             }
           ]
         },
@@ -3026,41 +3017,50 @@
             }
           ]
         },
-        "vehicle_move": {
-          "id": "0x29",
+        "arm_animation": {
+          "id": "0x1a",
           "fields": [
             {
-              "name": "x",
-              "type": "double"
-            },
-            {
-              "name": "y",
-              "type": "double"
-            },
-            {
-              "name": "z",
-              "type": "double"
-            },
-            {
-              "name": "yaw",
-              "type": "float"
-            },
-            {
-              "name": "pitch",
-              "type": "float"
+              "name": "hand",
+              "type": "varint"
             }
           ]
         },
-        "steer_boat": {
-          "id": "0x11",
+        "spectate": {
+          "id": "0x1b",
           "fields": [
             {
-              "name": "unknown1",
-              "type": "bool"
+              "name": "target",
+              "type": "UUID"
+            }
+          ]
+        },
+        "block_place": {
+          "id": "0x1c",
+          "fields": [
+            {
+              "name": "location",
+              "type": "position"
             },
             {
-              "name": "unknown2",
-              "type": "bool"
+              "name": "direction",
+              "type": "varint"
+            },
+            {
+              "name": "hand",
+              "type": "varint"
+            },
+            {
+              "name": "cursorX",
+              "type": "byte"
+            },
+            {
+              "name": "cursorY",
+              "type": "byte"
+            },
+            {
+              "name": "cursorZ",
+              "type": "byte"
             }
           ]
         },


### PR DESCRIPTION
Reorders all the 1.9 packets by packet ID as to provide the desired property outline in #106. This is a resend of #107 for the sake of respecting the commit log a bit better.