### PR TITLE
Fix bounding boxes of various blocks

### DIFF
--- a/data/pc/1.10/blocks.json
+++ b/data/pc/1.10/blocks.json
@@ -2359,7 +2359,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 93
@@ -2376,7 +2376,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 94
@@ -3942,7 +3942,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 149
@@ -3959,7 +3959,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 150

--- a/data/pc/1.11/blocks.json
+++ b/data/pc/1.11/blocks.json
@@ -2299,7 +2299,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 356
@@ -2316,7 +2316,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 356
@@ -3821,7 +3821,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 404
@@ -3838,7 +3838,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 404

--- a/data/pc/1.12/blocks.json
+++ b/data/pc/1.12/blocks.json
@@ -2300,7 +2300,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 356
@@ -2317,7 +2317,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 356
@@ -3822,7 +3822,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 404
@@ -3839,7 +3839,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 404

--- a/data/pc/1.13.2/blocks.json
+++ b/data/pc/1.13.2/blocks.json
@@ -3528,9 +3528,9 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock",
+    "material": "plant",
     "harvestTools": {
       "473": true,
       "487": true,
@@ -3554,7 +3554,7 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 1,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
     "material": "plant"
   },
@@ -3573,7 +3573,7 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 1,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
     "material": "plant"
   },
@@ -5327,7 +5327,7 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64
   },
   {
@@ -6840,7 +6840,7 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
     "material": "plant"
   },
@@ -9214,7 +9214,7 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
     "material": "wood"
   },

--- a/data/pc/1.14.4/blocks.json
+++ b/data/pc/1.14.4/blocks.json
@@ -3335,16 +3335,9 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock",
-    "harvestTools": {
-      "521": true,
-      "535": true,
-      "539": true,
-      "543": true,
-      "550": true
-    }
+    "material": "plant"
   },
   {
     "id": 119,
@@ -3361,16 +3354,9 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock",
-    "harvestTools": {
-      "521": true,
-      "535": true,
-      "539": true,
-      "543": true,
-      "550": true
-    }
+    "material": "plant",
   },
   {
     "id": 120,
@@ -3406,16 +3392,9 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock",
-    "harvestTools": {
-      "521": true,
-      "535": true,
-      "539": true,
-      "543": true,
-      "550": true
-    }
+    "material": "plant"
   },
   {
     "id": 122,
@@ -3432,16 +3411,9 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock",
-    "harvestTools": {
-      "521": true,
-      "535": true,
-      "539": true,
-      "543": true,
-      "550": true
-    }
+    "material": "plant"
   },
   {
     "id": 123,
@@ -3534,16 +3506,9 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock",
-    "harvestTools": {
-      "521": true,
-      "535": true,
-      "539": true,
-      "543": true,
-      "550": true
-    }
+    "material": "plant"
   },
   {
     "id": 128,
@@ -3561,7 +3526,8 @@
     "stackSize": 64,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block"
+    "boundingBox": "empty",
+    "material": "plant"
   },
   {
     "id": 129,
@@ -3579,7 +3545,8 @@
     "stackSize": 64,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block"
+    "boundingBox": "empty",
+    "material": "plant"
   },
   {
     "id": 130,
@@ -3597,7 +3564,8 @@
     "stackSize": 64,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block"
+    "boundingBox": "empty",
+    "material": "plant"
   },
   {
     "id": 131,
@@ -3614,7 +3582,7 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 1,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
     "material": "plant"
   },
@@ -3633,7 +3601,7 @@
     "transparent": false,
     "filterLight": 15,
     "emitLight": 1,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64,
     "material": "plant"
   },
@@ -5717,7 +5685,7 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64
   },
   {
@@ -8410,7 +8378,8 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
+    "material": "plant",
     "stackSize": 64
   },
   {
@@ -9632,7 +9601,7 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64
   },
   {

--- a/data/pc/1.8/blocks.json
+++ b/data/pc/1.8/blocks.json
@@ -2436,7 +2436,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 93
@@ -2453,7 +2453,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 94
@@ -3953,7 +3953,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 149
@@ -3970,7 +3970,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 150

--- a/data/pc/1.9/blocks.json
+++ b/data/pc/1.9/blocks.json
@@ -2359,7 +2359,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 93
@@ -2376,7 +2376,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 94
@@ -3942,7 +3942,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 149
@@ -3959,7 +3959,7 @@
     "hardness": 0,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 150


### PR DESCRIPTION
In particular, the redstone comparators needs to be fixed otherwise they gets considered as solid blocks by redstone logic. It should also improves the pathfinding and physic of mineflayer.