### PR TITLE
Fix incorrect ID for clientbound custom_payload

### DIFF
--- a/data/pc/1.11.2/protocol_comments.json
+++ b/data/pc/1.11.2/protocol_comments.json
@@ -358,7 +358,7 @@
           "",
           ""
         ],
-        "id": "0x20"
+        "id": "0x18"
       },
       "named_sound_effect": {
         "before": [


### PR DESCRIPTION
This was my mistake: when editing the article to add string max lengths, I changed the packet ID to 0x20 instead of putting a length of 20 to the channel ID.