### PR TITLE
1.7 custom_payload 0x3f varshort for Forge compatibility

### DIFF
--- a/data/1.7/protocol.json
+++ b/data/1.7/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varshort": "native",
     "string": "native",
     "u16": "native",
     "u8": "native",
@@ -1916,7 +1917,7 @@
               "type": [
                 "buffer",
                 {
-                  "countType": "i16"
+                  "countType": "varshort"
                 }
               ]
             }


### PR DESCRIPTION
Requires https://github.com/roblabla/ProtoDef/pull/52

http://wiki.vg/Minecraft_Forge_Handshake#Differences_from_Forge_1.7.10 "However, forge makes some more changes to the server to client packet [0x3f](but not the client to server packet [0x17]): Rather than using a short for the length, a varshort is used"

Note this is backwards-compatibile with vanilla 1.7, since short lengths would never be negative. varshorts extend short by adding an extra byte (to extend 16-bit range to 23-bit) following the negative short with MSB set. Tested on forge-1.7.10-10.13.4.1614. Would like this for https://github.com/PrismarineJS/node-minecraft-protocol-forge/pull/7 (couldn't make the change there since it is a lower-level protocol change, but at least this is backwards-compatible with vanilla, so it should be safe - only extends the protocol)
