### PR TITLE
popped_chorus_fruit -> chorus_fruit_popped

### DIFF
--- a/data/1.9/items.json
+++ b/data/1.9/items.json
@@ -1249,7 +1249,7 @@
     "id": 433,
     "displayName": "Popped Chorus Fruit",
     "stackSize": 64,
-    "name": "popped_chorus_fruit"
+    "name": "chorus_fruit_popped"
   },
   {
     "id": 434,


### PR DESCRIPTION
decompiled 1.9 source:
`adl.java:747:    a(433, (String)"chorus_fruit_popped", (new adl()).c("chorusFruitPopped").a(acn.l));`