### PR TITLE
Change ladder's bounding box to empty

### DIFF
--- a/data/pc/1.10/blocks.json
+++ b/data/pc/1.10/blocks.json
@@ -1727,7 +1727,7 @@
     "hardness": 0.4,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 65

--- a/data/pc/1.11/blocks.json
+++ b/data/pc/1.11/blocks.json
@@ -1701,7 +1701,7 @@
     "hardness": 0.4,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 65

--- a/data/pc/1.12/blocks.json
+++ b/data/pc/1.12/blocks.json
@@ -1701,7 +1701,7 @@
     "hardness": 0.4,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 65

--- a/data/pc/1.13.2/blocks.json
+++ b/data/pc/1.13.2/blocks.json
@@ -4308,7 +4308,7 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64
   },
   {

--- a/data/pc/1.13/blocks.json
+++ b/data/pc/1.13/blocks.json
@@ -4302,7 +4302,7 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64
   },
   {

--- a/data/pc/1.14.4/blocks.json
+++ b/data/pc/1.14.4/blocks.json
@@ -4486,7 +4486,7 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64
   },
   {

--- a/data/pc/1.15.2/blocks.json
+++ b/data/pc/1.15.2/blocks.json
@@ -4486,7 +4486,7 @@
     "transparent": true,
     "filterLight": 0,
     "emitLight": 0,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "stackSize": 64
   },
   {

--- a/data/pc/1.7/blocks.json
+++ b/data/pc/1.7/blocks.json
@@ -1492,7 +1492,7 @@
     "hardness": 0.4,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 65

--- a/data/pc/1.8/blocks.json
+++ b/data/pc/1.8/blocks.json
@@ -1800,7 +1800,7 @@
     "hardness": 0.4,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 65

--- a/data/pc/1.9/blocks.json
+++ b/data/pc/1.9/blocks.json
@@ -1727,7 +1727,7 @@
     "hardness": 0.4,
     "stackSize": 64,
     "diggable": true,
-    "boundingBox": "block",
+    "boundingBox": "empty",
     "drops": [
       {
         "drop": 65


### PR DESCRIPTION
Players can walk through blocks in which ladders are placed, so i dont think a "block" boundingBox is appropriate