### PR TITLE
Air should not be diggable (pc/1.11)

### DIFF
--- a/data/pc/1.11/blocks.json
+++ b/data/pc/1.11/blocks.json
@@ -5,7 +5,7 @@
     "name": "air",
     "hardness": 0,
     "stackSize": 0,
-    "diggable": true,
+    "diggable": false,
     "boundingBox": "empty",
     "drops": [
       {


### PR DESCRIPTION
[data/pc/1.11/blocks.json](https://github.com/PrismarineJS/minecraft-data/blob/bf4302f39b74c2fcc23d840bc4a2eb57a0262797/data/pc/1.11/blocks.json#L8) incorrectly specifies that air blocks are diggable.