### PR TITLE
Fixed functionality-breaking typo

### DIFF
--- a/data/pc/1.14.4/blocks.json
+++ b/data/pc/1.14.4/blocks.json
@@ -3356,7 +3356,7 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant",
+    "material": "plant"
   },
   {
     "id": 120,


### PR DESCRIPTION
This JSON is invalid and breaks the whole library.