### PR TITLE
Fix elytra handling, add optvarints

### DIFF
--- a/data/pc/1.14.1/protocol.json
+++ b/data/pc/1.14.1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "optvarint": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -228,7 +229,7 @@
               }
             ]
           ],
-          "17": ["option", "varint"],
+          "17": "optvarint",
           "18": "varint"
         }
       }

--- a/data/pc/1.14.1/protocol.json
+++ b/data/pc/1.14.1/protocol.json
@@ -1,7 +1,7 @@
 {
   "types": {
     "varint": "native",
-    "optvarint": "native",
+    "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
     "u8": "native",

--- a/data/pc/1.14.3/protocol.json
+++ b/data/pc/1.14.3/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "optvarint": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -228,7 +229,7 @@
               }
             ]
           ],
-          "17": ["option", "varint"],
+          "17": "optvarint",
           "18": "varint"
         }
       }

--- a/data/pc/1.14.3/protocol.json
+++ b/data/pc/1.14.3/protocol.json
@@ -1,7 +1,7 @@
 {
   "types": {
     "varint": "native",
-    "optvarint": "native",
+    "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
     "u8": "native",

--- a/data/pc/1.14.4/protocol.json
+++ b/data/pc/1.14.4/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "optvarint": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -228,7 +229,7 @@
               }
             ]
           ],
-          "17": ["option", "varint"],
+          "17": "optvarint",
           "18": "varint"
         }
       }

--- a/data/pc/1.14.4/protocol.json
+++ b/data/pc/1.14.4/protocol.json
@@ -1,7 +1,7 @@
 {
   "types": {
     "varint": "native",
-    "optvarint": "native",
+    "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
     "u8": "native",

--- a/data/pc/1.14/protocol.json
+++ b/data/pc/1.14/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "optvarint": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -228,7 +229,7 @@
               }
             ]
           ],
-          "17": ["option", "varint"],
+          "17": "optvarint",
           "18": "varint"
         }
       }

--- a/data/pc/1.14/protocol.json
+++ b/data/pc/1.14/protocol.json
@@ -1,7 +1,7 @@
 {
   "types": {
     "varint": "native",
-    "optvarint": "native",
+    "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
     "u8": "native",

--- a/data/pc/1.15.1/protocol.json
+++ b/data/pc/1.15.1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "optvarint": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -228,7 +229,7 @@
               }
             ]
           ],
-          "17": ["option", "varint"],
+          "17": "optvarint",
           "18": "varint"
         }
       }

--- a/data/pc/1.15.1/protocol.json
+++ b/data/pc/1.15.1/protocol.json
@@ -1,7 +1,7 @@
 {
   "types": {
     "varint": "native",
-    "optvarint": "native",
+    "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
     "u8": "native",

--- a/data/pc/1.15.2/protocol.json
+++ b/data/pc/1.15.2/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "optvarint": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -228,7 +229,7 @@
               }
             ]
           ],
-          "17": ["option", "varint"],
+          "17": "optvarint",
           "18": "varint"
         }
       }

--- a/data/pc/1.15.2/protocol.json
+++ b/data/pc/1.15.2/protocol.json
@@ -1,7 +1,7 @@
 {
   "types": {
     "varint": "native",
-    "optvarint": "native",
+    "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
     "u8": "native",

--- a/data/pc/1.15/protocol.json
+++ b/data/pc/1.15/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "optvarint": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -228,7 +229,7 @@
               }
             ]
           ],
-          "17": ["option", "varint"],
+          "17": "optvarint",
           "18": "varint"
         }
       }

--- a/data/pc/1.15/protocol.json
+++ b/data/pc/1.15/protocol.json
@@ -1,7 +1,7 @@
 {
   "types": {
     "varint": "native",
-    "optvarint": "native",
+    "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
     "u8": "native",

--- a/data/pc/20w13b/protocol.json
+++ b/data/pc/20w13b/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "optvarint": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -228,7 +229,7 @@
               }
             ]
           ],
-          "17": ["option", "varint"],
+          "17": "optvarint",
           "18": "varint"
         }
       }

--- a/data/pc/20w13b/protocol.json
+++ b/data/pc/20w13b/protocol.json
@@ -1,7 +1,7 @@
 {
   "types": {
     "varint": "native",
-    "optvarint": "native",
+    "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
     "u8": "native",


### PR DESCRIPTION
For some reason the OptVarint type of `entity_metadata` (type 17) was set to `["option", "varint"]` which is incorrect, I've also made a PR for `node-minecraft-protocol` to add support for the new optvarints. See [this bug](https://bugs.mojang.com/browse/MC-111480) for the reasoning behind this