### PR TITLE
Fix advancements packet (u64 -> i64) (fixes #217)

### DIFF
--- a/data/pc/1.12-pre4/protocol.json
+++ b/data/pc/1.12-pre4/protocol.json
@@ -962,7 +962,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/1.12.1/protocol.json
+++ b/data/pc/1.12.1/protocol.json
@@ -976,7 +976,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/1.12.2/protocol.json
+++ b/data/pc/1.12.2/protocol.json
@@ -976,7 +976,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/1.12/protocol.json
+++ b/data/pc/1.12/protocol.json
@@ -976,7 +976,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/1.13.1/protocol.json
+++ b/data/pc/1.13.1/protocol.json
@@ -1107,7 +1107,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/1.13.2-pre1/protocol.json
+++ b/data/pc/1.13.2-pre1/protocol.json
@@ -1112,7 +1112,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/1.13.2-pre2/protocol.json
+++ b/data/pc/1.13.2-pre2/protocol.json
@@ -1112,7 +1112,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/1.13.2/protocol.json
+++ b/data/pc/1.13.2/protocol.json
@@ -1112,7 +1112,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/1.13/protocol.json
+++ b/data/pc/1.13/protocol.json
@@ -1107,7 +1107,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/17w15a/protocol.json
+++ b/data/pc/17w15a/protocol.json
@@ -958,7 +958,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/17w18b/protocol.json
+++ b/data/pc/17w18b/protocol.json
@@ -962,7 +962,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]

--- a/data/pc/17w50a/protocol.json
+++ b/data/pc/17w50a/protocol.json
@@ -976,7 +976,7 @@
                                   "name": "criterionProgress",
                                   "type": [
                                     "option",
-                                    "u64"
+                                    "i64"
                                   ]
                                 }
                               ]


### PR DESCRIPTION
An unsigned long (u64) is never used in Minecraft, and the advancements packet criterion progress uses a normal long (i64) according to wiki.vg.