### PR TITLE
Add category property back

### DIFF
--- a/data/pc/1.13.2/entities.json
+++ b/data/pc/1.13.2/entities.json
@@ -6,7 +6,8 @@
     "displayName": "AreaEffectCloud",
     "width": null,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 1,
@@ -15,7 +16,8 @@
     "displayName": "ArmorStand",
     "width": null,
     "height": null,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 2,
@@ -24,7 +26,8 @@
     "displayName": "Arrow",
     "width": 0.5,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 3,
@@ -33,7 +36,8 @@
     "displayName": "Bat",
     "width": 0.5,
     "height": 0.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 4,
@@ -42,7 +46,8 @@
     "displayName": "Blaze",
     "width": 0.6,
     "height": 1.8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 5,
@@ -51,7 +56,8 @@
     "displayName": "Boat",
     "width": 1.375,
     "height": 0.5625,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 6,
@@ -60,7 +66,8 @@
     "displayName": "CaveSpider",
     "width": 0.7,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 7,
@@ -69,7 +76,8 @@
     "displayName": "Chicken",
     "width": 0.4,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 8,
@@ -87,7 +95,8 @@
     "displayName": "Cow",
     "width": 0.9,
     "height": 1.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 10,
@@ -96,7 +105,8 @@
     "displayName": "Creeper",
     "width": 0.6,
     "height": 1.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 11,
@@ -105,7 +115,8 @@
     "displayName": "Donkey",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 12,
@@ -123,7 +134,8 @@
     "displayName": "DragonFireball",
     "width": 1,
     "height": 1,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 14,
@@ -141,7 +153,8 @@
     "displayName": "ElderGuardian",
     "width": null,
     "height": null,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 16,
@@ -159,7 +172,8 @@
     "displayName": "EnderDragon",
     "width": 16,
     "height": 8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 18,
@@ -168,7 +182,8 @@
     "displayName": "Enderman",
     "width": 0.6,
     "height": 2.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 19,
@@ -177,7 +192,8 @@
     "displayName": "Endermite",
     "width": 0.4,
     "height": 0.3,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 20,
@@ -222,7 +238,8 @@
     "displayName": "FallingSand",
     "width": 0.98,
     "height": 0.98,
