### PR TITLE
Fix incorrectly named field in 1.13 packet_face_player

### DIFF
--- a/data/pc/1.13.1/protocol.json
+++ b/data/pc/1.13.1/protocol.json
@@ -107,7 +107,7 @@
                     {
                         "name": "blue",
                         "type": "f32"
-                    }, 
+                    },
                     {
                         "name": "scale",
                         "type": "f32"
@@ -1529,7 +1529,7 @@
                 "type": "f64"
               },
               {
-                "name": "x",
+                "name": "z",
                 "type": "f64"
               },
               {
@@ -3873,7 +3873,7 @@
               },
               {
                 "name": "hand",
-                "type": "varint"  
+                "type": "varint"
               }
             ]
         ],
@@ -3891,7 +3891,7 @@
             ]
         ],
         "packet_pick_item": [
-            "container", 
+            "container",
             [
                 {
                     "name": "slot",
@@ -3900,7 +3900,7 @@
             ]
         ],
         "packet_name_item": [
-            "container", 
+            "container",
             [
                 {
                     "name": "name",
@@ -3909,7 +3909,7 @@
             ]
         ],
         "packet_select_trade": [
-            "container", 
+            "container",
             [
                 {
                     "name": "slot",
@@ -3918,7 +3918,7 @@
             ]
         ],
         "packet_set_beacon_effect": [
-            "container", 
+            "container",
             [
                 {
                     "name": "primary_effect",
@@ -3931,7 +3931,7 @@
             ]
         ],
         "packet_update_command_block": [
-            "container", 
+            "container",
             [
                 {
                     "name": "location",
@@ -3952,7 +3952,7 @@
             ]
         ],
         "packet_update_command_block_minecart": [
-            "container", 
+            "container",
             [
                 {
                     "name": "entityId",
@@ -3970,7 +3970,7 @@
             ]
         ],
         "packet_update_structure_block": [
-            "container", 
+            "container",
             [
                 {
                     "name": "location",

--- a/data/pc/1.13/protocol.json
+++ b/data/pc/1.13/protocol.json
@@ -107,7 +107,7 @@
                     {
                         "name": "blue",
                         "type": "f32"
-                    }, 
+                    },
                     {
                         "name": "scale",
                         "type": "f32"
@@ -1529,7 +1529,7 @@
                 "type": "f64"
               },
               {
-                "name": "x",
+                "name": "z",
                 "type": "f64"
               },
               {
@@ -3887,7 +3887,7 @@
             ]
         ],
         "packet_pick_item": [
-            "container", 
+            "container",
             [
                 {
                     "name": "slot",
@@ -3896,7 +3896,7 @@
             ]
         ],
         "packet_name_item": [
-            "container", 
+            "container",
             [
                 {
                     "name": "name",
@@ -3905,7 +3905,7 @@
             ]
         ],
         "packet_select_trade": [
-            "container", 
+            "container",
             [
                 {
                     "name": "slot",
@@ -3914,7 +3914,7 @@
             ]
         ],
         "packet_set_beacon_effect": [
-            "container", 
+            "container",
             [
                 {
                     "name": "primary_effect",
@@ -3927,7 +3927,7 @@
             ]
         ],
         "packet_update_command_block": [
-            "container", 
+            "container",
             [
                 {
                     "name": "location",
@@ -3948,7 +3948,7 @@
             ]
         ],
         "packet_update_command_block_minecart": [
-            "container", 
+            "container",
             [
                 {
                     "name": "entityId",
@@ -3966,7 +3966,7 @@
             ]
         ],
         "packet_update_structure_block": [
-            "container", 
+            "container",
             [
                 {
                     "name": "location",


### PR DESCRIPTION
My compiler was complaining about a duplicated field for this packet.

The final double is labeled `x` when it should be `z`.

This patch fixes that, also a bunch of random trailing whitespace my editor autoremoved.