### PR TITLE
Add protocol versions up to 1.9-pre1 (103)

### DIFF
--- a/data/common/protocolVersions.json
+++ b/data/common/protocolVersions.json
@@ -1,5 +1,17 @@
 [
   {
+    "minecraftVersion": "1.9-pre1",
+    "version": 103,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
+    "minecraftVersion": "16w07b",
+    "version": 102,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
     "minecraftVersion": "16w07a",
     "version": 101,
     "usesNetty": true,


### PR DESCRIPTION
http://wiki.vg/Protocol_version_numbers

for today's release http://blog.mojang.com/2016/02/minecraft-19-pre-release-1/

note: this only adds protocol versions to protocolVersions.json, updating data/1.9/protocol.js to the 1.9-pre1 (103) data may require more work