### PR TITLE
Fix protocol version of ~1.9.4 and add missing versions

### DIFF
--- a/data/pc/common/protocolVersions.json
+++ b/data/pc/common/protocolVersions.json
@@ -1039,19 +1039,19 @@
   },
   {
     "minecraftVersion": "1.9.4",
-    "version": 109,
+    "version": 110,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9.3",
-    "version": 109,
+    "version": 110,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9.3-pre3",
-    "version": 109,
+    "version": 110,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
@@ -1092,8 +1092,20 @@
     "majorVersion": "1.9"
   },
   {
+    "minecraftVersion": "1.9.1",
+    "version": 108,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
     "minecraftVersion": "1.9.1-pre2",
     "version": 108,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
+    "minecraftVersion": "1.9.1-pre1",
+    "version": 107,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
@@ -1297,6 +1309,18 @@
   },
   {
     "minecraftVersion": "15w39c",
+    "version": 74,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
+    "minecraftVersion": "15w39b",
+    "version": 74,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
+    "minecraftVersion": "15w39a",
     "version": 74,
     "usesNetty": true,
     "majorVersion": "1.9"
@@ -1506,7 +1530,79 @@
     "majorVersion": "1.8"
   },
   {
+    "minecraftVersion": "1.8.2-pre7",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.2-pre6",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.2-pre5",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.2-pre4",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.2-pre3",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.2-pre2",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.2-pre1",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
     "minecraftVersion": "1.8.1",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.1-pre5",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.1-pre4",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.1-pre3",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.1-pre2",
+    "version": 47,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "1.8.1-pre1",
     "version": 47,
     "usesNetty": true,
     "majorVersion": "1.8"
@@ -1614,8 +1710,20 @@
     "majorVersion": "1.8"
   },
   {
+    "minecraftVersion": "14w30b",
+    "version": 30,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
     "minecraftVersion": "14w30a",
     "version": 30,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "14w29b",
+    "version": 29,
     "usesNetty": true,
     "majorVersion": "1.8"
   },
@@ -1692,6 +1800,12 @@
     "majorVersion": "1.8"
   },
   {
+    "minecraftVersion": "14w20b",
+    "version": 18,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
     "minecraftVersion": "14w20a",
     "version": 18,
     "usesNetty": true,
@@ -1710,14 +1824,44 @@
     "majorVersion": "1.8"
   },
   {
+    "minecraftVersion": "14w18a",
+    "version": 16,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
     "minecraftVersion": "14w17a",
     "version": 15,
     "usesNetty": true,
     "majorVersion": "1.8"
   },
   {
+    "minecraftVersion": "14w11b",
+    "version": 14,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
     "minecraftVersion": "14w11a",
     "version": 14,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "14w10c",
+    "version": 13,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "14w10b",
+    "version": 13,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "14w10a",
+    "version": 13,
     "usesNetty": true,
     "majorVersion": "1.8"
   },
@@ -1734,8 +1878,20 @@
     "majorVersion": "1.8"
   },
   {
+    "minecraftVersion": "14w06b",
+    "version": 10,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
     "minecraftVersion": "14w06a",
     "version": 10,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "14w05b",
+    "version": 9,
     "usesNetty": true,
     "majorVersion": "1.8"
   },
@@ -1758,8 +1914,26 @@
     "majorVersion": "1.8"
   },
   {
+    "minecraftVersion": "14w03b",
+    "version": 6,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
     "minecraftVersion": "14w03a",
     "version": 6,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "14w02c",
+    "version": 5,
+    "usesNetty": true,
+    "majorVersion": "1.8"
+  },
+  {
+    "minecraftVersion": "14w02b",
+    "version": 5,
     "usesNetty": true,
     "majorVersion": "1.8"
   },
@@ -1771,6 +1945,30 @@
   },
   {
     "minecraftVersion": "1.7.10",
+    "version": 5,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "1.7.10-pre4",
+    "version": 5,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "1.7.10-pre3",
+    "version": 5,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "1.7.10-pre2",
+    "version": 5,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "1.7.10-pre1",
     "version": 5,
     "usesNetty": true,
     "majorVersion": "1.7"
@@ -1800,6 +1998,18 @@
     "majorVersion": "1.7"
   },
   {
+    "minecraftVersion": "1.7.6-pre2",
+    "version": 5,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "1.7.6-pre1",
+    "version": 5,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
     "minecraftVersion": "1.7.5",
     "version": 4,
     "usesNetty": true,
@@ -1818,6 +2028,54 @@
     "majorVersion": "1.7"
   },
   {
+    "minecraftVersion": "13w49a",
+    "version": 4,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w48b",
+    "version": 4,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w48a",
+    "version": 4,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w47e",
+    "version": 4,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w47d",
+    "version": 4,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w47c",
+    "version": 4,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w47b",
+    "version": 4,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w47a",
+    "version": 4,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
     "minecraftVersion": "1.7.2",
     "version": 4,
     "usesNetty": true,
@@ -1825,7 +2083,43 @@
   },
   {
     "minecraftVersion": "1.7.1-pre",
-    "version": 4,
+    "version": 3,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "1.7-pre",
+    "version": 3,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w43a",
+    "version": 2,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w42b",
+    "version": 1,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w42a",
+    "version": 1,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w41b",
+    "version": 0,
+    "usesNetty": true,
+    "majorVersion": "1.7"
+  },
+  {
+    "minecraftVersion": "13w41a",
+    "version": 0,
     "usesNetty": true,
     "majorVersion": "1.7"
   },


### PR DESCRIPTION
Fixed some wrong protocol versions for minecraft 1.9.3-pre3 till 1.9.4 (was 109 instead of 110).
Checking https://wiki.vg/Protocol_version_numbers I've also added some missing versions to the file.