### PR TITLE
Add protocol version codes up to 16w07a (101)

### DIFF
--- a/data/common/protocolVersions.json
+++ b/data/common/protocolVersions.json
@@ -1,5 +1,35 @@
 [
   {
+    "minecraftVersion": "16w07a",
+    "version": 101,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
+    "minecraftVersion": "16w06a",
+    "version": 100,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
+    "minecraftVersion": "16w05b",
+    "version": 99,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
+    "minecraftVersion": "16w05a",
+    "version": 98,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
+    "minecraftVersion": "16w04a",
+    "version": 97,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
     "minecraftVersion": "16w03a",
     "version": 96,
     "usesNetty": true,


### PR DESCRIPTION
Along with https://github.com/PrismarineJS/minecraft-data/pull/105 this allows `require('minecraft-data')('16w04a')` to get the 16w04a data