### PR TITLE
[docs] bump minecraft-data to 2.37.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "json-stable-stringify": "^1.0.1",
     "marked": "^0.3.5",
     "minecraft-assets": "^1.1.2",
-    "minecraft-data": "^2.35.0",
+    "minecraft-data": "^2.37.5",
     "query-string": "^3.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
didn't test but according to the rules of semver it should be compatiable