### PR TITLE
fix spelling error

### DIFF
--- a/data/pc/1.10/protocol.json
+++ b/data/pc/1.10/protocol.json
@@ -2603,7 +2603,7 @@
               "type": "varint"
             },
             {
-              "name": "soundCatagory",
+              "name": "soundCategory",
               "type": "varint"
             },
             {


### PR DESCRIPTION
category not catagory (not sure if this needs to be fixed in previous versions, if so, let me know)