### PR TITLE
1.7: Add CoFH's SendUUID packet (packet id -26)

### DIFF
--- a/data/1.7/protocol.json
+++ b/data/1.7/protocol.json
@@ -1930,6 +1930,15 @@
               "type": "string"
             }
           ]
+        },
+        "cofh_senduuid": {
+          "id": "-0x1a",
+          "fields": [
+            {
+              "name": "playerUUID",
+              "type": "UUID"
+            }
+          ]
         }
       },
       "toServer": {
@@ -2378,6 +2387,15 @@
                   "countType": "i16"
                 }
               ]
+            }
+          ]
+        },
+        "cofh_senduuid": {
+          "id": "-0x1a",
+          "fields": [
+            {
+              "name": "playerUUID",
+              "type": "UUID"
             }
           ]
         }

--- a/schemas/protocol_schema.json
+++ b/schemas/protocol_schema.json
@@ -49,7 +49,7 @@
     },
     "id": {
       "type": "string",
-      "pattern": "^0x[0-9a-f]{2}$"
+      "pattern": "^-?0x[0-9a-f]{2}$"
     },
     "fields": {
       "type": "array",


### PR DESCRIPTION
This PR admittedly muddies the waters of what is 'minecraft' data, since it adds a packet not part of "vanilla" Minecraft, rather a modification for Minecraft. Used by http://teamcofh.com https://github.com/CoFH/ - as a popular library/dependency, CoFHLib/CoFHCore is present on many (most?) modded 1.7 servers.

The packet itself is very simple, only consisting of a UUID field. Since the ID is negative, it is not likely to conflict with vanilla packets, and 1.7.x is unlikely to change further anyway, so I think this is a worthwhile addition to minecraft-data. Another alternative would be to add this packet in node-minecraft-protocol-forge (but I'm not sure how to extend the packet specification in an nmp plugin. and other non-node software could also benefit from this -26 packet definition if it is in minecraft-data).

When combined with https://github.com/PrismarineJS/minecraft-data/pull/120, it is possible using https://github.com/PrismarineJS/node-minecraft-protocol-forge/pull/7 to connect to a heavily-modded server (Feed the Beast Infinity Evolved, 176 mods active) with no packet errors.
