### PR TITLE
Add data versions

### DIFF
--- a/data/pc/common/protocolVersions.json
+++ b/data/pc/common/protocolVersions.json
@@ -2,1260 +2,1477 @@
   {
     "minecraftVersion": "1.15.1",
     "version": 575,
+    "dataVersion": 2227,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.15.1-pre1",
     "version": 574,
+    "dataVersion": 2226,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.15",
     "version": 573,
+    "dataVersion": 2225,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.15-pre7",
     "version": 572,
+    "dataVersion": 2224,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.15-pre6",
     "version": 571,
+    "dataVersion": 2223,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.15-pre5",
     "version": 570,
+    "dataVersion": 2222,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.15-pre4",
     "version": 569,
+    "dataVersion": 2221,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.15-pre3",
     "version": 567,
+    "dataVersion": 2220,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.15-pre2",
     "version": 566,
+    "dataVersion": 2219,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.15-pre1",
     "version": 565,
+    "dataVersion": 2218,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w46b",
     "version": 564,
+    "dataVersion": 2217,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w46a",
     "version": 563,
+    "dataVersion": 2216,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w45b",
     "version": 562,
+    "dataVersion": 2215,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w45a",
     "version": 561,
+    "dataVersion": 2214,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w44a",
     "version": 560,
+    "dataVersion": 2213,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w42a",
     "version": 559,
+    "dataVersion": 2212,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w41a",
     "version": 558,
+    "dataVersion": 2210,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w40a",
     "version": 557,
+    "dataVersion": 2208,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w39a",
     "version": 556,
+    "dataVersion": 2207,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w38b",
     "version": 555,
+    "dataVersion": 2206,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w38a",
     "version": 554,
+    "dataVersion": 2205,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w37a",
     "version": 553,
+    "dataVersion": 2204,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w36a",
     "version": 552,
+    "dataVersion": 2203,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w35a",
     "version": 551,
+    "dataVersion": 2201,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "19w34a",
     "version": 550,
+    "dataVersion": 2200,
     "usesNetty": true,
     "majorVersion": "1.15"
   },
   {
     "minecraftVersion": "1.14.4",
     "version": 498,
+    "dataVersion": 1976,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.4-pre7",
     "version": 497,
+    "dataVersion": 1975,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.4-pre6",
     "version": 496,
+    "dataVersion": 1974,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.4-pre5",
     "version": 495,
+    "dataVersion": 1973,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.4-pre4",
     "version": 494,
+    "dataVersion": 1972,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.4-pre3",
     "version": 493,
+    "dataVersion": 1971,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.4-pre2",
     "version": 492,
+    "dataVersion": 1970,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.4-pre1",
     "version": 491,
+    "dataVersion": 1969,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.3",
     "version": 490,
+    "dataVersion": 1968,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.3-pre4",
     "version": 489,
+    "dataVersion": 1967,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.3-pre3",
     "version": 488,
+    "dataVersion": 1966,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.3-pre2",
     "version": 487,
+    "dataVersion": 1965,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.3-pre1",
     "version": 486,
+    "dataVersion": 1964,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.2",
     "version": 485,
+    "dataVersion": 1963,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.2-pre4",
     "version": 484,
+    "dataVersion": 1962,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.2-pre3",
     "version": 483,
+    "dataVersion": 1960,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.2-pre2",
     "version": 482,
+    "dataVersion": 1959,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.2-pre1",
     "version": 481,
+    "dataVersion": 1958,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.1",
     "version": 480,
+    "dataVersion": 1957,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.1-pre2",
     "version": 479,
+    "dataVersion": 1956,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14.1-pre1",
     "version": 478,
+    "dataVersion": 1955,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14",
     "version": 477,
+    "dataVersion": 1952,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14-pre5",
     "version": 476,
+    "dataVersion": 1951,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14-pre4",
     "version": 475,
+    "dataVersion": 1950,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14-pre3",
     "version": 474,
+    "dataVersion": 1949,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14-pre2",
     "version": 473,
+    "dataVersion": 1948,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.14-pre1",
     "version": 472,
+    "dataVersion": 1947,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w14b",
     "version": 471,
+    "dataVersion": 1945,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w14a",
     "version": 470,
+    "dataVersion": 1944,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w13b",
     "version": 469,
+    "dataVersion": 1943,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w13a",
     "version": 468,
+    "dataVersion": 1942,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w12b",
     "version": 467,
+    "dataVersion": 1941,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w12a",
     "version": 466,
+    "dataVersion": 1940,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w11b",
     "version": 465,
+    "dataVersion": 1938,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w11a",
     "version": 464,
+    "dataVersion": 1937,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w09a",
     "version": 463,
+    "dataVersion": 1935,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w08b",
     "version": 462,
+    "dataVersion": 1934,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w08a",
     "version": 461,
+    "dataVersion": 1933,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w07a",
     "version": 460,
+    "dataVersion": 1932,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w06a",
     "version": 459,
+    "dataVersion": 1931,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w05a",
     "version": 458,
+    "dataVersion": 1930,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w04b",
     "version": 457,
+    "dataVersion": 1927,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w04a",
     "version": 456,
+    "dataVersion": 1926,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w03c",
     "version": 455,
+    "dataVersion": 1924,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w03b",
     "version": 454,
+    "dataVersion": 1923,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w03a",
     "version": 453,
+    "dataVersion": 1922,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "19w02a",
     "version": 452,
+    "dataVersion": 1921,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w50a",
     "version": 451,
+    "dataVersion": 1919,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w49a",
     "version": 450,
+    "dataVersion": 1916,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w48b",
     "version": 449,
+    "dataVersion": 1915,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w48a",
     "version": 448,
+    "dataVersion": 1914,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w47b",
     "version": 447,
+    "dataVersion": 1913,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w47a",
     "version": 446,
+    "dataVersion": 1912,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w46a",
     "version": 445,
+    "dataVersion": 1910,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w45a",
     "version": 444,
+    "dataVersion": 1908,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w44a",
     "version": 443,
+    "dataVersion": 1907,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w43c",
     "version": 442,
+    "dataVersion": 1903,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w43b",
     "version": 441,
+    "dataVersion": 1902,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "18w43a",
     "version": 441,
+    "dataVersion": 1902,
     "usesNetty": true,
     "majorVersion": "1.14"
   },
   {
     "minecraftVersion": "1.13.2",
     "version": 404,
+    "dataVersion": 1631,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13.2-pre2",
     "version": 403,
+    "dataVersion": 1630,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13.2-pre1",
     "version": 402,
+    "dataVersion": 1629,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13.1",
     "version": 401,
+    "dataVersion": 1628,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13.1-pre2",
     "version": 400,
+    "dataVersion": 1627,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13.1-pre1",
     "version": 399,
+    "dataVersion": 1626,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w33a",
     "version": 398,
+    "dataVersion": 1625,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w32a",
     "version": 397,
+    "dataVersion": 1623,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w31a",
     "version": 396,
+    "dataVersion": 1622,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w30b",
     "version": 395,
+    "dataVersion": 1621,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w30a",
     "version": 394,
+    "dataVersion": 1620,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13",
     "version": 393,
+    "dataVersion": 1519,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre10",
     "version": 392,
+    "dataVersion": 1518,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre9",
     "version": 391,
+    "dataVersion": 1517,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre8",
     "version": 390,
+    "dataVersion": 1516,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre7",
     "version": 389,
+    "dataVersion": 1513,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre6",
     "version": 388,
+    "dataVersion": 1512,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre5",
     "version": 387,
+    "dataVersion": 1511,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre4",
     "version": 386,
+    "dataVersion": 1504,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre3",
     "version": 385,
+    "dataVersion": 1503,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre2",
     "version": 384,
+    "dataVersion": 1502,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.13-pre1",
     "version": 383,
+    "dataVersion": 1501,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w22c",
     "version": 382,
+    "dataVersion": 1499,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w22b",
     "version": 381,
+    "dataVersion": 1498,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w22a",
     "version": 380,
+    "dataVersion": 1497,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w21b",
     "version": 379,
+    "dataVersion": 1496,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w21a",
     "version": 378,
+    "dataVersion": 1495,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w20c",
     "version": 377,
+    "dataVersion": 1493,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w20b",
     "version": 376,
+    "dataVersion": 1491,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w20a",
     "version": 375,
+    "dataVersion": 1489,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w19b",
     "version": 374,
+    "dataVersion": 1485,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w19a",
     "version": 373,
+    "dataVersion": 1484,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w16a",
     "version": 372,
+    "dataVersion": 1483,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w15a",
     "version": 371,
+    "dataVersion": 1482,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w14b",
     "version": 370,
+    "dataVersion": 1481,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w14a",
     "version": 369,
+    "dataVersion": 1479,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w11a",
     "version": 368,
+    "dataVersion": 1478,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w10d",
     "version": 367,
+    "dataVersion": 1477,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w10c",
     "version": 366,
+    "dataVersion": 1476,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w10b",
     "version": 365,
+    "dataVersion": 1474,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w10a",
     "version": 364,
+    "dataVersion": 1473,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w09a",
     "version": 363,
+    "dataVersion": 1472,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w08b",
     "version": 362,
+    "dataVersion": 1471,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w08a",
     "version": 361,
+    "dataVersion": 1470,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w07c",
     "version": 360,
+    "dataVersion": 1469,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w07b",
     "version": 359,
+    "dataVersion": 1468,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w07a",
     "version": 358,
+    "dataVersion": 1467,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w06a",
     "version": 357,
+    "dataVersion": 1466,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w05a",
     "version": 356,
+    "dataVersion": 1464,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w03b",
     "version": 355,
+    "dataVersion": 1463,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w03a",
     "version": 354,
+    "dataVersion": 1462,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w02a",
     "version": 353,
+    "dataVersion": 1461,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "18w01a",
     "version": 352,
+    "dataVersion": 1459,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w50a",
     "version": 351,
+    "dataVersion": 1457,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w49b",
     "version": 350,
+    "dataVersion": 1455,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w49a",
     "version": 349,
+    "dataVersion": 1454,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w48a",
     "version": 348,
+    "dataVersion": 1453,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w47b",
     "version": 347,
+    "dataVersion": 1452,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w47a",
     "version": 346,
+    "dataVersion": 1451,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w46a",
     "version": 345,
+    "dataVersion": 1449,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w45b",
     "version": 344,
+    "dataVersion": 1448,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w45a",
     "version": 343,
+    "dataVersion": 1447,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w43b",
     "version": 342,
+    "dataVersion": 1445,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "17w43a",
     "version": 341,
+    "dataVersion": 1444,
     "usesNetty": true,
     "majorVersion": "1.13"
   },
   {
     "minecraftVersion": "1.12.2",
     "version": 340,
+    "dataVersion": 1343,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12.2-pre2",
     "version": 339,
+    "dataVersion": 1342,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12.2-pre1",
     "version": 339,
+    "dataVersion": 1341,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12.1",
     "version": 338,
+    "dataVersion": 1241,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12.1-pre1",
     "version": 337,
+    "dataVersion": 1240,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w31a",
     "version": 336,
+    "dataVersion": 1239,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12",
     "version": 335,
+    "dataVersion": 1139,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12-pre7",
     "version": 334,
+    "dataVersion": 1138,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12-pre6",
     "version": 333,
+    "dataVersion": 1137,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12-pre5",
     "version": 332,
+    "dataVersion": 1136,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12-pre4",
     "version": 331,
+    "dataVersion": 1135,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12-pre3",
     "version": 330,
+    "dataVersion": 1134,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12-pre2",
     "version": 329,
+    "dataVersion": 1133,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.12-pre1",
     "version": 328,
+    "dataVersion": 1132,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w18b",
     "version": 327,
+    "dataVersion": 1131,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w18a",
     "version": 326,
+    "dataVersion": 1130,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w17b",
     "version": 325,
+    "dataVersion": 1129,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w17a",
     "version": 324,
+    "dataVersion": 1128,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w16b",
     "version": 323,
+    "dataVersion": 1127,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w16a",
     "version": 322,
+    "dataVersion": 1126,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w15a",
     "version": 321,
+    "dataVersion": 1125,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w14a",
     "version": 320,
+    "dataVersion": 1124,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w13b",
     "version": 319,
+    "dataVersion": 1123,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w13a",
     "version": 318,
+    "dataVersion": 1122,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "17w06a",
     "version": 317,
+    "dataVersion": 1022,
     "usesNetty": true,
     "majorVersion": "1.12"
   },
   {
     "minecraftVersion": "1.11.2",
     "version": 316,
+    "dataVersion": 922,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "1.11.1",
     "version": 316,
+    "dataVersion": 921,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w50a",
     "version": 316,
+    "dataVersion": 920,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "1.11",
     "version": 315,
+    "dataVersion": 819,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "1.11-pre1",
     "version": 314,
+    "dataVersion": 818,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w44a",
     "version": 313,
+    "dataVersion": 817,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w43a",
     "version": 313,
+    "dataVersion": 817,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w42a",
     "version": 312,
+    "dataVersion": 815,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w41a",
     "version": 311,
+    "dataVersion": 814,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w40a",
     "version": 310,
+    "dataVersion": 813,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w39c",
     "version": 309,
+    "dataVersion": 812,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w39b",
     "version": 308,
+    "dataVersion": 811,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w39a",
     "version": 307,
+    "dataVersion": 809,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w38a",
     "version": 306,
+    "dataVersion": 807,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w36a",
     "version": 305,
+    "dataVersion": 805,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w35a",
     "version": 304,
+    "dataVersion": 803,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w33a",
     "version": 303,
+    "dataVersion": 802,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w32b",
     "version": 302,
+    "dataVersion": 801,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "16w32a",
     "version": 301,
+    "dataVersion": 800,
     "usesNetty": true,
     "majorVersion": "1.11"
   },
   {
     "minecraftVersion": "1.10.2",
     "version": 210,
+    "dataVersion": 512,
     "usesNetty": true,
     "majorVersion": "1.10"
   },
   {
     "minecraftVersion": "1.10.1",
     "version": 210,
+    "dataVersion": 511,
     "usesNetty": true,
     "majorVersion": "1.10"
   },
   {
     "minecraftVersion": "1.10",
     "version": 210,
+    "dataVersion": 510,
     "usesNetty": true,
     "majorVersion": "1.10"
   },
   {
     "minecraftVersion": "1.10-pre2",
     "version": 205,
+    "dataVersion": 507,
     "usesNetty": true,
     "majorVersion": "1.10"
   },
   {
     "minecraftVersion": "1.10-pre1",
     "version": 204,
+    "dataVersion": 506,
     "usesNetty": true,
     "majorVersion": "1.10"
   },
   {
     "minecraftVersion": "16w21b",
     "version": 203,
+    "dataVersion": 504,
     "usesNetty": true,
     "majorVersion": "1.10"
   },
   {
     "minecraftVersion": "16w21a",
     "version": 202,
+    "dataVersion": 503,
     "usesNetty": true,
     "majorVersion": "1.10"
   },
   {
     "minecraftVersion": "16w20a",
     "version": 201,
+    "dataVersion": 501,
     "usesNetty": true,
     "majorVersion": "1.10"
   },
   {
     "minecraftVersion": "1.9.4",
     "version": 110,
+    "dataVersion": 184,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9.3",
     "version": 110,
+    "dataVersion": 183,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9.3-pre3",
     "version": 110,
+    "dataVersion": 182,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9.3-pre2",
     "version": 110,
+    "dataVersion": 181,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9.3-pre1",
     "version": 109,
+    "dataVersion": 180,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w15b",
     "version": 109,
+    "dataVersion": 179,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w15a",
     "version": 109,
+    "dataVersion": 178,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w14a",
     "version": 109,
+    "dataVersion": 177,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9.2",
     "version": 109,
+    "dataVersion": 176,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9.1",
     "version": 108,
+    "dataVersion": 175,
+    "usesNetty": true,
+    "majorVersion": "1.9"
+  },
+  {
+    "minecraftVersion": "1.9.1-pre3",
+    "version": 108,
+    "dataVersion": 172,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
@@ -1268,360 +1485,420 @@
   {
     "minecraftVersion": "1.9.1-pre2",
     "version": 108,
+    "dataVersion": 171,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9.1-pre1",
     "version": 107,
+    "dataVersion": 170,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9",
     "version": 107,
+    "dataVersion": 169,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9-pre4",
     "version": 106,
+    "dataVersion": 168,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9-pre3",
     "version": 105,
+    "dataVersion": 167,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9-pre2",
     "version": 104,
+    "dataVersion": 165,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "1.9-pre1",
     "version": 103,
+    "dataVersion": 164,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w07b",
     "version": 102,
+    "dataVersion": 163,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w07a",
     "version": 101,
+    "dataVersion": 162,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w06a",
     "version": 100,
+    "dataVersion": 161,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w05b",
     "version": 99,
+    "dataVersion": 160,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w05a",
     "version": 98,
+    "dataVersion": 159,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w04a",
     "version": 97,
+    "dataVersion": 158,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w03a",
     "version": 96,
+    "dataVersion": 157,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "16w02a",
     "version": 95,
+    "dataVersion": 156,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w51b",
     "version": 94,
+    "dataVersion": 155,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w51a",
     "version": 93,
+    "dataVersion": 154,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w50a",
     "version": 92,
+    "dataVersion": 153,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w49b",
     "version": 91,
+    "dataVersion": 152,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w49a",
     "version": 90,
+    "dataVersion": 151,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w47c",
     "version": 89,
+    "dataVersion": 150,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w47b",
     "version": 88,
+    "dataVersion": 149,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w47a",
     "version": 87,
+    "dataVersion": 148,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w46a",
     "version": 86,
+    "dataVersion": 146,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w45a",
     "version": 85,
+    "dataVersion": 145,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w44b",
     "version": 84,
+    "dataVersion": 143,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w44a",
     "version": 83,
+    "dataVersion": 142,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w43c",
     "version": 82,
+    "dataVersion": 141,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w43b",
     "version": 81,
+    "dataVersion": 140,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w43a",
     "version": 80,
+    "dataVersion": 139,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w42a",
     "version": 79,
+    "dataVersion": 138,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w41b",
     "version": 78,
+    "dataVersion": 137,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w41a",
     "version": 77,
+    "dataVersion": 136,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w40b",
     "version": 76,
+    "dataVersion": 134,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w40a",
     "version": 75,
+    "dataVersion": 133,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w39c",
     "version": 74,
+    "dataVersion": 132,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w39b",
     "version": 74,
+    "dataVersion": 131,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w39a",
     "version": 74,
+    "dataVersion": 130,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w38b",
     "version": 73,
+    "dataVersion": 129,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w38a",
     "version": 72,
+    "dataVersion": 128,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w37a",
     "version": 71,
+    "dataVersion": 127,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w36d",
     "version": 70,
+    "dataVersion": 126,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w36c",
     "version": 69,
+    "dataVersion": 125,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w36b",
     "version": 68,
+    "dataVersion": 124,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w36a",
     "version": 67,
+    "dataVersion": 123,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w35e",
     "version": 66,
+    "dataVersion": 122,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w35d",
     "version": 65,
+    "dataVersion": 121,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w35c",
     "version": 64,
+    "dataVersion": 120,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w35b",
     "version": 63,
+    "dataVersion": 119,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w35a",
     "version": 62,
+    "dataVersion": 118,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w34d",
     "version": 61,
+    "dataVersion": 117,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w34c",
     "version": 60,
+    "dataVersion": 116,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w34b",
     "version": 59,
+    "dataVersion": 115,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w34a",
     "version": 58,
+    "dataVersion": 114,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w33c",
     "version": 57,
+    "dataVersion": 112,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w33b",
     "version": 56,
+    "dataVersion": 111,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w33a",
     "version": 55,
+    "dataVersion": 111,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w32c",
     "version": 54,
+    "dataVersion": 104,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w32b",
     "version": 53,
+    "dataVersion": 103,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
   {
     "minecraftVersion": "15w32a",
     "version": 52,
+    "dataVersion": 100,
     "usesNetty": true,
     "majorVersion": "1.9"
   },
@@ -2294,180 +2571,210 @@
   {
     "minecraftVersion": "1.6.4",
     "version": 78,
+    "dataVersion": 137,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "1.6.2",
     "version": 74,
+    "dataVersion": 132,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "1.6.1",
     "version": 73,
+    "dataVersion": 129,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "1.6-pre",
     "version": 72,
+    "dataVersion": 128,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w26a",
     "version": 72,
+    "dataVersion": 128,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w25c",
     "version": 71,
+    "dataVersion": 127,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w25b",
     "version": 71,
+    "dataVersion": 127,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w25a",
     "version": 71,
+    "dataVersion": 127,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w24b",
     "version": 70,
+    "dataVersion": 126,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w24a",
     "version": 69,
+    "dataVersion": 125,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w23b",
     "version": 68,
+    "dataVersion": 124,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w23a",
     "version": 67,
+    "dataVersion": 123,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w22a",
     "version": 67,
+    "dataVersion": 123,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w21b",
     "version": 67,
+    "dataVersion": 123,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w21a",
     "version": 67,
+    "dataVersion": 123,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w19a",
     "version": 66,
+    "dataVersion": 122,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w18a",
     "version": 65,
+    "dataVersion": 121,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w17a",
     "version": 64,
+    "dataVersion": 120,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "13w16b",
     "version": 63,
+    "dataVersion": 119,
     "usesNetty": false,
     "majorVersion": "1.6"
   },
   {
     "minecraftVersion": "1.5.2",
     "version": 61,
+    "dataVersion": 117,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "1.5.1",
     "version": 60,
+    "dataVersion": 116,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "1.5",
     "version": 60,
+    "dataVersion": 116,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "13w09b",
     "version": 59,
+    "dataVersion": 115,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "13w06a",
     "version": 58,
+    "dataVersion": 114,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "13w05b",
     "version": 57,
+    "dataVersion": 112,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "13w05a",
     "version": 56,
+    "dataVersion": 111,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "13w04a",
     "version": 55,
+    "dataVersion": 111,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "13w03a",
     "version": 54,
+    "dataVersion": 104,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "13w02a",
     "version": 53,
+    "dataVersion": 103,
     "usesNetty": false,
     "majorVersion": "1.5"
   },
   {
     "minecraftVersion": "13w01a",
     "version": 52,
+    "dataVersion": 100,
     "usesNetty": false,
     "majorVersion": "1.5"
   },

--- a/schemas/protocolVersions_schema.json
+++ b/schemas/protocolVersions_schema.json
@@ -7,6 +7,10 @@
     "uniqueItems": true,
     "properties": {
       "version": {
+        "description": "The protocol version",
+        "type": "integer"
+      },
+      "dataVersion": {
         "type": "integer"
       },
       "minecraftVersion": {

--- a/schemas/version_schema.json
+++ b/schemas/version_schema.json
@@ -2,17 +2,20 @@
   "title": "version",
   "type": "object",
   "uniqueItems": true,
-  "properties" : {
-    "version":
-    {
-      "type":"integer"
+  "properties": {
+    "version": {
+      "description": "The protocol version",
+      "type": "integer"
     },
-    "minecraftVersion":{
-      "type":"string",
+    "dataVersion": {
+      "type": "integer"
+    },
+    "minecraftVersion": {
+      "type": "string",
       "pattern": "([0-9]+\\.[0-9]+(\\.[0-9]+)?[a-z]?(-pre[0-9]+)?)|([0-9]{2}w[0-9]{2}[a-z])"
     },
-    "majorVersion":{
-      "type":"string",
+    "majorVersion": {
+      "type": "string",
       "pattern": "[0-9]+\\.[0-9]+[a-z]?"
     }
   },

--- a/schemas/version_schema.json
+++ b/schemas/version_schema.json
@@ -7,9 +7,6 @@
       "description": "The protocol version",
       "type": "integer"
     },
-    "dataVersion": {
-      "type": "integer"
-    },
     "minecraftVersion": {
       "type": "string",
       "pattern": "([0-9]+\\.[0-9]+(\\.[0-9]+)?[a-z]?(-pre[0-9]+)?)|([0-9]{2}w[0-9]{2}[a-z])"


### PR DESCRIPTION
I know that "dataVersion" is never actually used in the protocol, so it might not be a perfect fit for "protocolVersions.json" but since "versions.json" is already taken (related: #240), this is the best solution to remain backward-compatibility.