### PR TITLE
1.7 plugin channel data buffers are length-prefixed

### DIFF
--- a/data/1.7/protocol.json
+++ b/data/1.7/protocol.json
@@ -1913,7 +1913,12 @@
             },
             {
               "name": "data",
-              "type": "restBuffer"
+              "type": [
+                "buffer",
+                {
+                  "countType": "short"
+                }
+              ]
             }
           ]
         },
@@ -2367,7 +2372,12 @@
             },
             {
               "name": "data",
-              "type": "restBuffer"
+              "type": [
+                "buffer",
+                {
+                  "countType": "short"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
http://wiki.vg/index.php?title=Protocol&oldid=6003#Plugin_Message

before:

```
MC-PROTO: 6780 read packet play.custom_payload
MC-PROTO: 6780 { channel: 'REGISTER',
  data: <Buffer 00 14 46 4d 4c 7c 48 53 00 46 4d 4c 00 46 4d 4c 00 46 4f 52 47 45> }
MC-PROTO: 6780 read packet play.custom_payload
MC-PROTO: 6780 { channel: 'FML|HS', data: <Buffer 00 06 00 02 00 00 00 00> }
```

after:

```
MC-PROTO: 6834 { channel: 'REGISTER',
  data: <Buffer 46 4d 4c 7c 48 53 00 46 4d 4c 00 46 4d 4c 00 46 4f 52 47 45> }
MC-PROTO: 6834 read packet play.custom_payload
MC-PROTO: 6834 { channel: 'FML|HS', data: <Buffer 00 02 00 00 00 00> }
```

http://wiki.vg/Minecraft_Forge_Handshake#Differences_from_Forge_1.7.10
> The most important thing to keep track of isn't (entirely) a forge change. In 1.7.10, plugin channel packets are length prefixed, while in 1.8 they are not. 