-    "type": "mob"
+    "type": "mob",
+    "category": "Blocks"
   },
   {
     "id": 25,
@@ -231,7 +248,8 @@
     "displayName": "FireworksRocketEntity",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 26,
@@ -240,7 +258,8 @@
     "displayName": "Ghast",
     "width": 4,
     "height": 4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 27,
@@ -249,7 +268,8 @@
     "displayName": "Giant",
     "width": 3.6,
     "height": 10.8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 28,
@@ -258,7 +278,8 @@
     "displayName": "Guardian",
     "width": 0.85,
     "height": 0.85,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 29,
@@ -267,7 +288,8 @@
     "displayName": "Horse (EntityHorse until 1.11)",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 30,
@@ -276,7 +298,8 @@
     "displayName": "Husk",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 31,
@@ -294,7 +317,8 @@
     "displayName": "Item",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Drops"
   },
   {
     "id": 33,
@@ -303,7 +327,8 @@
     "displayName": "ItemFrame",
     "width": 0.75,
     "height": 0.75,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 34,
@@ -312,7 +337,8 @@
     "displayName": "Fireball (ghast)",
     "width": 1,
     "height": 1,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 35,
@@ -321,7 +347,8 @@
     "displayName": "LeashKnot",
     "width": 0.375,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 36,
@@ -330,7 +357,8 @@
     "displayName": "Llama",
     "width": 0.9,
     "height": 1.87,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 37,
@@ -339,7 +367,8 @@
     "displayName": "LlamaSpit",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 38,
@@ -348,7 +377,8 @@
     "displayName": "LavaSlime (Magma Cube)",
     "width": 0.51000005,
     "height": 0.51000005,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 39,
@@ -357,7 +387,8 @@
     "displayName": "MinecartRideable",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 40,
@@ -366,7 +397,8 @@
     "displayName": "MinecartChest",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 41,
@@ -375,7 +407,8 @@
     "displayName": "MinecartCommandBlock",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 42,
@@ -384,7 +417,8 @@
     "displayName": "MinecartFurnace",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 43,
@@ -393,7 +427,8 @@
     "displayName": "MinecartHopper",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 44,
@@ -402,7 +437,8 @@
     "displayName": "MinecartSpawner",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 45,
@@ -411,7 +447,8 @@
     "displayName": "MinecartTNT",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 46,
@@ -420,7 +457,8 @@
     "displayName": "Mule",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 47,
@@ -429,7 +467,8 @@
     "displayName": "MushroomCow (Mooshroom)",
     "width": 0.9,
     "height": 1.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 48,
@@ -438,7 +477,8 @@
     "displayName": "Ozelot (Ocelot)",
     "width": 0.6,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 49,
@@ -447,7 +487,8 @@
     "displayName": "Painting",
     "width": null,
     "height": null,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 50,
@@ -456,7 +497,8 @@
     "displayName": "Parrot",
     "width": 0.5,
     "height": 0.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 51,
@@ -465,7 +507,8 @@
     "displayName": "Pig",
     "width": 0.9,
     "height": 0.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 52,
@@ -483,7 +526,8 @@
     "displayName": "PigZombie",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 54,
@@ -492,7 +536,8 @@
     "displayName": "PolarBear",
     "width": 1.3,
     "height": 1.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 55,
@@ -501,7 +546,8 @@
     "displayName": "PrimedTnt",
     "width": 0.98,
     "height": 0.98,
-    "type": "mob"
+    "type": "mob",
+    "category": "Blocks"
   },
   {
     "id": 56,
@@ -510,7 +556,8 @@
     "displayName": "Rabbit",
     "width": 0.4,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 57,
@@ -528,7 +575,8 @@
     "displayName": "Sheep",
     "width": 0.9,
     "height": 1.3,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 59,
@@ -537,7 +585,8 @@
     "displayName": "Shulker",
     "width": 1,
     "height": 1,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 60,
@@ -546,7 +595,8 @@
     "displayName": "ShulkerBullet",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 61,
@@ -555,7 +605,8 @@
     "displayName": "Silverfish",
     "width": 0.4,
     "height": 0.3,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 62,
@@ -564,7 +615,8 @@
     "displayName": "Skeleton",
     "width": 0.6,
     "height": 1.99,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 63,
@@ -573,7 +625,8 @@
     "displayName": "SkeletonHorse",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 64,
@@ -582,7 +635,8 @@
     "displayName": "Slime",
     "width": 0.51000005,
     "height": 0.51000005,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 65,
@@ -591,7 +645,8 @@
     "displayName": "SmallFireball (blaze)",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 66,
@@ -609,7 +664,8 @@
     "displayName": "Snowball",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 68,
@@ -618,7 +674,8 @@
     "displayName": "SpectralArrow",
     "width": 0.5,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 69,
@@ -627,7 +684,8 @@
     "displayName": "Spider",
     "width": 1.4,
     "height": 0.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 70,
@@ -636,7 +694,8 @@
     "displayName": "Squid",
     "width": 0.8,
     "height": 0.8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 71,
@@ -645,7 +704,8 @@
     "displayName": "Stray",
     "width": 0.6,
     "height": 1.99,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 72,
@@ -672,7 +732,8 @@
     "displayName": "ThrownEgg",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 75,
@@ -681,7 +742,8 @@
     "displayName": "ThrownEnderpearl",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 76,
@@ -699,7 +761,8 @@
     "displayName": "ThrownPotion",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 78,
@@ -708,7 +771,8 @@
     "displayName": "Vex",
     "width": 0.4,
     "height": 0.8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 79,
@@ -717,7 +781,8 @@
     "displayName": "Villager",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 80,
@@ -744,7 +809,8 @@
     "displayName": "Witch",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 83,
@@ -753,7 +819,8 @@
     "displayName": "WitherBoss",
     "width": 0.9,
     "height": 3.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 84,
@@ -762,7 +829,8 @@
     "displayName": "WitherSkeleton",
     "width": 0.7,
     "height": 2.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 85,
@@ -771,7 +839,8 @@
     "displayName": "WitherSkull",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 86,
@@ -780,7 +849,8 @@
     "displayName": "Wolf",
     "width": 0.6,
     "height": 0.85,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 87,
@@ -789,7 +859,8 @@
     "displayName": "Zombie",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 88,
@@ -798,7 +869,8 @@
     "displayName": "ZombieHorse",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 89,
@@ -807,7 +879,8 @@
     "displayName": "ZombieVillager",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 90,
@@ -861,7 +934,8 @@
     "displayName": "Boat",
     "width": 1.375,
     "height": 0.6,
-    "type": "object"
+    "type": "object",
+    "category": "Vehicles"
   },
   {
     "id": 2,
@@ -888,7 +962,8 @@
     "displayName": "Minecart",
     "width": 0.98,
     "height": 0.7,
-    "type": "object"
+    "type": "object",
+    "category": "Vehicles"
   },
   {
     "id": 50,
@@ -924,7 +999,8 @@
     "displayName": "Snowball (projectile)",
     "width": 0.25,
     "height": 0.25,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 62,
@@ -933,7 +1009,8 @@
     "displayName": "Egg (projectile)",
     "width": 0.25,
     "height": 0.25,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 63,
@@ -942,7 +1019,8 @@
     "displayName": "FireBall (ghast projectile)",
     "width": 1,
     "height": 1,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 64,
@@ -969,7 +1047,8 @@
     "displayName": "Wither Skull (projectile)",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 67,
@@ -978,7 +1057,8 @@
     "displayName": "Shulker Bullet",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 68,
@@ -987,7 +1067,8 @@
     "displayName": "Llama spit",
     "width": 0.25,
     "height": 0.25,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 70,
@@ -1050,7 +1131,8 @@
     "displayName": "Leash Knot",
     "width": 0.375,
     "height": 0.5,
-    "type": "object"
+    "type": "object",
+    "category": "Immobile"
   },
   {
     "id": 78,
@@ -1068,7 +1150,8 @@
     "displayName": "Evocation Fangs",
     "width": 0.5,
     "height": 0.8,
-    "type": "object"
+    "type": "object",
+    "category": "Immobile"
   },
   {
     "id": 90,
@@ -1086,7 +1169,8 @@
     "displayName": "Spectral Arrow",
     "width": 0.5,
     "height": 0.5,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 93,
@@ -1095,7 +1179,8 @@
     "displayName": "Dragon Fireball",
     "width": 1,
     "height": 1,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 94,

--- a/data/pc/1.13/entities.json
+++ b/data/pc/1.13/entities.json
@@ -6,7 +6,8 @@
     "displayName": "AreaEffectCloud",
     "width": null,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 1,
@@ -15,7 +16,8 @@
     "displayName": "ArmorStand",
     "width": null,
     "height": null,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 2,
@@ -24,7 +26,8 @@
     "displayName": "Arrow",
     "width": 0.5,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 3,
@@ -33,7 +36,8 @@
     "displayName": "Bat",
     "width": 0.5,
     "height": 0.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 4,
@@ -42,7 +46,8 @@
     "displayName": "Blaze",
     "width": 0.6,
     "height": 1.8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 5,
@@ -51,7 +56,8 @@
     "displayName": "Boat",
     "width": 1.375,
     "height": 0.5625,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 6,
@@ -60,7 +66,8 @@
     "displayName": "CaveSpider",
     "width": 0.7,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 7,
@@ -69,7 +76,8 @@
     "displayName": "Chicken",
     "width": 0.4,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 8,
@@ -87,7 +95,8 @@
     "displayName": "Cow",
     "width": 0.9,
     "height": 1.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 10,
@@ -96,7 +105,8 @@
     "displayName": "Creeper",
     "width": 0.6,
     "height": 1.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 11,
@@ -105,7 +115,8 @@
     "displayName": "Donkey",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 12,
@@ -123,7 +134,8 @@
     "displayName": "DragonFireball",
     "width": 1,
     "height": 1,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 14,
@@ -141,7 +153,8 @@
     "displayName": "ElderGuardian",
     "width": null,
     "height": null,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 16,
@@ -159,7 +172,8 @@
     "displayName": "EnderDragon",
     "width": 16,
     "height": 8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 18,
@@ -168,7 +182,8 @@
     "displayName": "Enderman",
     "width": 0.6,
     "height": 2.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 19,
@@ -177,7 +192,8 @@
     "displayName": "Endermite",
     "width": 0.4,
     "height": 0.3,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 20,
@@ -222,7 +238,8 @@
     "displayName": "FallingSand",
     "width": 0.98,
     "height": 0.98,
-    "type": "mob"
+    "type": "mob",
+    "category": "Blocks"
   },
   {
     "id": 25,
@@ -231,7 +248,8 @@
     "displayName": "FireworksRocketEntity",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 26,
@@ -240,7 +258,8 @@
     "displayName": "Ghast",
     "width": 4,
     "height": 4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 27,
@@ -249,7 +268,8 @@
     "displayName": "Giant",
     "width": 3.6,
     "height": 10.8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 28,
@@ -258,7 +278,8 @@
     "displayName": "Guardian",
     "width": 0.85,
     "height": 0.85,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 29,
@@ -267,7 +288,8 @@
     "displayName": "Horse (EntityHorse until 1.11)",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 30,
@@ -276,7 +298,8 @@
     "displayName": "Husk",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 31,
@@ -294,7 +317,8 @@
     "displayName": "Item",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Drops"
   },
   {
     "id": 33,
@@ -303,7 +327,8 @@
     "displayName": "ItemFrame",
     "width": 0.75,
     "height": 0.75,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 34,
@@ -312,7 +337,8 @@
     "displayName": "Fireball (ghast)",
     "width": 1,
     "height": 1,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 35,
@@ -321,7 +347,8 @@
     "displayName": "LeashKnot",
     "width": 0.375,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 36,
@@ -330,7 +357,8 @@
     "displayName": "Llama",
     "width": 0.9,
     "height": 1.87,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 37,
@@ -339,7 +367,8 @@
     "displayName": "LlamaSpit",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 38,
@@ -348,7 +377,8 @@
     "displayName": "LavaSlime (Magma Cube)",
     "width": 0.51000005,
     "height": 0.51000005,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 39,
@@ -357,7 +387,8 @@
     "displayName": "MinecartRideable",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 40,
@@ -366,7 +397,8 @@
     "displayName": "MinecartChest",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 41,
@@ -375,7 +407,8 @@
     "displayName": "MinecartCommandBlock",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 42,
@@ -384,7 +417,8 @@
     "displayName": "MinecartFurnace",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 43,
@@ -393,7 +427,8 @@
     "displayName": "MinecartHopper",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 44,
@@ -402,7 +437,8 @@
     "displayName": "MinecartSpawner",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 45,
@@ -411,7 +447,8 @@
     "displayName": "MinecartTNT",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 46,
@@ -420,7 +457,8 @@
     "displayName": "Mule",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 47,
@@ -429,7 +467,8 @@
     "displayName": "MushroomCow (Mooshroom)",
     "width": 0.9,
     "height": 1.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 48,
@@ -438,7 +477,8 @@
     "displayName": "Ozelot (Ocelot)",
     "width": 0.6,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 49,
@@ -447,7 +487,8 @@
     "displayName": "Painting",
     "width": null,
     "height": null,
-    "type": "mob"
+    "type": "mob",
+    "category": "Immobile"
   },
   {
     "id": 50,
@@ -456,7 +497,8 @@
     "displayName": "Parrot",
     "width": 0.5,
     "height": 0.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 51,
@@ -465,7 +507,8 @@
     "displayName": "Pig",
     "width": 0.9,
     "height": 0.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 52,
@@ -483,7 +526,8 @@
     "displayName": "PigZombie",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 54,
@@ -492,7 +536,8 @@
     "displayName": "PolarBear",
     "width": 1.3,
     "height": 1.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 55,
@@ -501,7 +546,8 @@
     "displayName": "PrimedTnt",
     "width": 0.98,
     "height": 0.98,
-    "type": "mob"
+    "type": "mob",
+    "category": "Blocks"
   },
   {
     "id": 56,
@@ -510,7 +556,8 @@
     "displayName": "Rabbit",
     "width": 0.4,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 57,
@@ -528,7 +575,8 @@
     "displayName": "Sheep",
     "width": 0.9,
     "height": 1.3,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 59,
@@ -537,7 +585,8 @@
     "displayName": "Shulker",
     "width": 1,
     "height": 1,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 60,
@@ -546,7 +595,8 @@
     "displayName": "ShulkerBullet",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 61,
@@ -555,7 +605,8 @@
     "displayName": "Silverfish",
     "width": 0.4,
     "height": 0.3,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 62,
@@ -564,7 +615,8 @@
     "displayName": "Skeleton",
     "width": 0.6,
     "height": 1.99,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 63,
@@ -573,7 +625,8 @@
     "displayName": "SkeletonHorse",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 64,
@@ -582,7 +635,8 @@
     "displayName": "Slime",
     "width": 0.51000005,
     "height": 0.51000005,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 65,
@@ -591,7 +645,8 @@
     "displayName": "SmallFireball (blaze)",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 66,
@@ -609,7 +664,8 @@
     "displayName": "Snowball",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 68,
@@ -618,7 +674,8 @@
     "displayName": "SpectralArrow",
     "width": 0.5,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 69,
@@ -627,7 +684,8 @@
     "displayName": "Spider",
     "width": 1.4,
     "height": 0.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 70,
@@ -636,7 +694,8 @@
     "displayName": "Squid",
     "width": 0.8,
     "height": 0.8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 71,
@@ -645,7 +704,8 @@
     "displayName": "Stray",
     "width": 0.6,
     "height": 1.99,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 72,
@@ -672,7 +732,8 @@
     "displayName": "ThrownEgg",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 75,
@@ -681,7 +742,8 @@
     "displayName": "ThrownEnderpearl",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 76,
@@ -699,7 +761,8 @@
     "displayName": "ThrownPotion",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 78,
@@ -708,7 +771,8 @@
     "displayName": "Vex",
     "width": 0.4,
     "height": 0.8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 79,
@@ -717,7 +781,8 @@
     "displayName": "Villager",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 80,
@@ -744,7 +809,8 @@
     "displayName": "Witch",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 83,
@@ -753,7 +819,8 @@
     "displayName": "WitherBoss",
     "width": 0.9,
     "height": 3.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 84,
@@ -762,7 +829,8 @@
     "displayName": "WitherSkeleton",
     "width": 0.7,
     "height": 2.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 85,
@@ -771,7 +839,8 @@
     "displayName": "WitherSkull",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "mob"
+    "type": "mob",
+    "category": "Projectiles"
   },
   {
     "id": 86,
@@ -780,7 +849,8 @@
     "displayName": "Wolf",
     "width": 0.6,
     "height": 0.85,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 87,
@@ -789,7 +859,8 @@
     "displayName": "Zombie",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 88,
@@ -798,7 +869,8 @@
     "displayName": "ZombieHorse",
     "width": 1.3964844,
     "height": 1.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 89,
@@ -807,7 +879,8 @@
     "displayName": "ZombieVillager",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 90,
@@ -861,7 +934,8 @@
     "displayName": "Boat",
     "width": 1.375,
     "height": 0.6,
-    "type": "object"
+    "type": "object",
+    "category": "Vehicles"
   },
   {
     "id": 2,
@@ -888,7 +962,8 @@
     "displayName": "Minecart",
     "width": 0.98,
     "height": 0.7,
-    "type": "object"
+    "type": "object",
+    "category": "Vehicles"
   },
   {
     "id": 50,
@@ -924,7 +999,8 @@
     "displayName": "Snowball (projectile)",
     "width": 0.25,
     "height": 0.25,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 62,
@@ -933,7 +1009,8 @@
     "displayName": "Egg (projectile)",
     "width": 0.25,
     "height": 0.25,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 63,
@@ -942,7 +1019,8 @@
     "displayName": "FireBall (ghast projectile)",
     "width": 1,
     "height": 1,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 64,
@@ -969,7 +1047,8 @@
     "displayName": "Wither Skull (projectile)",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 67,
@@ -978,7 +1057,8 @@
     "displayName": "Shulker Bullet",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 68,
@@ -987,7 +1067,8 @@
     "displayName": "Llama spit",
     "width": 0.25,
     "height": 0.25,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 70,
@@ -1050,7 +1131,8 @@
     "displayName": "Leash Knot",
     "width": 0.375,
     "height": 0.5,
-    "type": "object"
+    "type": "object",
+    "category": "Immobile"
   },
   {
     "id": 78,
@@ -1068,7 +1150,8 @@
     "displayName": "Evocation Fangs",
     "width": 0.5,
     "height": 0.8,
-    "type": "object"
+    "type": "object",
+    "category": "Immobile"
   },
   {
     "id": 90,
@@ -1086,7 +1169,8 @@
     "displayName": "Spectral Arrow",
     "width": 0.5,
     "height": 0.5,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 93,
@@ -1095,7 +1179,8 @@
     "displayName": "Dragon Fireball",
     "width": 1,
     "height": 1,
-    "type": "object"
+    "type": "object",
+    "category": "Projectiles"
   },
   {
     "id": 94,


### PR DESCRIPTION
In https://github.com/PrismarineJS/minecraft-data/commit/7e0b470872d7e3d1de937d7099dd547fe62e0a2b Entity.category was removed from 1.13, which was pretty useful to distinguish between hostile and non-hostile mobs (https://github.com/PrismarineJS/mineflayer/pull/941#discussion_r410127163).

I added them back using data from https://github.com/PrismarineJS/minecraft-wiki-extractor but I didn't get the category of some entities that were added in the same commin, so I'm not sure if that could be a problem.