### PR TITLE
Copy category from older minecraft version

### DIFF
--- a/data/pc/1.14.4/entities.json
+++ b/data/pc/1.14.4/entities.json
@@ -66,7 +66,8 @@
     "displayName": "Cat",
     "width": 0.6,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 7,
@@ -95,7 +96,8 @@
     "displayName": "Cod",
     "width": 0.5,
     "height": 0.3,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 10,
@@ -134,7 +136,8 @@
     "displayName": "Dolphin",
     "width": 0.9,
     "height": 0.6,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 14,
@@ -153,7 +156,8 @@
     "displayName": "Drowned",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 16,
@@ -211,7 +215,8 @@
     "displayName": "Evoker Fangs",
     "width": 0.5,
     "height": 0.8,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 22,
@@ -220,7 +225,8 @@
     "displayName": "Evoker",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 23,
@@ -325,7 +331,8 @@
     "displayName": "Illusioner",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 34,
@@ -424,7 +431,8 @@
     "displayName": "Minecart with Command Block",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Vehicles"
   },
   {
     "id": 44,
@@ -513,7 +521,8 @@
     "displayName": "Panda",
     "width": 1.3,
     "height": 1.25,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 53,
@@ -542,7 +551,8 @@
     "displayName": "Pufferfish",
     "width": 0.7,
     "height": 0.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 56,
@@ -591,7 +601,8 @@
     "displayName": "Salmon",
     "width": 0.7,
     "height": 0.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 61,
@@ -680,7 +691,8 @@
     "displayName": "Snow Golem",
     "width": 0.7,
     "height": 1.9,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 70,
@@ -739,7 +751,8 @@
     "displayName": "Trader Llama",
     "width": 0.9,
     "height": 1.87,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 76,
@@ -748,7 +761,8 @@
     "displayName": "Tropical Fish",
     "width": 0.5,
     "height": 0.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 77,
@@ -757,7 +771,8 @@
     "displayName": "Turtle",
     "width": 1.2,
     "height": 0.4,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 78,
@@ -834,7 +849,8 @@
     "displayName": "Iron Golem",
     "width": 1.4,
     "height": 2.7,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 86,
@@ -843,7 +859,8 @@
     "displayName": "Vindicator",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 87,
@@ -852,7 +869,8 @@
     "displayName": "Pillager",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 88,
@@ -861,7 +879,8 @@
     "displayName": "Wandering Trader",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob"
+    "type": "mob",
+    "category": "Passive mobs"
   },
   {
     "id": 89,
@@ -950,7 +969,8 @@
     "displayName": "Phantom",
     "width": 0.9,
     "height": 0.5,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 98,
@@ -959,7 +979,8 @@
     "displayName": "Ravager",
     "width": 1.95,
     "height": 2.2,
-    "type": "mob"
+    "type": "mob",
+    "category": "Hostile mobs"
   },
   {
     "id": 99,

--- a/data/pc/1.14.4/entities.json
+++ b/data/pc/1.14.4/entities.json
@@ -7,7 +7,7 @@
     "width": 6,
     "height": 0.5,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Immobile"
   },
   {
     "id": 1,
@@ -17,7 +17,7 @@
     "width": 0.5,
     "height": 1.975,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Immobile"
   },
   {
     "id": 2,
@@ -27,7 +27,7 @@
     "width": 0.5,
     "height": 0.5,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 3,
@@ -37,7 +37,7 @@
     "width": 0.5,
     "height": 0.9,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 4,
@@ -57,7 +57,7 @@
     "width": 1.375,
     "height": 0.5625,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Vehicles"
   },
   {
     "id": 6,
@@ -66,8 +66,7 @@
     "displayName": "Cat",
     "width": 0.6,
     "height": 0.7,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 7,
@@ -87,7 +86,7 @@
     "width": 0.4,
     "height": 0.7,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 9,
@@ -96,8 +95,7 @@
     "displayName": "Cod",
     "width": 0.5,
     "height": 0.3,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 10,
@@ -107,7 +105,7 @@
     "width": 0.9,
     "height": 1.4,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 11,
@@ -127,7 +125,7 @@
     "width": 1.39648,
     "height": 1.5,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 13,
@@ -136,8 +134,7 @@
     "displayName": "Dolphin",
     "width": 0.9,
     "height": 0.6,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 14,
@@ -147,7 +144,7 @@
     "width": 1,
     "height": 1,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 15,
@@ -156,8 +153,7 @@
     "displayName": "Drowned",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 16,
@@ -176,8 +172,7 @@
     "displayName": "End Crystal",
     "width": 2,
     "height": 2,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 18,
@@ -216,8 +211,7 @@
     "displayName": "Evoker Fangs",
     "width": 0.5,
     "height": 0.8,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 22,
@@ -226,8 +220,7 @@
     "displayName": "Evoker",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 23,
@@ -236,8 +229,7 @@
     "displayName": "Experience Orb",
     "width": 0.5,
     "height": 0.5,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 24,
@@ -246,8 +238,7 @@
     "displayName": "Eye of Ender",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 25,
@@ -257,7 +248,7 @@
     "width": 0.98,
     "height": 0.98,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Blocks"
   },
   {
     "id": 26,
@@ -266,8 +257,7 @@
     "displayName": "Firework Rocket",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 27,
@@ -276,8 +266,7 @@
     "displayName": "Fox",
     "width": 0.6,
     "height": 0.7,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 28,
@@ -317,7 +306,7 @@
     "width": 1.39648,
     "height": 1.6,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 32,
@@ -336,8 +325,7 @@
     "displayName": "Illusioner",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 34,
@@ -347,7 +335,7 @@
     "width": 0.25,
     "height": 0.25,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Drops"
   },
   {
     "id": 35,
@@ -357,7 +345,7 @@
     "width": 0.5,
     "height": 0.5,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Immobile"
   },
   {
     "id": 36,
@@ -367,7 +355,7 @@
     "width": 1,
     "height": 1,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 37,
@@ -377,7 +365,7 @@
     "width": 0.5,
     "height": 0.5,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Immobile"
   },
   {
     "id": 38,
@@ -387,7 +375,7 @@
     "width": 0.9,
     "height": 1.87,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 39,
@@ -397,7 +385,7 @@
     "width": 0.25,
     "height": 0.25,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 40,
@@ -417,7 +405,7 @@
     "width": 0.98,
     "height": 0.7,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Vehicles"
   },
   {
     "id": 42,
@@ -427,7 +415,7 @@
     "width": 0.98,
     "height": 0.7,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Vehicles"
   },
   {
     "id": 43,
@@ -436,8 +424,7 @@
     "displayName": "Minecart with Command Block",
     "width": 0.98,
     "height": 0.7,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 44,
@@ -447,7 +434,7 @@
     "width": 0.98,
     "height": 0.7,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Vehicles"
   },
   {
     "id": 45,
@@ -457,7 +444,7 @@
     "width": 0.98,
     "height": 0.7,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Vehicles"
   },
   {
     "id": 46,
@@ -467,7 +454,7 @@
     "width": 0.98,
     "height": 0.7,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Vehicles"
   },
   {
     "id": 47,
@@ -477,7 +464,7 @@
     "width": 0.98,
     "height": 0.7,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Vehicles"
   },
   {
     "id": 48,
@@ -487,7 +474,7 @@
     "width": 1.39648,
     "height": 1.6,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 49,
@@ -497,7 +484,7 @@
     "width": 0.9,
     "height": 1.4,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 50,
@@ -507,7 +494,7 @@
     "width": 0.6,
     "height": 0.7,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 51,
@@ -517,7 +504,7 @@
     "width": 0.5,
     "height": 0.5,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Immobile"
   },
   {
     "id": 52,
@@ -526,8 +513,7 @@
     "displayName": "Panda",
     "width": 1.3,
     "height": 1.25,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 53,
@@ -537,7 +523,7 @@
     "width": 0.5,
     "height": 0.9,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 54,
@@ -547,7 +533,7 @@
     "width": 0.9,
     "height": 0.9,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 55,
@@ -556,8 +542,7 @@
     "displayName": "Pufferfish",
     "width": 0.7,
     "height": 0.7,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 56,
@@ -577,7 +562,7 @@
     "width": 1.4,
     "height": 1.4,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 58,
@@ -587,7 +572,7 @@
     "width": 0.98,
     "height": 0.98,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Blocks"
   },
   {
     "id": 59,
@@ -597,7 +582,7 @@
     "width": 0.4,
     "height": 0.5,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 60,
@@ -606,8 +591,7 @@
     "displayName": "Salmon",
     "width": 0.7,
     "height": 0.4,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 61,
@@ -617,7 +601,7 @@
     "width": 0.9,
     "height": 1.3,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 62,
@@ -637,7 +621,7 @@
     "width": 0.3125,
     "height": 0.3125,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 64,
@@ -667,7 +651,7 @@
     "width": 1.39648,
     "height": 1.6,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 67,
@@ -687,7 +671,7 @@
     "width": 0.3125,
     "height": 0.3125,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 69,
@@ -696,8 +680,7 @@
     "displayName": "Snow Golem",
     "width": 0.7,
     "height": 1.9,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 70,
@@ -707,7 +690,7 @@
     "width": 0.25,
     "height": 0.25,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 71,
@@ -717,7 +700,7 @@
     "width": 0.5,
     "height": 0.5,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 72,
@@ -737,7 +720,7 @@
     "width": 0.8,
     "height": 0.8,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 74,
@@ -756,8 +739,7 @@
     "displayName": "Trader Llama",
     "width": 0.9,
     "height": 1.87,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 76,
@@ -766,8 +748,7 @@
     "displayName": "Tropical Fish",
     "width": 0.5,
     "height": 0.4,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 77,
@@ -776,8 +757,7 @@
     "displayName": "Turtle",
     "width": 1.2,
     "height": 0.4,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 78,
@@ -787,7 +767,7 @@
     "width": 0.25,
     "height": 0.25,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 79,
@@ -797,7 +777,7 @@
     "width": 0.25,
     "height": 0.25,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 80,
@@ -806,8 +786,7 @@
     "displayName": "Thrown Bottle o' Enchanting",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 81,
@@ -817,7 +796,7 @@
     "width": 0.25,
     "height": 0.25,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 82,
@@ -826,8 +805,7 @@
     "displayName": "Trident",
     "width": 0.5,
     "height": 0.5,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 83,
@@ -847,7 +825,7 @@
     "width": 0.6,
     "height": 1.95,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 85,
@@ -856,8 +834,7 @@
     "displayName": "Iron Golem",
     "width": 1.4,
     "height": 2.7,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 86,
@@ -866,8 +843,7 @@
     "displayName": "Vindicator",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 87,
@@ -876,8 +852,7 @@
     "displayName": "Pillager",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 88,
@@ -886,8 +861,7 @@
     "displayName": "Wandering Trader",
     "width": 0.6,
     "height": 1.95,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 89,
@@ -927,7 +901,7 @@
     "width": 0.3125,
     "height": 0.3125,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Projectiles"
   },
   {
     "id": 93,
@@ -937,7 +911,7 @@
     "width": 0.6,
     "height": 0.85,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 94,
@@ -957,7 +931,7 @@
     "width": 1.39648,
     "height": 1.6,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Passive mobs"
   },
   {
     "id": 96,
@@ -976,8 +950,7 @@
     "displayName": "Phantom",
     "width": 0.9,
     "height": 0.5,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 98,
@@ -986,8 +959,7 @@
     "displayName": "Ravager",
     "width": 1.95,
     "height": 2.2,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 99,
@@ -996,8 +968,7 @@
     "displayName": "Lightning Bolt",
     "width": 0,
     "height": 0,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 100,
@@ -1006,8 +977,7 @@
     "displayName": "Player",
     "width": 0.6,
     "height": 1.8,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   },
   {
     "id": 101,
@@ -1016,7 +986,6 @@
     "displayName": "Fishing Bobber",
     "width": 0.25,
     "height": 0.25,
-    "type": "mob",
-    "category": "Hostile mobs"
+    "type": "mob"
   }
 ]


### PR DESCRIPTION
I copied the entity.category of the entities in 1.13 and also hardcoded some of them.

I used something similar to [this](https://github.com/ImHarvol/burger-extractor/commit/886501156c4b89efa28df63a5dd44c5989a18282) to copy them, which I might PR so it is done automatically.