### PR TITLE
Add missing block items

### DIFF
--- a/data/pc/1.10/items.json
+++ b/data/pc/1.10/items.json
@@ -1,5 +1,1193 @@
 [
   {
+    "id": 0,
+    "displayName": "Air",
+    "name": "air",
+    "stackSize": 64
+  },
+  {
+    "id": 1,
+    "displayName": "Stone",
+    "name": "stone",
+    "stackSize": 64
+  },
+  {
+    "id": 2,
+    "displayName": "Grass Block",
+    "name": "grass",
+    "stackSize": 64
+  },
+  {
+    "id": 3,
+    "displayName": "Dirt",
+    "name": "dirt",
+    "stackSize": 64
+  },
+  {
+    "id": 4,
+    "displayName": "Cobblestone",
+    "name": "cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 5,
+    "displayName": "Wood Planks",
+    "name": "planks",
+    "stackSize": 64
+  },
+  {
+    "id": 6,
+    "displayName": "Sapling",
+    "name": "sapling",
+    "stackSize": 64
+  },
+  {
+    "id": 7,
+    "displayName": "Bedrock",
+    "name": "bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 8,
+    "displayName": "Water",
+    "name": "flowing_water",
+    "stackSize": 64
+  },
+  {
+    "id": 9,
+    "displayName": "Stationary Water",
+    "name": "water",
+    "stackSize": 64
+  },
+  {
+    "id": 10,
+    "displayName": "Lava",
+    "name": "flowing_lava",
+    "stackSize": 64
+  },
+  {
+    "id": 11,
+    "displayName": "Stationary Lava",
+    "name": "lava",
+    "stackSize": 64
+  },
+  {
+    "id": 12,
+    "displayName": "Sand",
+    "name": "sand",
+    "stackSize": 64
+  },
+  {
+    "id": 13,
+    "displayName": "Gravel",
+    "name": "gravel",
+    "stackSize": 64
+  },
+  {
+    "id": 14,
+    "displayName": "Gold Ore",
+    "name": "gold_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 15,
+    "displayName": "Iron Ore",
+    "name": "iron_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 16,
+    "displayName": "Coal Ore",
+    "name": "coal_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 17,
+    "displayName": "Wood",
+    "name": "log",
+    "stackSize": 64
+  },
+  {
+    "id": 18,
+    "displayName": "Leaves",
+    "name": "leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 19,
+    "displayName": "Sponge",
+    "name": "sponge",
+    "stackSize": 64
+  },
+  {
+    "id": 20,
+    "displayName": "Glass",
+    "name": "glass",
+    "stackSize": 64
+  },
+  {
+    "id": 21,
+    "displayName": "Lapis Lazuli Ore",
+    "name": "lapis_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 22,
+    "displayName": "Lapis Lazuli Block",
+    "name": "lapis_block",
+    "stackSize": 64
+  },
+  {
+    "id": 23,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 24,
+    "displayName": "Sandstone",
+    "name": "sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 25,
+    "displayName": "Note Block",
+    "name": "noteblock",
+    "stackSize": 64
+  },
+  {
+    "id": 27,
+    "displayName": "Powered Rail",
+    "name": "golden_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 28,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 29,
+    "displayName": "Sticky Piston",
+    "name": "sticky_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 30,
+    "displayName": "Cobweb",
+    "name": "web",
+    "stackSize": 64
+  },
+  {
+    "id": 31,
+    "displayName": "Grass",
+    "name": "tallgrass",
+    "stackSize": 64
+  },
+  {
+    "id": 32,
+    "displayName": "Dead Bush",
+    "name": "deadbush",
+    "stackSize": 64
+  },
+  {
+    "id": 33,
+    "displayName": "Piston",
+    "name": "piston",
+    "stackSize": 64
+  },
+  {
+    "id": 34,
+    "displayName": "Piston Head",
+    "name": "piston_head",
+    "stackSize": 64
+  },
+  {
+    "id": 35,
+    "displayName": "Wool",
+    "name": "wool",
+    "stackSize": 64
+  },
+  {
+    "id": 36,
+    "displayName": "Block moved by Piston",
+    "name": "piston_extension",
+    "stackSize": 64
+  },
+  {
+    "id": 37,
+    "displayName": "Dandelion",
+    "name": "yellow_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 38,
+    "displayName": "Poppy",
+    "name": "red_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 39,
+    "displayName": "Brown Mushroom",
+    "name": "brown_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 40,
+    "displayName": "Red Mushroom",
+    "name": "red_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 41,
+    "displayName": "Block of Gold",
+    "name": "gold_block",
+    "stackSize": 64
+  },
+  {
+    "id": 42,
+    "displayName": "Block of Iron",
+    "name": "iron_block",
+    "stackSize": 64
+  },
+  {
+    "id": 43,
+    "displayName": "Double Stone Slab",
+    "name": "double_stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 44,
+    "displayName": "Stone Slab",
+    "name": "stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 45,
+    "displayName": "Bricks",
+    "name": "brick_block",
+    "stackSize": 64
+  },
+  {
+    "id": 46,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 47,
+    "displayName": "Bookshelf",
+    "name": "bookshelf",
+    "stackSize": 64
+  },
+  {
+    "id": 48,
+    "displayName": "Moss Stone",
+    "name": "mossy_cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 49,
+    "displayName": "Obsidian",
+    "name": "obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 50,
+    "displayName": "Torch",
+    "name": "torch",
+    "stackSize": 64
+  },
+  {
+    "id": 51,
+    "displayName": "Fire",
+    "name": "fire",
+    "stackSize": 64
+  },
+  {
+    "id": 52,
+    "displayName": "Monster Spawner",
+    "name": "mob_spawner",
+    "stackSize": 64
+  },
+  {
+    "id": 53,
+    "displayName": "Oak Wood Stairs",
+    "name": "oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 54,
+    "displayName": "Chest",
+    "name": "chest",
+    "stackSize": 64
+  },
+  {
+    "id": 55,
+    "displayName": "Redstone Wire",
+    "name": "redstone_wire",
+    "stackSize": 64
+  },
+  {
+    "id": 56,
+    "displayName": "Diamond Ore",
+    "name": "diamond_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 57,
+    "displayName": "Block of Diamond",
+    "name": "diamond_block",
+    "stackSize": 64
+  },
+  {
+    "id": 58,
+    "displayName": "Crafting Table",
+    "name": "crafting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 60,
+    "displayName": "Farmland",
+    "name": "farmland",
+    "stackSize": 64
+  },
+  {
+    "id": 61,
+    "displayName": "Furnace",
+    "name": "furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 62,
+    "displayName": "Burning Furnace",
+    "name": "lit_furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 63,
+    "displayName": "Standing Sign",
+    "name": "standing_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 65,
+    "displayName": "Ladder",
+    "name": "ladder",
+    "stackSize": 64
+  },
+  {
+    "id": 66,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 67,
+    "displayName": "Cobblestone Stairs",
+    "name": "stone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 68,
+    "displayName": "Wall Sign",
+    "name": "wall_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 69,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 70,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 72,
+    "displayName": "Wooden Pressure Plate",
+    "name": "wooden_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 73,
+    "displayName": "Redstone Ore",
+    "name": "redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 74,
+    "displayName": "Glowing Redstone Ore",
+    "name": "lit_redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 75,
+    "displayName": "Redstone Torch (inactive)",
+    "name": "unlit_redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 76,
+    "displayName": "Redstone Torch (active)",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 77,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 78,
+    "displayName": "Snow (layer)",
+    "name": "snow_layer",
+    "stackSize": 64
+  },
+  {
+    "id": 79,
+    "displayName": "Ice",
+    "name": "ice",
+    "stackSize": 64
+  },
+  {
+    "id": 80,
+    "displayName": "Snow",
+    "name": "snow",
+    "stackSize": 64
+  },
+  {
+    "id": 81,
+    "displayName": "Cactus",
+    "name": "cactus",
+    "stackSize": 64
+  },
+  {
+    "id": 82,
+    "displayName": "Clay",
+    "name": "clay",
+    "stackSize": 64
+  },
+  {
+    "id": 84,
+    "displayName": "Jukebox",
+    "name": "jukebox",
+    "stackSize": 64
+  },
+  {
+    "id": 85,
+    "displayName": "Fence",
+    "name": "fence",
+    "stackSize": 64
+  },
+  {
+    "id": 86,
+    "displayName": "Pumpkin",
+    "name": "pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 87,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 88,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 89,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 90,
+    "displayName": "Nether Portal",
+    "name": "portal",
+    "stackSize": 64
+  },
+  {
+    "id": 91,
+    "displayName": "Jack o'Lantern",
+    "name": "lit_pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 93,
+    "displayName": "Redstone Repeater (inactive)",
+    "name": "unpowered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 94,
+    "displayName": "Redstone Repeater (active)",
+    "name": "powered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 95,
+    "displayName": "Stained Glass",
+    "name": "stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 96,
+    "displayName": "Trapdoor",
+    "name": "trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 97,
+    "displayName": "Monster Egg",
+    "name": "monster_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 98,
+    "displayName": "Stone Bricks",
+    "name": "stonebrick",
+    "stackSize": 64
+  },
+  {
+    "id": 99,
+    "displayName": "Brown Mushroom (block)",
+    "name": "brown_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 100,
+    "displayName": "Red Mushroom (block)",
+    "name": "red_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 101,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 102,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 103,
+    "displayName": "Melon",
+    "name": "melon_block",
+    "stackSize": 64
+  },
+  {
+    "id": 104,
+    "displayName": "Pumpkin Stem",
+    "name": "pumpkin_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 105,
+    "displayName": "Melon Stem",
+    "name": "melon_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 106,
+    "displayName": "Vines",
+    "name": "vine",
+    "stackSize": 64
+  },
+  {
+    "id": 107,
+    "displayName": "Fence Gate",
+    "name": "fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 108,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 109,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 110,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 111,
+    "displayName": "Lily Pad",
+    "name": "waterlily",
+    "stackSize": 64
+  },
+  {
+    "id": 112,
+    "displayName": "Nether Brick",
+    "name": "nether_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 113,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 114,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 116,
+    "displayName": "Enchantment Table",
+    "name": "enchanting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 119,
+    "displayName": "End Portal",
+    "name": "end_portal",
+    "stackSize": 64
+  },
+  {
+    "id": 120,
+    "displayName": "End Portal Frame",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 121,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 122,
+    "displayName": "Dragon Egg",
+    "name": "dragon_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 123,
+    "displayName": "Redstone Lamp (inactive)",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 124,
+    "displayName": "Redstone Lamp (active)",
+    "name": "lit_redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 125,
+    "displayName": "Double Wooden Slab",
+    "name": "double_wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 126,
+    "displayName": "Wooden Slab",
+    "name": "wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 127,
+    "displayName": "Cocoa",
+    "name": "cocoa",
+    "stackSize": 64
+  },
+  {
+    "id": 128,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 129,
+    "displayName": "Emerald Ore",
+    "name": "emerald_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 130,
+    "displayName": "Ender Chest",
+    "name": "ender_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 131,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 132,
+    "displayName": "Tripwire",
+    "name": "tripwire",
+    "stackSize": 64
+  },
+  {
+    "id": 133,
+    "displayName": "Block of Emerald",
+    "name": "emerald_block",
+    "stackSize": 64
+  },
+  {
+    "id": 134,
+    "displayName": "Spruce Wood Stairs",
+    "name": "spruce_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 135,
+    "displayName": "Birch Wood Stairs",
+    "name": "birch_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 136,
+    "displayName": "Jungle Wood Stairs",
+    "name": "jungle_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 137,
+    "displayName": "Command Block",
+    "name": "command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 138,
+    "displayName": "Beacon",
+    "name": "beacon",
+    "stackSize": 64
+  },
+  {
+    "id": 139,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 141,
+    "displayName": "Carrot",
+    "name": "carrots",
+    "stackSize": 64
+  },
+  {
+    "id": 142,
+    "displayName": "Potato",
+    "name": "potatoes",
+    "stackSize": 64
+  },
+  {
+    "id": 143,
+    "displayName": "Wooden Button",
+    "name": "wooden_button",
+    "stackSize": 64
+  },
+  {
+    "id": 145,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 146,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 147,
+    "displayName": "Weighted Pressure Plate (Light)",
+    "name": "light_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 148,
+    "displayName": "Weighted Pressure Plate (Heavy)",
+    "name": "heavy_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 149,
+    "displayName": "Redstone Comparator",
+    "name": "unpowered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 150,
+    "displayName": "Redstone Comparator (deprecated)",
+    "name": "powered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 151,
+    "displayName": "Daylight Sensor",
+    "name": "daylight_detector",
+    "stackSize": 64
+  },
+  {
+    "id": 152,
+    "displayName": "Block of Redstone",
+    "name": "redstone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 153,
+    "displayName": "Nether Quartz Ore",
+    "name": "quartz_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 154,
+    "displayName": "Hopper",
+    "name": "hopper",
+    "stackSize": 64
+  },
+  {
+    "id": 155,
+    "displayName": "Block of Quartz",
+    "name": "quartz_block",
+    "stackSize": 64
+  },
+  {
+    "id": 156,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 157,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 158,
+    "displayName": "Dropper",
+    "name": "dropper",
+    "stackSize": 64
+  },
+  {
+    "id": 159,
+    "displayName": "Stained Clay",
+    "name": "stained_hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 160,
+    "displayName": "Stained Glass Pane",
+    "name": "stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 161,
+    "displayName": "Leaves (Acacia/Dark Oak)",
+    "name": "leaves2",
+    "stackSize": 64
+  },
+  {
+    "id": 162,
+    "displayName": "Wood (Acacia/Dark Oak)",
+    "name": "log2",
+    "stackSize": 64
+  },
+  {
+    "id": 163,
+    "displayName": "Acacia Wood Stairs",
+    "name": "acacia_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 164,
+    "displayName": "Dark Oak Wood Stairs",
+    "name": "dark_oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 165,
+    "displayName": "Slime Block",
+    "name": "slime",
+    "stackSize": 64
+  },
+  {
+    "id": 166,
+    "displayName": "Barrier",
+    "name": "barrier",
+    "stackSize": 64
+  },
+  {
+    "id": 167,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 168,
+    "displayName": "Prismarine",
+    "name": "prismarine",
+    "stackSize": 64
+  },
+  {
+    "id": 169,
+    "displayName": "Sea Lantern",
+    "name": "sea_lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 170,
+    "displayName": "Hay Bale",
+    "name": "hay_block",
+    "stackSize": 64
+  },
+  {
+    "id": 171,
+    "displayName": "Carpet",
+    "name": "carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 172,
+    "displayName": "Hardened Clay",
+    "name": "hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 173,
+    "displayName": "Block of Coal",
+    "name": "coal_block",
+    "stackSize": 64
+  },
+  {
+    "id": 174,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 175,
+    "displayName": "Large Flowers",
+    "name": "double_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 176,
+    "displayName": "Standing Banner",
+    "name": "standing_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 177,
+    "displayName": "Wall Banner",
+    "name": "wall_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 178,
+    "displayName": "Inverted Daylight Sensor",
+    "name": "daylight_detector_inverted",
+    "stackSize": 64
+  },
+  {
+    "id": 179,
+    "displayName": "Red Sandstone",
+    "name": "red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 180,
+    "displayName": "Red Sandstone Stairs",
+    "name": "red_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 181,
+    "displayName": "Double Red Sandstone Slab",
+    "name": "double_stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 182,
+    "displayName": "Red Sandstone Slab",
+    "name": "stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 183,
+    "displayName": "Spruce Fence Gate",
+    "name": "spruce_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 184,
+    "displayName": "Birch Fence Gate",
+    "name": "birch_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 185,
+    "displayName": "Jungle Fence Gate",
+    "name": "jungle_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 186,
+    "displayName": "Dark Oak Fence Gate",
+    "name": "dark_oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 187,
+    "displayName": "Acacia Fence Gate",
+    "name": "acacia_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 188,
+    "displayName": "Spruce Fence",
+    "name": "spruce_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 189,
+    "displayName": "Birch Fence",
+    "name": "birch_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 190,
+    "displayName": "Jungle Fence",
+    "name": "jungle_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 191,
+    "displayName": "Dark Oak Fence",
+    "name": "dark_oak_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 192,
+    "displayName": "Acacia Fence",
+    "name": "acacia_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 198,
+    "displayName": "End Rod",
+    "name": "end_rod",
+    "stackSize": 64
+  },
+  {
+    "id": 199,
+    "displayName": "Chorus Plant",
+    "name": "chorus_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 200,
+    "displayName": "Chorus Flower",
+    "name": "chorus_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 201,
+    "displayName": "Purpur Block",
+    "name": "purpur_block",
+    "stackSize": 64
+  },
+  {
+    "id": 202,
+    "displayName": "Purpur Pillar",
+    "name": "purpur_pillar",
+    "stackSize": 64
+  },
+  {
+    "id": 203,
+    "displayName": "Purpur Stairs",
+    "name": "purpur_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 204,
+    "displayName": "Purpur Double Slab",
+    "name": "purpur_double_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 205,
+    "displayName": "Purpur Slab",
+    "name": "purpur_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 206,
+    "displayName": "End Stone Bricks",
+    "name": "end_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 207,
+    "displayName": "Beetroot Seeds",
+    "name": "beetroots",
+    "stackSize": 64
+  },
+  {
+    "id": 208,
+    "displayName": "Grass Path",
+    "name": "grass_path",
+    "stackSize": 64
+  },
+  {
+    "id": 209,
+    "displayName": "End Gateway",
+    "name": "end_gateway",
+    "stackSize": 64
+  },
+  {
+    "id": 210,
+    "displayName": "Repeating Command Block",
+    "name": "repeating_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 211,
+    "displayName": "Chain Command Block",
+    "name": "chain_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 212,
+    "displayName": "Frosted Ice",
+    "name": "frosted_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 255,
+    "displayName": "Structure Block",
+    "name": "structure_block",
+    "stackSize": 64
+  },
+  {
     "id": 256,
     "displayName": "Iron Shovel",
     "stackSize": 1,

--- a/data/pc/1.11/items.json
+++ b/data/pc/1.11/items.json
@@ -1,5 +1,1325 @@
 [
   {
+    "id": 0,
+    "displayName": "Air",
+    "name": "air",
+    "stackSize": 64
+  },
+  {
+    "id": 1,
+    "displayName": "Stone",
+    "name": "stone",
+    "stackSize": 64
+  },
+  {
+    "id": 2,
+    "displayName": "Grass Block",
+    "name": "grass",
+    "stackSize": 64
+  },
+  {
+    "id": 3,
+    "displayName": "Dirt",
+    "name": "dirt",
+    "stackSize": 64
+  },
+  {
+    "id": 4,
+    "displayName": "Cobblestone",
+    "name": "cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 5,
+    "displayName": "Wood Planks",
+    "name": "planks",
+    "stackSize": 64
+  },
+  {
+    "id": 6,
+    "displayName": "Sapling",
+    "name": "sapling",
+    "stackSize": 64
+  },
+  {
+    "id": 7,
+    "displayName": "Bedrock",
+    "name": "bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 8,
+    "displayName": "Water",
+    "name": "flowing_water",
+    "stackSize": 64
+  },
+  {
+    "id": 9,
+    "displayName": "Stationary Water",
+    "name": "water",
+    "stackSize": 64
+  },
+  {
+    "id": 10,
+    "displayName": "Lava",
+    "name": "flowing_lava",
+    "stackSize": 64
+  },
+  {
+    "id": 11,
+    "displayName": "Stationary Lava",
+    "name": "lava",
+    "stackSize": 64
+  },
+  {
+    "id": 12,
+    "displayName": "Sand",
+    "name": "sand",
+    "stackSize": 64
+  },
+  {
+    "id": 13,
+    "displayName": "Gravel",
+    "name": "gravel",
+    "stackSize": 64
+  },
+  {
+    "id": 14,
+    "displayName": "Gold Ore",
+    "name": "gold_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 15,
+    "displayName": "Iron Ore",
+    "name": "iron_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 16,
+    "displayName": "Coal Ore",
+    "name": "coal_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 17,
+    "displayName": "Wood",
+    "name": "log",
+    "stackSize": 64
+  },
+  {
+    "id": 18,
+    "displayName": "Leaves",
+    "name": "leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 19,
+    "displayName": "Sponge",
+    "name": "sponge",
+    "stackSize": 64
+  },
+  {
+    "id": 20,
+    "displayName": "Glass",
+    "name": "glass",
+    "stackSize": 64
+  },
+  {
+    "id": 21,
+    "displayName": "Lapis Lazuli Ore",
+    "name": "lapis_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 22,
+    "displayName": "Lapis Lazuli Block",
+    "name": "lapis_block",
+    "stackSize": 64
+  },
+  {
+    "id": 23,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 24,
+    "displayName": "Sandstone",
+    "name": "sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 25,
+    "displayName": "Note Block",
+    "name": "noteblock",
+    "stackSize": 64
+  },
+  {
+    "id": 27,
+    "displayName": "Powered Rail",
+    "name": "golden_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 28,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 29,
+    "displayName": "Sticky Piston",
+    "name": "sticky_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 30,
+    "displayName": "Cobweb",
+    "name": "web",
+    "stackSize": 64
+  },
+  {
+    "id": 31,
+    "displayName": "Grass",
+    "name": "tallgrass",
+    "stackSize": 64
+  },
+  {
+    "id": 32,
+    "displayName": "Dead Bush",
+    "name": "deadbush",
+    "stackSize": 64
+  },
+  {
+    "id": 33,
+    "displayName": "Piston",
+    "name": "piston",
+    "stackSize": 64
+  },
+  {
+    "id": 34,
+    "displayName": "Piston Head",
+    "name": "piston_head",
+    "stackSize": 64
+  },
+  {
+    "id": 35,
+    "displayName": "Wool",
+    "name": "wool",
+    "stackSize": 64
+  },
+  {
+    "id": 36,
+    "displayName": "Block moved by Piston",
+    "name": "piston_extension",
+    "stackSize": 64
+  },
+  {
+    "id": 37,
+    "displayName": "Dandelion",
+    "name": "yellow_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 38,
+    "displayName": "Poppy",
+    "name": "red_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 39,
+    "displayName": "Brown Mushroom",
+    "name": "brown_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 40,
+    "displayName": "Red Mushroom",
+    "name": "red_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 41,
+    "displayName": "Block of Gold",
+    "name": "gold_block",
+    "stackSize": 64
+  },
+  {
+    "id": 42,
+    "displayName": "Block of Iron",
+    "name": "iron_block",
+    "stackSize": 64
+  },
+  {
+    "id": 43,
+    "displayName": "Double Stone Slab",
+    "name": "double_stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 44,
+    "displayName": "Stone Slab",
+    "name": "stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 45,
+    "displayName": "Bricks",
+    "name": "brick_block",
+    "stackSize": 64
+  },
+  {
+    "id": 46,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 47,
+    "displayName": "Bookshelf",
+    "name": "bookshelf",
+    "stackSize": 64
+  },
+  {
+    "id": 48,
+    "displayName": "Moss Stone",
+    "name": "mossy_cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 49,
+    "displayName": "Obsidian",
+    "name": "obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 50,
+    "displayName": "Torch",
+    "name": "torch",
+    "stackSize": 64
+  },
+  {
+    "id": 51,
+    "displayName": "Fire",
+    "name": "fire",
+    "stackSize": 64
+  },
+  {
+    "id": 52,
+    "displayName": "Monster Spawner",
+    "name": "mob_spawner",
+    "stackSize": 64
+  },
+  {
+    "id": 53,
+    "displayName": "Oak Wood Stairs",
+    "name": "oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 54,
+    "displayName": "Chest",
+    "name": "chest",
+    "stackSize": 64
+  },
+  {
+    "id": 55,
+    "displayName": "Redstone Wire",
+    "name": "redstone_wire",
+    "stackSize": 64
+  },
+  {
+    "id": 56,
+    "displayName": "Diamond Ore",
+    "name": "diamond_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 57,
+    "displayName": "Block of Diamond",
+    "name": "diamond_block",
+    "stackSize": 64
+  },
+  {
+    "id": 58,
+    "displayName": "Crafting Table",
+    "name": "crafting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 60,
+    "displayName": "Farmland",
+    "name": "farmland",
+    "stackSize": 64
+  },
+  {
+    "id": 61,
+    "displayName": "Furnace",
+    "name": "furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 62,
+    "displayName": "Burning Furnace",
+    "name": "lit_furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 63,
+    "displayName": "Standing Sign",
+    "name": "standing_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 65,
+    "displayName": "Ladder",
+    "name": "ladder",
+    "stackSize": 64
+  },
+  {
+    "id": 66,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 67,
+    "displayName": "Cobblestone Stairs",
+    "name": "stone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 68,
+    "displayName": "Wall Sign",
+    "name": "wall_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 69,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 70,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 72,
+    "displayName": "Wooden Pressure Plate",
+    "name": "wooden_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 73,
+    "displayName": "Redstone Ore",
+    "name": "redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 74,
+    "displayName": "Glowing Redstone Ore",
+    "name": "lit_redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 75,
+    "displayName": "Redstone Torch (inactive)",
+    "name": "unlit_redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 76,
+    "displayName": "Redstone Torch (active)",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 77,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 78,
+    "displayName": "Snow (layer)",
+    "name": "snow_layer",
+    "stackSize": 64
+  },
+  {
+    "id": 79,
+    "displayName": "Ice",
+    "name": "ice",
+    "stackSize": 64
+  },
+  {
+    "id": 80,
+    "displayName": "Snow",
+    "name": "snow",
+    "stackSize": 64
+  },
+  {
+    "id": 81,
+    "displayName": "Cactus",
+    "name": "cactus",
+    "stackSize": 64
+  },
+  {
+    "id": 82,
+    "displayName": "Clay",
+    "name": "clay",
+    "stackSize": 64
+  },
+  {
+    "id": 84,
+    "displayName": "Jukebox",
+    "name": "jukebox",
+    "stackSize": 64
+  },
+  {
+    "id": 85,
+    "displayName": "Fence",
+    "name": "fence",
+    "stackSize": 64
+  },
+  {
+    "id": 86,
+    "displayName": "Pumpkin",
+    "name": "pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 87,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 88,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 89,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 90,
+    "displayName": "Nether Portal",
+    "name": "portal",
+    "stackSize": 64
+  },
+  {
+    "id": 91,
+    "displayName": "Jack o'Lantern",
+    "name": "lit_pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 93,
+    "displayName": "Redstone Repeater (inactive)",
+    "name": "unpowered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 94,
+    "displayName": "Redstone Repeater (active)",
+    "name": "powered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 95,
+    "displayName": "Stained Glass",
+    "name": "stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 96,
+    "displayName": "Trapdoor",
+    "name": "trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 97,
+    "displayName": "Monster Egg",
+    "name": "monster_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 98,
+    "displayName": "Stone Bricks",
+    "name": "stonebrick",
+    "stackSize": 64
+  },
+  {
+    "id": 99,
+    "displayName": "Brown Mushroom (block)",
+    "name": "brown_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 100,
+    "displayName": "Red Mushroom (block)",
+    "name": "red_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 101,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 102,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 103,
+    "displayName": "Melon",
+    "name": "melon_block",
+    "stackSize": 64
+  },
+  {
+    "id": 104,
+    "displayName": "Pumpkin Stem",
+    "name": "pumpkin_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 105,
+    "displayName": "Melon Stem",
+    "name": "melon_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 106,
+    "displayName": "Vines",
+    "name": "vine",
+    "stackSize": 64
+  },
+  {
+    "id": 107,
+    "displayName": "Fence Gate",
+    "name": "fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 108,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 109,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 110,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 111,
+    "displayName": "Lily Pad",
+    "name": "waterlily",
+    "stackSize": 64
+  },
+  {
+    "id": 112,
+    "displayName": "Nether Brick",
+    "name": "nether_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 113,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 114,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 116,
+    "displayName": "Enchantment Table",
+    "name": "enchanting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 119,
+    "displayName": "End Portal",
+    "name": "end_portal",
+    "stackSize": 64
+  },
+  {
+    "id": 120,
+    "displayName": "End Portal Frame",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 121,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 122,
+    "displayName": "Dragon Egg",
+    "name": "dragon_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 123,
+    "displayName": "Redstone Lamp (inactive)",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 124,
+    "displayName": "Redstone Lamp (active)",
+    "name": "lit_redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 125,
+    "displayName": "Double Wooden Slab",
+    "name": "double_wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 126,
+    "displayName": "Wooden Slab",
+    "name": "wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 127,
+    "displayName": "Cocoa",
+    "name": "cocoa",
+    "stackSize": 64
+  },
+  {
+    "id": 128,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 129,
+    "displayName": "Emerald Ore",
+    "name": "emerald_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 130,
+    "displayName": "Ender Chest",
+    "name": "ender_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 131,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 132,
+    "displayName": "Tripwire",
+    "name": "tripwire",
+    "stackSize": 64
+  },
+  {
+    "id": 133,
+    "displayName": "Block of Emerald",
+    "name": "emerald_block",
+    "stackSize": 64
+  },
+  {
+    "id": 134,
+    "displayName": "Spruce Wood Stairs",
+    "name": "spruce_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 135,
+    "displayName": "Birch Wood Stairs",
+    "name": "birch_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 136,
+    "displayName": "Jungle Wood Stairs",
+    "name": "jungle_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 137,
+    "displayName": "Command Block",
+    "name": "command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 138,
+    "displayName": "Beacon",
+    "name": "beacon",
+    "stackSize": 64
+  },
+  {
+    "id": 139,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 141,
+    "displayName": "Carrot",
+    "name": "carrots",
+    "stackSize": 64
+  },
+  {
+    "id": 142,
+    "displayName": "Potato",
+    "name": "potatoes",
+    "stackSize": 64
+  },
+  {
+    "id": 143,
+    "displayName": "Wooden Button",
+    "name": "wooden_button",
+    "stackSize": 64
+  },
+  {
+    "id": 145,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 146,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 147,
+    "displayName": "Weighted Pressure Plate (Light)",
+    "name": "light_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 148,
+    "displayName": "Weighted Pressure Plate (Heavy)",
+    "name": "heavy_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 149,
+    "displayName": "Redstone Comparator",
+    "name": "unpowered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 150,
+    "displayName": "Redstone Comparator (deprecated)",
+    "name": "powered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 151,
+    "displayName": "Daylight Sensor",
+    "name": "daylight_detector",
+    "stackSize": 64
+  },
+  {
+    "id": 152,
+    "displayName": "Block of Redstone",
+    "name": "redstone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 153,
+    "displayName": "Nether Quartz Ore",
+    "name": "quartz_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 154,
+    "displayName": "Hopper",
+    "name": "hopper",
+    "stackSize": 64
+  },
+  {
+    "id": 155,
+    "displayName": "Block of Quartz",
+    "name": "quartz_block",
+    "stackSize": 64
+  },
+  {
+    "id": 156,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 157,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 158,
+    "displayName": "Dropper",
+    "name": "dropper",
+    "stackSize": 64
+  },
+  {
+    "id": 159,
+    "displayName": "Stained Clay",
+    "name": "stained_hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 160,
+    "displayName": "Stained Glass Pane",
+    "name": "stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 161,
+    "displayName": "Leaves (Acacia/Dark Oak)",
+    "name": "leaves2",
+    "stackSize": 64
+  },
+  {
+    "id": 162,
+    "displayName": "Wood (Acacia/Dark Oak)",
+    "name": "log2",
+    "stackSize": 64
+  },
+  {
+    "id": 163,
+    "displayName": "Acacia Wood Stairs",
+    "name": "acacia_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 164,
+    "displayName": "Dark Oak Wood Stairs",
+    "name": "dark_oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 165,
+    "displayName": "Slime Block",
+    "name": "slime",
+    "stackSize": 64
+  },
+  {
+    "id": 166,
+    "displayName": "Barrier",
+    "name": "barrier",
+    "stackSize": 64
+  },
+  {
+    "id": 167,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 168,
+    "displayName": "Prismarine",
+    "name": "prismarine",
+    "stackSize": 64
+  },
+  {
+    "id": 169,
+    "displayName": "Sea Lantern",
+    "name": "sea_lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 170,
+    "displayName": "Hay Bale",
+    "name": "hay_block",
+    "stackSize": 64
+  },
+  {
+    "id": 171,
+    "displayName": "Carpet",
+    "name": "carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 172,
+    "displayName": "Hardened Clay",
+    "name": "hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 173,
+    "displayName": "Block of Coal",
+    "name": "coal_block",
+    "stackSize": 64
+  },
+  {
+    "id": 174,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 175,
+    "displayName": "Large Flowers",
+    "name": "double_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 176,
+    "displayName": "Standing Banner",
+    "name": "standing_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 177,
+    "displayName": "Wall Banner",
+    "name": "wall_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 178,
+    "displayName": "Inverted Daylight Sensor",
+    "name": "daylight_detector_inverted",
+    "stackSize": 64
+  },
+  {
+    "id": 179,
+    "displayName": "Red Sandstone",
+    "name": "red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 180,
+    "displayName": "Red Sandstone Stairs",
+    "name": "red_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 181,
+    "displayName": "Double Red Sandstone Slab",
+    "name": "double_stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 182,
+    "displayName": "Red Sandstone Slab",
+    "name": "stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 183,
+    "displayName": "Spruce Fence Gate",
+    "name": "spruce_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 184,
+    "displayName": "Birch Fence Gate",
+    "name": "birch_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 185,
+    "displayName": "Jungle Fence Gate",
+    "name": "jungle_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 186,
+    "displayName": "Dark Oak Fence Gate",
+    "name": "dark_oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 187,
+    "displayName": "Acacia Fence Gate",
+    "name": "acacia_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 188,
+    "displayName": "Spruce Fence",
+    "name": "spruce_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 189,
+    "displayName": "Birch Fence",
+    "name": "birch_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 190,
+    "displayName": "Jungle Fence",
+    "name": "jungle_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 191,
+    "displayName": "Dark Oak Fence",
+    "name": "dark_oak_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 192,
+    "displayName": "Acacia Fence",
+    "name": "acacia_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 198,
+    "displayName": "End Rod",
+    "name": "end_rod",
+    "stackSize": 64
+  },
+  {
+    "id": 199,
+    "displayName": "Chorus Plant",
+    "name": "chorus_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 200,
+    "displayName": "Chorus Flower",
+    "name": "chorus_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 201,
+    "displayName": "Purpur Block",
+    "name": "purpur_block",
+    "stackSize": 64
+  },
+  {
+    "id": 202,
+    "displayName": "Purpur Pillar",
+    "name": "purpur_pillar",
+    "stackSize": 64
+  },
+  {
+    "id": 203,
+    "displayName": "Purpur Stairs",
+    "name": "purpur_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 204,
+    "displayName": "Purpur Double Slab",
+    "name": "purpur_double_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 205,
+    "displayName": "Purpur Slab",
+    "name": "purpur_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 206,
+    "displayName": "End Stone Bricks",
+    "name": "end_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 207,
+    "displayName": "Beetroot Seeds",
+    "name": "beetroots",
+    "stackSize": 64
+  },
+  {
+    "id": 208,
+    "displayName": "Grass Path",
+    "name": "grass_path",
+    "stackSize": 64
+  },
+  {
+    "id": 209,
+    "displayName": "End Gateway",
+    "name": "end_gateway",
+    "stackSize": 64
+  },
+  {
+    "id": 210,
+    "displayName": "Repeating Command Block",
+    "name": "repeating_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 211,
+    "displayName": "Chain Command Block",
+    "name": "chain_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 212,
+    "displayName": "Frosted Ice",
+    "name": "frosted_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 213,
+    "displayName": "Magma Block",
+    "name": "magma",
+    "stackSize": 64
+  },
+  {
+    "id": 214,
+    "displayName": "Nether Wart Block",
+    "name": "nether_wart_block",
+    "stackSize": 64
+  },
+  {
+    "id": 215,
+    "displayName": "Red Nether Brick",
+    "name": "red_nether_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 216,
+    "displayName": "Bone Block",
+    "name": "bone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 217,
+    "displayName": "Structure Void",
+    "name": "structure_void",
+    "stackSize": 64
+  },
+  {
+    "id": 218,
+    "displayName": "Observer",
+    "name": "observer",
+    "stackSize": 64
+  },
+  {
+    "id": 219,
+    "displayName": "White Shulker Box",
+    "name": "white_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 220,
+    "displayName": "Orange Shulker Box",
+    "name": "orange_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 221,
+    "displayName": "Magenta Shulker Box",
+    "name": "magenta_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 222,
+    "displayName": "Light Blue Shulker Box",
+    "name": "light_blue_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 223,
+    "displayName": "Yellow Shulker Box",
+    "name": "yellow_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 224,
+    "displayName": "Lime Shulker Box",
+    "name": "lime_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 225,
+    "displayName": "Pink Shulker Box",
+    "name": "pink_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 226,
+    "displayName": "Gray Shulker Box",
+    "name": "gray_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 227,
+    "displayName": "Light Gray Shulker Box",
+    "name": "light_gray_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 228,
+    "displayName": "Cyan Shulker Box",
+    "name": "cyan_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 229,
+    "displayName": "Purple Shulker Box",
+    "name": "purple_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 230,
+    "displayName": "Blue Shulker Box",
+    "name": "blue_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 231,
+    "displayName": "Brown Shulker Box",
+    "name": "brown_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 232,
+    "displayName": "Green Shulker Box",
+    "name": "green_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 233,
+    "displayName": "Red Shulker Box",
+    "name": "red_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 234,
+    "displayName": "Black Shulker Box",
+    "name": "black_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 255,
+    "displayName": "Structure Block",
+    "name": "structure_block",
+    "stackSize": 64
+  },
+  {
     "id": 256,
     "displayName": "Iron Shovel",
     "stackSize": 1,

--- a/data/pc/1.12/items.json
+++ b/data/pc/1.12/items.json
@@ -1,5 +1,1433 @@
 [
   {
+    "id": 0,
+    "displayName": "Air",
+    "name": "air",
+    "stackSize": 64
+  },
+  {
+    "id": 1,
+    "displayName": "Stone",
+    "name": "stone",
+    "stackSize": 64
+  },
+  {
+    "id": 2,
+    "displayName": "Grass Block",
+    "name": "grass",
+    "stackSize": 64
+  },
+  {
+    "id": 3,
+    "displayName": "Dirt",
+    "name": "dirt",
+    "stackSize": 64
+  },
+  {
+    "id": 4,
+    "displayName": "Cobblestone",
+    "name": "cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 5,
+    "displayName": "Wood Planks",
+    "name": "planks",
+    "stackSize": 64
+  },
+  {
+    "id": 6,
+    "displayName": "Sapling",
+    "name": "sapling",
+    "stackSize": 64
+  },
+  {
+    "id": 7,
+    "displayName": "Bedrock",
+    "name": "bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 8,
+    "displayName": "Water",
+    "name": "flowing_water",
+    "stackSize": 64
+  },
+  {
+    "id": 9,
+    "displayName": "Stationary Water",
+    "name": "water",
+    "stackSize": 64
+  },
+  {
+    "id": 10,
+    "displayName": "Lava",
+    "name": "flowing_lava",
+    "stackSize": 64
+  },
+  {
+    "id": 11,
+    "displayName": "Stationary Lava",
+    "name": "lava",
+    "stackSize": 64
+  },
+  {
+    "id": 12,
+    "displayName": "Sand",
+    "name": "sand",
+    "stackSize": 64
+  },
+  {
+    "id": 13,
+    "displayName": "Gravel",
+    "name": "gravel",
+    "stackSize": 64
+  },
+  {
+    "id": 14,
+    "displayName": "Gold Ore",
+    "name": "gold_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 15,
+    "displayName": "Iron Ore",
+    "name": "iron_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 16,
+    "displayName": "Coal Ore",
+    "name": "coal_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 17,
+    "displayName": "Wood",
+    "name": "log",
+    "stackSize": 64
+  },
+  {
+    "id": 18,
+    "displayName": "Leaves",
+    "name": "leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 19,
+    "displayName": "Sponge",
+    "name": "sponge",
+    "stackSize": 64
+  },
+  {
+    "id": 20,
+    "displayName": "Glass",
+    "name": "glass",
+    "stackSize": 64
+  },
+  {
+    "id": 21,
+    "displayName": "Lapis Lazuli Ore",
+    "name": "lapis_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 22,
+    "displayName": "Lapis Lazuli Block",
+    "name": "lapis_block",
+    "stackSize": 64
+  },
+  {
+    "id": 23,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 24,
+    "displayName": "Sandstone",
+    "name": "sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 25,
+    "displayName": "Note Block",
+    "name": "noteblock",
+    "stackSize": 64
+  },
+  {
+    "id": 27,
+    "displayName": "Powered Rail",
+    "name": "golden_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 28,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 29,
+    "displayName": "Sticky Piston",
+    "name": "sticky_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 30,
+    "displayName": "Cobweb",
+    "name": "web",
+    "stackSize": 64
+  },
+  {
+    "id": 31,
+    "displayName": "Grass",
+    "name": "tallgrass",
+    "stackSize": 64
+  },
+  {
+    "id": 32,
+    "displayName": "Dead Bush",
+    "name": "deadbush",
+    "stackSize": 64
+  },
+  {
+    "id": 33,
+    "displayName": "Piston",
+    "name": "piston",
+    "stackSize": 64
+  },
+  {
+    "id": 34,
+    "displayName": "Piston Head",
+    "name": "piston_head",
+    "stackSize": 64
+  },
+  {
+    "id": 35,
+    "displayName": "Wool",
+    "name": "wool",
+    "stackSize": 64
+  },
+  {
+    "id": 36,
+    "displayName": "Block moved by Piston",
+    "name": "piston_extension",
+    "stackSize": 64
+  },
+  {
+    "id": 37,
+    "displayName": "Dandelion",
+    "name": "yellow_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 38,
+    "displayName": "Poppy",
+    "name": "red_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 39,
+    "displayName": "Brown Mushroom",
+    "name": "brown_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 40,
+    "displayName": "Red Mushroom",
+    "name": "red_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 41,
+    "displayName": "Block of Gold",
+    "name": "gold_block",
+    "stackSize": 64
+  },
+  {
+    "id": 42,
+    "displayName": "Block of Iron",
+    "name": "iron_block",
+    "stackSize": 64
+  },
+  {
+    "id": 43,
+    "displayName": "Double Stone Slab",
+    "name": "double_stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 44,
+    "displayName": "Stone Slab",
+    "name": "stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 45,
+    "displayName": "Bricks",
+    "name": "brick_block",
+    "stackSize": 64
+  },
+  {
+    "id": 46,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 47,
+    "displayName": "Bookshelf",
+    "name": "bookshelf",
+    "stackSize": 64
+  },
+  {
+    "id": 48,
+    "displayName": "Moss Stone",
+    "name": "mossy_cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 49,
+    "displayName": "Obsidian",
+    "name": "obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 50,
+    "displayName": "Torch",
+    "name": "torch",
+    "stackSize": 64
+  },
+  {
+    "id": 51,
+    "displayName": "Fire",
+    "name": "fire",
+    "stackSize": 64
+  },
+  {
+    "id": 52,
+    "displayName": "Monster Spawner",
+    "name": "mob_spawner",
+    "stackSize": 64
+  },
+  {
+    "id": 53,
+    "displayName": "Oak Wood Stairs",
+    "name": "oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 54,
+    "displayName": "Chest",
+    "name": "chest",
+    "stackSize": 64
+  },
+  {
+    "id": 55,
+    "displayName": "Redstone Wire",
+    "name": "redstone_wire",
+    "stackSize": 64
+  },
+  {
+    "id": 56,
+    "displayName": "Diamond Ore",
+    "name": "diamond_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 57,
+    "displayName": "Block of Diamond",
+    "name": "diamond_block",
+    "stackSize": 64
+  },
+  {
+    "id": 58,
+    "displayName": "Crafting Table",
+    "name": "crafting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 60,
+    "displayName": "Farmland",
+    "name": "farmland",
+    "stackSize": 64
+  },
+  {
+    "id": 61,
+    "displayName": "Furnace",
+    "name": "furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 62,
+    "displayName": "Burning Furnace",
+    "name": "lit_furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 63,
+    "displayName": "Standing Sign",
+    "name": "standing_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 65,
+    "displayName": "Ladder",
+    "name": "ladder",
+    "stackSize": 64
+  },
+  {
+    "id": 66,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 67,
+    "displayName": "Cobblestone Stairs",
+    "name": "stone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 68,
+    "displayName": "Wall Sign",
+    "name": "wall_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 69,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 70,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 72,
+    "displayName": "Wooden Pressure Plate",
+    "name": "wooden_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 73,
+    "displayName": "Redstone Ore",
+    "name": "redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 74,
+    "displayName": "Glowing Redstone Ore",
+    "name": "lit_redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 75,
+    "displayName": "Redstone Torch (inactive)",
+    "name": "unlit_redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 76,
+    "displayName": "Redstone Torch (active)",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 77,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 78,
+    "displayName": "Snow (layer)",
+    "name": "snow_layer",
+    "stackSize": 64
+  },
+  {
+    "id": 79,
+    "displayName": "Ice",
+    "name": "ice",
+    "stackSize": 64
+  },
+  {
+    "id": 80,
+    "displayName": "Snow",
+    "name": "snow",
+    "stackSize": 64
+  },
+  {
+    "id": 81,
+    "displayName": "Cactus",
+    "name": "cactus",
+    "stackSize": 64
+  },
+  {
+    "id": 82,
+    "displayName": "Clay",
+    "name": "clay",
+    "stackSize": 64
+  },
+  {
+    "id": 84,
+    "displayName": "Jukebox",
+    "name": "jukebox",
+    "stackSize": 64
+  },
+  {
+    "id": 85,
+    "displayName": "Oak Fence",
+    "name": "fence",
+    "stackSize": 64
+  },
+  {
+    "id": 86,
+    "displayName": "Pumpkin",
+    "name": "pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 87,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 88,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 89,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 90,
+    "displayName": "Nether Portal",
+    "name": "portal",
+    "stackSize": 64
+  },
+  {
+    "id": 91,
+    "displayName": "Jack o'Lantern",
+    "name": "lit_pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 93,
+    "displayName": "Redstone Repeater (inactive)",
+    "name": "unpowered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 94,
+    "displayName": "Redstone Repeater (active)",
+    "name": "powered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 95,
+    "displayName": "Stained Glass",
+    "name": "stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 96,
+    "displayName": "Trapdoor",
+    "name": "trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 97,
+    "displayName": "Monster Egg",
+    "name": "monster_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 98,
+    "displayName": "Stone Bricks",
+    "name": "stonebrick",
+    "stackSize": 64
+  },
+  {
+    "id": 99,
+    "displayName": "Brown Mushroom (block)",
+    "name": "brown_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 100,
+    "displayName": "Red Mushroom (block)",
+    "name": "red_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 101,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 102,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 103,
+    "displayName": "Melon",
+    "name": "melon_block",
+    "stackSize": 64
+  },
+  {
+    "id": 104,
+    "displayName": "Pumpkin Stem",
+    "name": "pumpkin_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 105,
+    "displayName": "Melon Stem",
+    "name": "melon_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 106,
+    "displayName": "Vines",
+    "name": "vine",
+    "stackSize": 64
+  },
+  {
+    "id": 107,
+    "displayName": "Fence Gate",
+    "name": "fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 108,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 109,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 110,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 111,
+    "displayName": "Lily Pad",
+    "name": "waterlily",
+    "stackSize": 64
+  },
+  {
+    "id": 112,
+    "displayName": "Nether Brick",
+    "name": "nether_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 113,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 114,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 116,
+    "displayName": "Enchantment Table",
+    "name": "enchanting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 119,
+    "displayName": "End Portal",
+    "name": "end_portal",
+    "stackSize": 64
+  },
+  {
+    "id": 120,
+    "displayName": "End Portal Frame",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 121,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 122,
+    "displayName": "Dragon Egg",
+    "name": "dragon_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 123,
+    "displayName": "Redstone Lamp (inactive)",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 124,
+    "displayName": "Redstone Lamp (active)",
+    "name": "lit_redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 125,
+    "displayName": "Double Wooden Slab",
+    "name": "double_wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 126,
+    "displayName": "Wooden Slab",
+    "name": "wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 127,
+    "displayName": "Cocoa",
+    "name": "cocoa",
+    "stackSize": 64
+  },
+  {
+    "id": 128,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 129,
+    "displayName": "Emerald Ore",
+    "name": "emerald_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 130,
+    "displayName": "Ender Chest",
+    "name": "ender_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 131,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 132,
+    "displayName": "Tripwire",
+    "name": "tripwire",
+    "stackSize": 64
+  },
+  {
+    "id": 133,
+    "displayName": "Block of Emerald",
+    "name": "emerald_block",
+    "stackSize": 64
+  },
+  {
+    "id": 134,
+    "displayName": "Spruce Wood Stairs",
+    "name": "spruce_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 135,
+    "displayName": "Birch Wood Stairs",
+    "name": "birch_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 136,
+    "displayName": "Jungle Wood Stairs",
+    "name": "jungle_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 137,
+    "displayName": "Command Block",
+    "name": "command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 138,
+    "displayName": "Beacon",
+    "name": "beacon",
+    "stackSize": 64
+  },
+  {
+    "id": 139,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 141,
+    "displayName": "Carrot",
+    "name": "carrots",
+    "stackSize": 64
+  },
+  {
+    "id": 142,
+    "displayName": "Potato",
+    "name": "potatoes",
+    "stackSize": 64
+  },
+  {
+    "id": 143,
+    "displayName": "Wooden Button",
+    "name": "wooden_button",
+    "stackSize": 64
+  },
+  {
+    "id": 145,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 146,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 147,
+    "displayName": "Weighted Pressure Plate (Light)",
+    "name": "light_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 148,
+    "displayName": "Weighted Pressure Plate (Heavy)",
+    "name": "heavy_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 149,
+    "displayName": "Redstone Comparator",
+    "name": "unpowered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 150,
+    "displayName": "Redstone Comparator (deprecated)",
+    "name": "powered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 151,
+    "displayName": "Daylight Sensor",
+    "name": "daylight_detector",
+    "stackSize": 64
+  },
+  {
+    "id": 152,
+    "displayName": "Block of Redstone",
+    "name": "redstone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 153,
+    "displayName": "Nether Quartz Ore",
+    "name": "quartz_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 154,
+    "displayName": "Hopper",
+    "name": "hopper",
+    "stackSize": 64
+  },
+  {
+    "id": 155,
+    "displayName": "Block of Quartz",
+    "name": "quartz_block",
+    "stackSize": 64
+  },
+  {
+    "id": 156,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 157,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 158,
+    "displayName": "Dropper",
+    "name": "dropper",
+    "stackSize": 64
+  },
+  {
+    "id": 159,
+    "displayName": "Stained Clay",
+    "name": "stained_hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 160,
+    "displayName": "Stained Glass Pane",
+    "name": "stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 161,
+    "displayName": "Leaves (Acacia/Dark Oak)",
+    "name": "leaves2",
+    "stackSize": 64
+  },
+  {
+    "id": 162,
+    "displayName": "Wood (Acacia/Dark Oak)",
+    "name": "log2",
+    "stackSize": 64
+  },
+  {
+    "id": 163,
+    "displayName": "Acacia Wood Stairs",
+    "name": "acacia_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 164,
+    "displayName": "Dark Oak Wood Stairs",
+    "name": "dark_oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 165,
+    "displayName": "Slime Block",
+    "name": "slime",
+    "stackSize": 64
+  },
+  {
+    "id": 166,
+    "displayName": "Barrier",
+    "name": "barrier",
+    "stackSize": 64
+  },
+  {
+    "id": 167,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 168,
+    "displayName": "Prismarine",
+    "name": "prismarine",
+    "stackSize": 64
+  },
+  {
+    "id": 169,
+    "displayName": "Sea Lantern",
+    "name": "sea_lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 170,
+    "displayName": "Hay Bale",
+    "name": "hay_block",
+    "stackSize": 64
+  },
+  {
+    "id": 171,
+    "displayName": "Carpet",
+    "name": "carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 172,
+    "displayName": "Hardened Clay",
+    "name": "hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 173,
+    "displayName": "Block of Coal",
+    "name": "coal_block",
+    "stackSize": 64
+  },
+  {
+    "id": 174,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 175,
+    "displayName": "Large Flowers",
+    "name": "double_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 176,
+    "displayName": "Standing Banner",
+    "name": "standing_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 177,
+    "displayName": "Wall Banner",
+    "name": "wall_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 178,
+    "displayName": "Inverted Daylight Sensor",
+    "name": "daylight_detector_inverted",
+    "stackSize": 64
+  },
+  {
+    "id": 179,
+    "displayName": "Red Sandstone",
+    "name": "red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 180,
+    "displayName": "Red Sandstone Stairs",
+    "name": "red_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 181,
+    "displayName": "Double Red Sandstone Slab",
+    "name": "double_stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 182,
+    "displayName": "Red Sandstone Slab",
+    "name": "stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 183,
+    "displayName": "Spruce Fence Gate",
+    "name": "spruce_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 184,
+    "displayName": "Birch Fence Gate",
+    "name": "birch_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 185,
+    "displayName": "Jungle Fence Gate",
+    "name": "jungle_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 186,
+    "displayName": "Dark Oak Fence Gate",
+    "name": "dark_oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 187,
+    "displayName": "Acacia Fence Gate",
+    "name": "acacia_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 188,
+    "displayName": "Spruce Fence",
+    "name": "spruce_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 189,
+    "displayName": "Birch Fence",
+    "name": "birch_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 190,
+    "displayName": "Jungle Fence",
+    "name": "jungle_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 191,
+    "displayName": "Dark Oak Fence",
+    "name": "dark_oak_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 192,
+    "displayName": "Acacia Fence",
+    "name": "acacia_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 198,
+    "displayName": "End Rod",
+    "name": "end_rod",
+    "stackSize": 64
+  },
+  {
+    "id": 199,
+    "displayName": "Chorus Plant",
+    "name": "chorus_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 200,
+    "displayName": "Chorus Flower",
+    "name": "chorus_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 201,
+    "displayName": "Purpur Block",
+    "name": "purpur_block",
+    "stackSize": 64
+  },
+  {
+    "id": 202,
+    "displayName": "Purpur Pillar",
+    "name": "purpur_pillar",
+    "stackSize": 64
+  },
+  {
+    "id": 203,
+    "displayName": "Purpur Stairs",
+    "name": "purpur_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 204,
+    "displayName": "Purpur Double Slab",
+    "name": "purpur_double_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 205,
+    "displayName": "Purpur Slab",
+    "name": "purpur_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 206,
+    "displayName": "End Stone Bricks",
+    "name": "end_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 207,
+    "displayName": "Beetroot Seeds",
+    "name": "beetroots",
+    "stackSize": 64
+  },
+  {
+    "id": 208,
+    "displayName": "Grass Path",
+    "name": "grass_path",
+    "stackSize": 64
+  },
+  {
+    "id": 209,
+    "displayName": "End Gateway",
+    "name": "end_gateway",
+    "stackSize": 64
+  },
+  {
+    "id": 210,
+    "displayName": "Repeating Command Block",
+    "name": "repeating_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 211,
+    "displayName": "Chain Command Block",
+    "name": "chain_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 212,
+    "displayName": "Frosted Ice",
+    "name": "frosted_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 213,
+    "displayName": "Magma Block",
+    "name": "magma",
+    "stackSize": 64
+  },
+  {
+    "id": 214,
+    "displayName": "Nether Wart Block",
+    "name": "nether_wart_block",
+    "stackSize": 64
+  },
+  {
+    "id": 215,
+    "displayName": "Red Nether Brick",
+    "name": "red_nether_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 216,
+    "displayName": "Bone Block",
+    "name": "bone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 217,
+    "displayName": "Structure Void",
+    "name": "structure_void",
+    "stackSize": 64
+  },
+  {
+    "id": 218,
+    "displayName": "Observer",
+    "name": "observer",
+    "stackSize": 64
+  },
+  {
+    "id": 219,
+    "displayName": "White Shulker Box",
+    "name": "white_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 220,
+    "displayName": "Orange Shulker Box",
+    "name": "orange_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 221,
+    "displayName": "Magenta Shulker Box",
+    "name": "magenta_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 222,
+    "displayName": "Light Blue Shulker Box",
+    "name": "light_blue_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 223,
+    "displayName": "Yellow Shulker Box",
+    "name": "yellow_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 224,
+    "displayName": "Lime Shulker Box",
+    "name": "lime_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 225,
+    "displayName": "Pink Shulker Box",
+    "name": "pink_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 226,
+    "displayName": "Gray Shulker Box",
+    "name": "gray_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 227,
+    "displayName": "Light Gray Shulker Box",
+    "name": "light_gray_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 228,
+    "displayName": "Cyan Shulker Box",
+    "name": "cyan_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 229,
+    "displayName": "Purple Shulker Box",
+    "name": "purple_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 230,
+    "displayName": "Blue Shulker Box",
+    "name": "blue_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 231,
+    "displayName": "Brown Shulker Box",
+    "name": "brown_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 232,
+    "displayName": "Green Shulker Box",
+    "name": "green_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 233,
+    "displayName": "Red Shulker Box",
+    "name": "red_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 234,
+    "displayName": "Black Shulker Box",
+    "name": "black_shulker_box",
+    "stackSize": 64
+  },
+  {
+    "id": 235,
+    "displayName": "White Glazed Terracotta",
+    "name": "white_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 236,
+    "displayName": "Orange Glazed Terracotta",
+    "name": "orange_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 237,
+    "displayName": "Magenta Glazed Terracotta",
+    "name": "magenta_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 238,
+    "displayName": "Light Blue Glazed Terracotta",
+    "name": "light_blue_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 239,
+    "displayName": "Yellow Glazed Terracotta",
+    "name": "yellow_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 240,
+    "displayName": "Lime Glazed Terracotta",
+    "name": "lime_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 241,
+    "displayName": "Pink Glazed Terracotta",
+    "name": "pink_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 242,
+    "displayName": "Gray Glazed Terracotta",
+    "name": "gray_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 243,
+    "displayName": "Light Gray Glazed Terracotta",
+    "name": "light_gray_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 244,
+    "displayName": "Cyan Glazed Terracotta",
+    "name": "cyan_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 245,
+    "displayName": "Purple Glazed Terracotta",
+    "name": "purple_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 246,
+    "displayName": "Blue Glazed Terracotta",
+    "name": "blue_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 247,
+    "displayName": "Brown Glazed Terracotta",
+    "name": "brown_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 248,
+    "displayName": "Green Glazed Terracotta",
+    "name": "green_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 249,
+    "displayName": "Red Glazed Terracotta",
+    "name": "red_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 250,
+    "displayName": "Black Glazed Terracotta",
+    "name": "black_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 251,
+    "displayName": "Concrete",
+    "name": "concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 252,
+    "displayName": "Concrete Powder",
+    "name": "concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 255,
+    "displayName": "Structure Block",
+    "name": "structure_block",
+    "stackSize": 64
+  },
+  {
     "id": 256,
     "displayName": "Iron Shovel",
     "stackSize": 1,

--- a/data/pc/1.7/items.json
+++ b/data/pc/1.7/items.json
@@ -1,5 +1,995 @@
 [
   {
+    "id": 0,
+    "displayName": "Air",
+    "name": "air",
+    "stackSize": 64
+  },
+  {
+    "id": 1,
+    "displayName": "Stone",
+    "name": "stone",
+    "stackSize": 64
+  },
+  {
+    "id": 2,
+    "displayName": "Grass Block",
+    "name": "grass",
+    "stackSize": 64
+  },
+  {
+    "id": 3,
+    "displayName": "Dirt",
+    "name": "dirt",
+    "stackSize": 64
+  },
+  {
+    "id": 4,
+    "displayName": "Cobblestone",
+    "name": "cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 5,
+    "displayName": "Wood Planks",
+    "name": "wood_planks",
+    "stackSize": 64
+  },
+  {
+    "id": 6,
+    "displayName": "Sapling",
+    "name": "sapling",
+    "stackSize": 64
+  },
+  {
+    "id": 7,
+    "displayName": "Bedrock",
+    "name": "bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 8,
+    "displayName": "Water",
+    "name": "flowing_water",
+    "stackSize": 64
+  },
+  {
+    "id": 9,
+    "displayName": "Stationary Water",
+    "name": "water",
+    "stackSize": 64
+  },
+  {
+    "id": 10,
+    "displayName": "Lava",
+    "name": "flowing_lava",
+    "stackSize": 64
+  },
+  {
+    "id": 11,
+    "displayName": "Stationary Lava",
+    "name": "lava",
+    "stackSize": 64
+  },
+  {
+    "id": 12,
+    "displayName": "Sand",
+    "name": "sand",
+    "stackSize": 64
+  },
+  {
+    "id": 13,
+    "displayName": "Gravel",
+    "name": "gravel",
+    "stackSize": 64
+  },
+  {
+    "id": 14,
+    "displayName": "Gold Ore",
+    "name": "gold_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 15,
+    "displayName": "Iron Ore",
+    "name": "iron_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 16,
+    "displayName": "Coal Ore",
+    "name": "coal_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 17,
+    "displayName": "Wood",
+    "name": "log",
+    "stackSize": 64
+  },
+  {
+    "id": 18,
+    "displayName": "Leaves",
+    "name": "leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 19,
+    "displayName": "Sponge",
+    "name": "sponge",
+    "stackSize": 64
+  },
+  {
+    "id": 20,
+    "displayName": "Glass",
+    "name": "glass",
+    "stackSize": 64
+  },
+  {
+    "id": 21,
+    "displayName": "Lapis Lazuli Ore",
+    "name": "lapis_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 22,
+    "displayName": "Lapis Lazuli Block",
+    "name": "lapis_block",
+    "stackSize": 64
+  },
+  {
+    "id": 23,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 24,
+    "displayName": "Sandstone",
+    "name": "sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 25,
+    "displayName": "Note Block",
+    "name": "noteblock",
+    "stackSize": 64
+  },
+  {
+    "id": 27,
+    "displayName": "Powered Rail",
+    "name": "golden_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 28,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 29,
+    "displayName": "Sticky Piston",
+    "name": "sticky_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 30,
+    "displayName": "Cobweb",
+    "name": "web",
+    "stackSize": 64
+  },
+  {
+    "id": 31,
+    "displayName": "Grass",
+    "name": "tallgrass",
+    "stackSize": 64
+  },
+  {
+    "id": 32,
+    "displayName": "Dead Bush",
+    "name": "deadbush",
+    "stackSize": 64
+  },
+  {
+    "id": 33,
+    "displayName": "Piston",
+    "name": "piston",
+    "stackSize": 64
+  },
+  {
+    "id": 34,
+    "displayName": "Piston Extension",
+    "name": "piston_head",
+    "stackSize": 64
+  },
+  {
+    "id": 35,
+    "displayName": "Wool",
+    "name": "wool",
+    "stackSize": 64
+  },
+  {
+    "id": 36,
+    "displayName": "Block moved by Piston",
+    "name": "piston_extension",
+    "stackSize": 64
+  },
+  {
+    "id": 37,
+    "displayName": "Dandelion",
+    "name": "yellow_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 38,
+    "displayName": "Poppy",
+    "name": "red_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 39,
+    "displayName": "Brown Mushroom",
+    "name": "brown_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 40,
+    "displayName": "Red Mushroom",
+    "name": "red_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 41,
+    "displayName": "Block of Gold",
+    "name": "gold_block",
+    "stackSize": 64
+  },
+  {
+    "id": 42,
+    "displayName": "Block of Iron",
+    "name": "iron_block",
+    "stackSize": 64
+  },
+  {
+    "id": 43,
+    "displayName": "Double Stone Slab",
+    "name": "double_stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 44,
+    "displayName": "Stone Slab",
+    "name": "stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 45,
+    "displayName": "Bricks",
+    "name": "brick_block",
+    "stackSize": 64
+  },
+  {
+    "id": 46,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 47,
+    "displayName": "Bookshelf",
+    "name": "bookshelf",
+    "stackSize": 64
+  },
+  {
+    "id": 48,
+    "displayName": "Moss Stone",
+    "name": "mossy_cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 49,
+    "displayName": "Obsidian",
+    "name": "obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 50,
+    "displayName": "Torch",
+    "name": "torch",
+    "stackSize": 64
+  },
+  {
+    "id": 51,
+    "displayName": "Fire",
+    "name": "fire",
+    "stackSize": 64
+  },
+  {
+    "id": 52,
+    "displayName": "Monster Spawner",
+    "name": "mob_spawner",
+    "stackSize": 64
+  },
+  {
+    "id": 53,
+    "displayName": "Oak Wood Stairs",
+    "name": "oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 54,
+    "displayName": "Chest",
+    "name": "chest",
+    "stackSize": 64
+  },
+  {
+    "id": 55,
+    "displayName": "Redstone Wire",
+    "name": "redstone_wire",
+    "stackSize": 64
+  },
+  {
+    "id": 56,
+    "displayName": "Diamond Ore",
+    "name": "diamond_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 57,
+    "displayName": "Block of Diamond",
+    "name": "diamond_block",
+    "stackSize": 64
+  },
+  {
+    "id": 58,
+    "displayName": "Crafting Table",
+    "name": "crafting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 60,
+    "displayName": "Farmland",
+    "name": "farmland",
+    "stackSize": 64
+  },
+  {
+    "id": 61,
+    "displayName": "Furnace",
+    "name": "furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 62,
+    "displayName": "Burning Furnace",
+    "name": "lit_furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 63,
+    "displayName": "Standing Sign",
+    "name": "standing_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 65,
+    "displayName": "Ladder",
+    "name": "ladder",
+    "stackSize": 64
+  },
+  {
+    "id": 66,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 67,
+    "displayName": "Cobblestone Stairs",
+    "name": "stone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 68,
+    "displayName": "Wall Sign",
+    "name": "wall_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 69,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 70,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 72,
+    "displayName": "Wooden Pressure Plate",
+    "name": "wooden_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 73,
+    "displayName": "Redstone Ore",
+    "name": "redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 74,
+    "displayName": "Glowing Redstone Ore",
+    "name": "lit_redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 75,
+    "displayName": "Redstone Torch",
+    "name": "unlit_redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 76,
+    "displayName": "Redstone Torch",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 77,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 78,
+    "displayName": "Snow",
+    "name": "snow_layer",
+    "stackSize": 64
+  },
+  {
+    "id": 79,
+    "displayName": "Ice",
+    "name": "ice",
+    "stackSize": 64
+  },
+  {
+    "id": 80,
+    "displayName": "Snow",
+    "name": "snow",
+    "stackSize": 64
+  },
+  {
+    "id": 81,
+    "displayName": "Cactus",
+    "name": "cactus",
+    "stackSize": 64
+  },
+  {
+    "id": 82,
+    "displayName": "Clay",
+    "name": "clay",
+    "stackSize": 64
+  },
+  {
+    "id": 84,
+    "displayName": "Jukebox",
+    "name": "jukebox",
+    "stackSize": 64
+  },
+  {
+    "id": 85,
+    "displayName": "Fence",
+    "name": "fence",
+    "stackSize": 64
+  },
+  {
+    "id": 86,
+    "displayName": "Pumpkin",
+    "name": "pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 87,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 88,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 89,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 90,
+    "displayName": "Nether Portal",
+    "name": "portal",
+    "stackSize": 64
+  },
+  {
+    "id": 91,
+    "displayName": "Jack o'Lantern",
+    "name": "lit_pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 93,
+    "displayName": "Redstone Repeater",
+    "name": "unpowered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 94,
+    "displayName": "Redstone Repeater",
+    "name": "powered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 95,
+    "displayName": "Stained Glass",
+    "name": "stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 96,
+    "displayName": "Trapdoor",
+    "name": "trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 97,
+    "displayName": "Monster Egg",
+    "name": "monster_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 98,
+    "displayName": "Stone Bricks",
+    "name": "stonebrick",
+    "stackSize": 64
+  },
+  {
+    "id": 99,
+    "displayName": "Huge Brown Mushroom",
+    "name": "brown_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 100,
+    "displayName": "Huge Red Mushroom",
+    "name": "red_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 101,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 102,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 103,
+    "displayName": "Melon",
+    "name": "melon_block",
+    "stackSize": 64
+  },
+  {
+    "id": 104,
+    "displayName": "Pumpkin Stem",
+    "name": "pumpkin_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 105,
+    "displayName": "Melon Stem",
+    "name": "melon_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 106,
+    "displayName": "Vines",
+    "name": "vine",
+    "stackSize": 64
+  },
+  {
+    "id": 107,
+    "displayName": "Fence Gate",
+    "name": "fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 108,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 109,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 110,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 111,
+    "displayName": "Lily Pad",
+    "name": "waterlily",
+    "stackSize": 64
+  },
+  {
+    "id": 112,
+    "displayName": "Nether Brick",
+    "name": "nether_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 113,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 114,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 116,
+    "displayName": "Enchantment Table",
+    "name": "enchanting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 119,
+    "displayName": "End Portal",
+    "name": "end_portal",
+    "stackSize": 64
+  },
+  {
+    "id": 120,
+    "displayName": "End Portal Block",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 121,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 122,
+    "displayName": "Dragon Egg",
+    "name": "dragon_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 123,
+    "displayName": "Redstone Lamp",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 124,
+    "displayName": "Redstone Lamp",
+    "name": "lit_redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 125,
+    "displayName": "Double Wooden Slab",
+    "name": "double_wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 126,
+    "displayName": "Wooden Slab",
+    "name": "wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 127,
+    "displayName": "Cocoa",
+    "name": "cocoa",
+    "stackSize": 64
+  },
+  {
+    "id": 128,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 129,
+    "displayName": "Emerald Ore",
+    "name": "emerald_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 130,
+    "displayName": "Ender Chest",
+    "name": "ender_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 131,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 132,
+    "displayName": "Tripwire",
+    "name": "tripwire",
+    "stackSize": 64
+  },
+  {
+    "id": 133,
+    "displayName": "Block of Emerald",
+    "name": "emerald_block",
+    "stackSize": 64
+  },
+  {
+    "id": 134,
+    "displayName": "Spruce Wood Stairs",
+    "name": "spruce_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 135,
+    "displayName": "Birch Wood Stairs",
+    "name": "birch_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 136,
+    "displayName": "Jungle Wood Stairs",
+    "name": "jungle_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 137,
+    "displayName": "Command Block",
+    "name": "command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 138,
+    "displayName": "Beacon",
+    "name": "beacon",
+    "stackSize": 64
+  },
+  {
+    "id": 139,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 141,
+    "displayName": "Carrot",
+    "name": "carrots",
+    "stackSize": 64
+  },
+  {
+    "id": 142,
+    "displayName": "Potato",
+    "name": "potatoes",
+    "stackSize": 64
+  },
+  {
+    "id": 143,
+    "displayName": "Wooden Button",
+    "name": "wooden_button",
+    "stackSize": 64
+  },
+  {
+    "id": 145,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 146,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 147,
+    "displayName": "Light Weighted Pressure Plate",
+    "name": "light_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 148,
+    "displayName": "Heavy Weighted Pressure Plate",
+    "name": "heavy_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 149,
+    "displayName": "Redstone Comparator",
+    "name": "unpowered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 150,
+    "displayName": "Redstone Comparator",
+    "name": "powered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 151,
+    "displayName": "Daylight Sensor",
+    "name": "daylight_detector",
+    "stackSize": 64
+  },
+  {
+    "id": 152,
+    "displayName": "Block of Redstone",
+    "name": "redstone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 153,
+    "displayName": "Nether Quartz Ore",
+    "name": "quartz_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 154,
+    "displayName": "Hopper",
+    "name": "hopper",
+    "stackSize": 64
+  },
+  {
+    "id": 155,
+    "displayName": "Block of Quartz",
+    "name": "quartz_block",
+    "stackSize": 64
+  },
+  {
+    "id": 156,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 157,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 158,
+    "displayName": "Dropper",
+    "name": "dropper",
+    "stackSize": 64
+  },
+  {
+    "id": 159,
+    "displayName": "Stained Clay",
+    "name": "stained_hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 160,
+    "displayName": "Stained Glass Pane",
+    "name": "stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 161,
+    "displayName": "Leaves",
+    "name": "leaves2",
+    "stackSize": 64
+  },
+  {
+    "id": 162,
+    "displayName": "Wood",
+    "name": "log2",
+    "stackSize": 64
+  },
+  {
+    "id": 163,
+    "displayName": "Acacia Wood Stairs",
+    "name": "acacia_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 164,
+    "displayName": "Dark Oak Wood Stairs",
+    "name": "dark_oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 165,
+    "displayName": "Slime Block",
+    "name": "slime",
+    "stackSize": 64
+  },
+  {
+    "id": 166,
+    "displayName": "Barrier",
+    "name": "barrier",
+    "stackSize": 64
+  },
+  {
+    "id": 167,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 168,
+    "displayName": "Prismarine",
+    "name": "prismarine",
+    "stackSize": 64
+  },
+  {
+    "id": 169,
+    "displayName": "Sea Lantern",
+    "name": "sea_lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 170,
+    "displayName": "Hay Block",
+    "name": "hay_block",
+    "stackSize": 64
+  },
+  {
+    "id": 171,
+    "displayName": "Carpet",
+    "name": "carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 172,
+    "displayName": "Hardened Clay",
+    "name": "hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 173,
+    "displayName": "Block of Coal",
+    "name": "coal_block",
+    "stackSize": 64
+  },
+  {
+    "id": 174,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 175,
+    "displayName": "Large Flowers",
+    "name": "large_flowers",
+    "stackSize": 64
+  },
+  {
     "id": 256,
     "displayName": "Iron Shovel",
     "stackSize": 1,

--- a/data/pc/1.8/items.json
+++ b/data/pc/1.8/items.json
@@ -1,5 +1,1097 @@
 [
   {
+    "id": 0,
+    "displayName": "Air",
+    "name": "air",
+    "stackSize": 64
+  },
+  {
+    "id": 1,
+    "displayName": "Stone",
+    "name": "stone",
+    "stackSize": 64
+  },
+  {
+    "id": 2,
+    "displayName": "Grass Block",
+    "name": "grass",
+    "stackSize": 64
+  },
+  {
+    "id": 3,
+    "displayName": "Dirt",
+    "name": "dirt",
+    "stackSize": 64
+  },
+  {
+    "id": 4,
+    "displayName": "Cobblestone",
+    "name": "cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 5,
+    "displayName": "Wood Planks",
+    "name": "planks",
+    "stackSize": 64
+  },
+  {
+    "id": 6,
+    "displayName": "Sapling",
+    "name": "sapling",
+    "stackSize": 64
+  },
+  {
+    "id": 7,
+    "displayName": "Bedrock",
+    "name": "bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 8,
+    "displayName": "Water",
+    "name": "flowing_water",
+    "stackSize": 64
+  },
+  {
+    "id": 9,
+    "displayName": "Stationary Water",
+    "name": "water",
+    "stackSize": 64
+  },
+  {
+    "id": 10,
+    "displayName": "Lava",
+    "name": "flowing_lava",
+    "stackSize": 64
+  },
+  {
+    "id": 11,
+    "displayName": "Stationary Lava",
+    "name": "lava",
+    "stackSize": 64
+  },
+  {
+    "id": 12,
+    "displayName": "Sand",
+    "name": "sand",
+    "stackSize": 64
+  },
+  {
+    "id": 13,
+    "displayName": "Gravel",
+    "name": "gravel",
+    "stackSize": 64
+  },
+  {
+    "id": 14,
+    "displayName": "Gold Ore",
+    "name": "gold_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 15,
+    "displayName": "Iron Ore",
+    "name": "iron_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 16,
+    "displayName": "Coal Ore",
+    "name": "coal_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 17,
+    "displayName": "Wood",
+    "name": "log",
+    "stackSize": 64
+  },
+  {
+    "id": 18,
+    "displayName": "Leaves",
+    "name": "leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 19,
+    "displayName": "Sponge",
+    "name": "sponge",
+    "stackSize": 64
+  },
+  {
+    "id": 20,
+    "displayName": "Glass",
+    "name": "glass",
+    "stackSize": 64
+  },
+  {
+    "id": 21,
+    "displayName": "Lapis Lazuli Ore",
+    "name": "lapis_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 22,
+    "displayName": "Lapis Lazuli Block",
+    "name": "lapis_block",
+    "stackSize": 64
+  },
+  {
+    "id": 23,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 24,
+    "displayName": "Sandstone",
+    "name": "sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 25,
+    "displayName": "Note Block",
+    "name": "noteblock",
+    "stackSize": 64
+  },
+  {
+    "id": 27,
+    "displayName": "Powered Rail",
+    "name": "golden_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 28,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 29,
+    "displayName": "Sticky Piston",
+    "name": "sticky_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 30,
+    "displayName": "Cobweb",
+    "name": "web",
+    "stackSize": 64
+  },
+  {
+    "id": 31,
+    "displayName": "Grass",
+    "name": "tallgrass",
+    "stackSize": 64
+  },
+  {
+    "id": 32,
+    "displayName": "Dead Bush",
+    "name": "deadbush",
+    "stackSize": 64
+  },
+  {
+    "id": 33,
+    "displayName": "Piston",
+    "name": "piston",
+    "stackSize": 64
+  },
+  {
+    "id": 34,
+    "displayName": "Piston Head",
+    "name": "piston_head",
+    "stackSize": 64
+  },
+  {
+    "id": 35,
+    "displayName": "Wool",
+    "name": "wool",
+    "stackSize": 64
+  },
+  {
+    "id": 36,
+    "displayName": "Block moved by Piston",
+    "name": "piston_extension",
+    "stackSize": 64
+  },
+  {
+    "id": 37,
+    "displayName": "Dandelion",
+    "name": "yellow_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 38,
+    "displayName": "Poppy",
+    "name": "red_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 39,
+    "displayName": "Brown Mushroom",
+    "name": "brown_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 40,
+    "displayName": "Red Mushroom",
+    "name": "red_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 41,
+    "displayName": "Block of Gold",
+    "name": "gold_block",
+    "stackSize": 64
+  },
+  {
+    "id": 42,
+    "displayName": "Block of Iron",
+    "name": "iron_block",
+    "stackSize": 64
+  },
+  {
+    "id": 43,
+    "displayName": "Double Stone Slab",
+    "name": "double_stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 44,
+    "displayName": "Stone Slab",
+    "name": "stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 45,
+    "displayName": "Bricks",
+    "name": "brick_block",
+    "stackSize": 64
+  },
+  {
+    "id": 46,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 47,
+    "displayName": "Bookshelf",
+    "name": "bookshelf",
+    "stackSize": 64
+  },
+  {
+    "id": 48,
+    "displayName": "Moss Stone",
+    "name": "mossy_cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 49,
+    "displayName": "Obsidian",
+    "name": "obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 50,
+    "displayName": "Torch",
+    "name": "torch",
+    "stackSize": 64
+  },
+  {
+    "id": 51,
+    "displayName": "Fire",
+    "name": "fire",
+    "stackSize": 64
+  },
+  {
+    "id": 52,
+    "displayName": "Monster Spawner",
+    "name": "mob_spawner",
+    "stackSize": 64
+  },
+  {
+    "id": 53,
+    "displayName": "Oak Wood Stairs",
+    "name": "oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 54,
+    "displayName": "Chest",
+    "name": "chest",
+    "stackSize": 64
+  },
+  {
+    "id": 55,
+    "displayName": "Redstone Wire",
+    "name": "redstone_wire",
+    "stackSize": 64
+  },
+  {
+    "id": 56,
+    "displayName": "Diamond Ore",
+    "name": "diamond_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 57,
+    "displayName": "Block of Diamond",
+    "name": "diamond_block",
+    "stackSize": 64
+  },
+  {
+    "id": 58,
+    "displayName": "Crafting Table",
+    "name": "crafting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 60,
+    "displayName": "Farmland",
+    "name": "farmland",
+    "stackSize": 64
+  },
+  {
+    "id": 61,
+    "displayName": "Furnace",
+    "name": "furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 62,
+    "displayName": "Burning Furnace",
+    "name": "lit_furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 63,
+    "displayName": "Standing Sign",
+    "name": "standing_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 65,
+    "displayName": "Ladder",
+    "name": "ladder",
+    "stackSize": 64
+  },
+  {
+    "id": 66,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 67,
+    "displayName": "Cobblestone Stairs",
+    "name": "stone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 68,
+    "displayName": "Wall Sign",
+    "name": "wall_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 69,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 70,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 72,
+    "displayName": "Wooden Pressure Plate",
+    "name": "wooden_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 73,
+    "displayName": "Redstone Ore",
+    "name": "redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 74,
+    "displayName": "Glowing Redstone Ore",
+    "name": "lit_redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 75,
+    "displayName": "Redstone Torch (inactive)",
+    "name": "unlit_redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 76,
+    "displayName": "Redstone Torch (active)",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 77,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 78,
+    "displayName": "Snow (layer)",
+    "name": "snow_layer",
+    "stackSize": 64
+  },
+  {
+    "id": 79,
+    "displayName": "Ice",
+    "name": "ice",
+    "stackSize": 64
+  },
+  {
+    "id": 80,
+    "displayName": "Snow",
+    "name": "snow",
+    "stackSize": 64
+  },
+  {
+    "id": 81,
+    "displayName": "Cactus",
+    "name": "cactus",
+    "stackSize": 64
+  },
+  {
+    "id": 82,
+    "displayName": "Clay",
+    "name": "clay",
+    "stackSize": 64
+  },
+  {
+    "id": 84,
+    "displayName": "Jukebox",
+    "name": "jukebox",
+    "stackSize": 64
+  },
+  {
+    "id": 85,
+    "displayName": "Fence",
+    "name": "fence",
+    "stackSize": 64
+  },
+  {
+    "id": 86,
+    "displayName": "Pumpkin",
+    "name": "pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 87,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 88,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 89,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 90,
+    "displayName": "Nether Portal",
+    "name": "portal",
+    "stackSize": 64
+  },
+  {
+    "id": 91,
+    "displayName": "Jack o'Lantern",
+    "name": "lit_pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 93,
+    "displayName": "Redstone Repeater (inactive)",
+    "name": "unpowered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 94,
+    "displayName": "Redstone Repeater (active)",
+    "name": "powered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 95,
+    "displayName": "Stained Glass",
+    "name": "stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 96,
+    "displayName": "Trapdoor",
+    "name": "trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 97,
+    "displayName": "Monster Egg",
+    "name": "monster_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 98,
+    "displayName": "Stone Bricks",
+    "name": "stonebrick",
+    "stackSize": 64
+  },
+  {
+    "id": 99,
+    "displayName": "Brown Mushroom (block)",
+    "name": "brown_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 100,
+    "displayName": "Red Mushroom (block)",
+    "name": "red_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 101,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 102,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 103,
+    "displayName": "Melon",
+    "name": "melon_block",
+    "stackSize": 64
+  },
+  {
+    "id": 104,
+    "displayName": "Pumpkin Stem",
+    "name": "pumpkin_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 105,
+    "displayName": "Melon Stem",
+    "name": "melon_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 106,
+    "displayName": "Vines",
+    "name": "vine",
+    "stackSize": 64
+  },
+  {
+    "id": 107,
+    "displayName": "Fence Gate",
+    "name": "fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 108,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 109,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 110,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 111,
+    "displayName": "Lily Pad",
+    "name": "waterlily",
+    "stackSize": 64
+  },
+  {
+    "id": 112,
+    "displayName": "Nether Brick",
+    "name": "nether_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 113,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 114,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 116,
+    "displayName": "Enchantment Table",
+    "name": "enchanting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 119,
+    "displayName": "End Portal",
+    "name": "end_portal",
+    "stackSize": 64
+  },
+  {
+    "id": 120,
+    "displayName": "End Portal Block",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 121,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 122,
+    "displayName": "Dragon Egg",
+    "name": "dragon_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 123,
+    "displayName": "Redstone Lamp (inactive)",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 124,
+    "displayName": "Redstone Lamp (active)",
+    "name": "lit_redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 125,
+    "displayName": "Double Wooden Slab",
+    "name": "double_wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 126,
+    "displayName": "Wooden Slab",
+    "name": "wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 127,
+    "displayName": "Cocoa",
+    "name": "cocoa",
+    "stackSize": 64
+  },
+  {
+    "id": 128,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 129,
+    "displayName": "Emerald Ore",
+    "name": "emerald_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 130,
+    "displayName": "Ender Chest",
+    "name": "ender_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 131,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 132,
+    "displayName": "Tripwire",
+    "name": "tripwire",
+    "stackSize": 64
+  },
+  {
+    "id": 133,
+    "displayName": "Block of Emerald",
+    "name": "emerald_block",
+    "stackSize": 64
+  },
+  {
+    "id": 134,
+    "displayName": "Spruce Wood Stairs",
+    "name": "spruce_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 135,
+    "displayName": "Birch Wood Stairs",
+    "name": "birch_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 136,
+    "displayName": "Jungle Wood Stairs",
+    "name": "jungle_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 137,
+    "displayName": "Command Block",
+    "name": "command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 138,
+    "displayName": "Beacon",
+    "name": "beacon",
+    "stackSize": 64
+  },
+  {
+    "id": 139,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 141,
+    "displayName": "Carrot",
+    "name": "carrots",
+    "stackSize": 64
+  },
+  {
+    "id": 142,
+    "displayName": "Potato",
+    "name": "potatoes",
+    "stackSize": 64
+  },
+  {
+    "id": 143,
+    "displayName": "Wooden Button",
+    "name": "wooden_button",
+    "stackSize": 64
+  },
+  {
+    "id": 145,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 146,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 147,
+    "displayName": "Weighted Pressure Plate (Light)",
+    "name": "light_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 148,
+    "displayName": "Weighted Pressure Plate (Heavy)",
+    "name": "heavy_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 149,
+    "displayName": "Redstone Comparator",
+    "name": "unpowered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 150,
+    "displayName": "Redstone Comparator (deprecated)",
+    "name": "powered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 151,
+    "displayName": "Daylight Sensor",
+    "name": "daylight_detector",
+    "stackSize": 64
+  },
+  {
+    "id": 152,
+    "displayName": "Block of Redstone",
+    "name": "redstone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 153,
+    "displayName": "Nether Quartz Ore",
+    "name": "quartz_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 154,
+    "displayName": "Hopper",
+    "name": "hopper",
+    "stackSize": 64
+  },
+  {
+    "id": 155,
+    "displayName": "Block of Quartz",
+    "name": "quartz_block",
+    "stackSize": 64
+  },
+  {
+    "id": 156,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 157,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 158,
+    "displayName": "Dropper",
+    "name": "dropper",
+    "stackSize": 64
+  },
+  {
+    "id": 159,
+    "displayName": "Stained Clay",
+    "name": "stained_hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 160,
+    "displayName": "Stained Glass Pane",
+    "name": "stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 161,
+    "displayName": "Leaves (Acacia/Dark Oak)",
+    "name": "leaves2",
+    "stackSize": 64
+  },
+  {
+    "id": 162,
+    "displayName": "Wood (Acacia/Dark Oak)",
+    "name": "log2",
+    "stackSize": 64
+  },
+  {
+    "id": 163,
+    "displayName": "Acacia Wood Stairs",
+    "name": "acacia_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 164,
+    "displayName": "Dark Oak Wood Stairs",
+    "name": "dark_oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 165,
+    "displayName": "Slime Block",
+    "name": "slime",
+    "stackSize": 64
+  },
+  {
+    "id": 166,
+    "displayName": "Barrier",
+    "name": "barrier",
+    "stackSize": 64
+  },
+  {
+    "id": 167,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 168,
+    "displayName": "Prismarine",
+    "name": "prismarine",
+    "stackSize": 64
+  },
+  {
+    "id": 169,
+    "displayName": "Sea Lantern",
+    "name": "sea_lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 170,
+    "displayName": "Hay Bale",
+    "name": "hay_block",
+    "stackSize": 64
+  },
+  {
+    "id": 171,
+    "displayName": "Carpet",
+    "name": "carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 172,
+    "displayName": "Hardened Clay",
+    "name": "hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 173,
+    "displayName": "Block of Coal",
+    "name": "coal_block",
+    "stackSize": 64
+  },
+  {
+    "id": 174,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 175,
+    "displayName": "Large Flowers",
+    "name": "double_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 176,
+    "displayName": "Standing Banner",
+    "name": "standing_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 177,
+    "displayName": "Wall Banner",
+    "name": "wall_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 178,
+    "displayName": "Inverted Daylight Sensor",
+    "name": "daylight_detector_inverted",
+    "stackSize": 64
+  },
+  {
+    "id": 179,
+    "displayName": "Red Sandstone",
+    "name": "red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 180,
+    "displayName": "Red Sandstone Stairs",
+    "name": "red_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 181,
+    "displayName": "Double Red Sandstone Slab",
+    "name": "double_stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 182,
+    "displayName": "Red Sandstone Slab",
+    "name": "stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 183,
+    "displayName": "Spruce Fence Gate",
+    "name": "spruce_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 184,
+    "displayName": "Birch Fence Gate",
+    "name": "birch_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 185,
+    "displayName": "Jungle Fence Gate",
+    "name": "jungle_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 186,
+    "displayName": "Dark Oak Fence Gate",
+    "name": "dark_oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 187,
+    "displayName": "Acacia Fence Gate",
+    "name": "acacia_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 188,
+    "displayName": "Spruce Fence",
+    "name": "spruce_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 189,
+    "displayName": "Birch Fence",
+    "name": "birch_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 190,
+    "displayName": "Jungle Fence",
+    "name": "jungle_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 191,
+    "displayName": "Dark Oak Fence",
+    "name": "dark_oak_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 192,
+    "displayName": "Acacia Fence",
+    "name": "acacia_fence",
+    "stackSize": 64
+  },
+  {
     "id": 256,
     "displayName": "Iron Shovel",
     "stackSize": 1,

--- a/data/pc/1.9/items.json
+++ b/data/pc/1.9/items.json
@@ -1,5 +1,1193 @@
 [
   {
+    "id": 0,
+    "displayName": "Air",
+    "name": "air",
+    "stackSize": 64
+  },
+  {
+    "id": 1,
+    "displayName": "Stone",
+    "name": "stone",
+    "stackSize": 64
+  },
+  {
+    "id": 2,
+    "displayName": "Grass Block",
+    "name": "grass",
+    "stackSize": 64
+  },
+  {
+    "id": 3,
+    "displayName": "Dirt",
+    "name": "dirt",
+    "stackSize": 64
+  },
+  {
+    "id": 4,
+    "displayName": "Cobblestone",
+    "name": "cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 5,
+    "displayName": "Wood Planks",
+    "name": "planks",
+    "stackSize": 64
+  },
+  {
+    "id": 6,
+    "displayName": "Sapling",
+    "name": "sapling",
+    "stackSize": 64
+  },
+  {
+    "id": 7,
+    "displayName": "Bedrock",
+    "name": "bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 8,
+    "displayName": "Water",
+    "name": "flowing_water",
+    "stackSize": 64
+  },
+  {
+    "id": 9,
+    "displayName": "Stationary Water",
+    "name": "water",
+    "stackSize": 64
+  },
+  {
+    "id": 10,
+    "displayName": "Lava",
+    "name": "flowing_lava",
+    "stackSize": 64
+  },
+  {
+    "id": 11,
+    "displayName": "Stationary Lava",
+    "name": "lava",
+    "stackSize": 64
+  },
+  {
+    "id": 12,
+    "displayName": "Sand",
+    "name": "sand",
+    "stackSize": 64
+  },
+  {
+    "id": 13,
+    "displayName": "Gravel",
+    "name": "gravel",
+    "stackSize": 64
+  },
+  {
+    "id": 14,
+    "displayName": "Gold Ore",
+    "name": "gold_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 15,
+    "displayName": "Iron Ore",
+    "name": "iron_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 16,
+    "displayName": "Coal Ore",
+    "name": "coal_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 17,
+    "displayName": "Wood",
+    "name": "log",
+    "stackSize": 64
+  },
+  {
+    "id": 18,
+    "displayName": "Leaves",
+    "name": "leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 19,
+    "displayName": "Sponge",
+    "name": "sponge",
+    "stackSize": 64
+  },
+  {
+    "id": 20,
+    "displayName": "Glass",
+    "name": "glass",
+    "stackSize": 64
+  },
+  {
+    "id": 21,
+    "displayName": "Lapis Lazuli Ore",
+    "name": "lapis_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 22,
+    "displayName": "Lapis Lazuli Block",
+    "name": "lapis_block",
+    "stackSize": 64
+  },
+  {
+    "id": 23,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 24,
+    "displayName": "Sandstone",
+    "name": "sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 25,
+    "displayName": "Note Block",
+    "name": "noteblock",
+    "stackSize": 64
+  },
+  {
+    "id": 27,
+    "displayName": "Powered Rail",
+    "name": "golden_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 28,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 29,
+    "displayName": "Sticky Piston",
+    "name": "sticky_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 30,
+    "displayName": "Cobweb",
+    "name": "web",
+    "stackSize": 64
+  },
+  {
+    "id": 31,
+    "displayName": "Grass",
+    "name": "tallgrass",
+    "stackSize": 64
+  },
+  {
+    "id": 32,
+    "displayName": "Dead Bush",
+    "name": "deadbush",
+    "stackSize": 64
+  },
+  {
+    "id": 33,
+    "displayName": "Piston",
+    "name": "piston",
+    "stackSize": 64
+  },
+  {
+    "id": 34,
+    "displayName": "Piston Head",
+    "name": "piston_head",
+    "stackSize": 64
+  },
+  {
+    "id": 35,
+    "displayName": "Wool",
+    "name": "wool",
+    "stackSize": 64
+  },
+  {
+    "id": 36,
+    "displayName": "Block moved by Piston",
+    "name": "piston_extension",
+    "stackSize": 64
+  },
+  {
+    "id": 37,
+    "displayName": "Dandelion",
+    "name": "yellow_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 38,
+    "displayName": "Poppy",
+    "name": "red_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 39,
+    "displayName": "Brown Mushroom",
+    "name": "brown_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 40,
+    "displayName": "Red Mushroom",
+    "name": "red_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 41,
+    "displayName": "Block of Gold",
+    "name": "gold_block",
+    "stackSize": 64
+  },
+  {
+    "id": 42,
+    "displayName": "Block of Iron",
+    "name": "iron_block",
+    "stackSize": 64
+  },
+  {
+    "id": 43,
+    "displayName": "Double Stone Slab",
+    "name": "double_stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 44,
+    "displayName": "Stone Slab",
+    "name": "stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 45,
+    "displayName": "Bricks",
+    "name": "brick_block",
+    "stackSize": 64
+  },
+  {
+    "id": 46,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 47,
+    "displayName": "Bookshelf",
+    "name": "bookshelf",
+    "stackSize": 64
+  },
+  {
+    "id": 48,
+    "displayName": "Moss Stone",
+    "name": "mossy_cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 49,
+    "displayName": "Obsidian",
+    "name": "obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 50,
+    "displayName": "Torch",
+    "name": "torch",
+    "stackSize": 64
+  },
+  {
+    "id": 51,
+    "displayName": "Fire",
+    "name": "fire",
+    "stackSize": 64
+  },
+  {
+    "id": 52,
+    "displayName": "Monster Spawner",
+    "name": "mob_spawner",
+    "stackSize": 64
+  },
+  {
+    "id": 53,
+    "displayName": "Oak Wood Stairs",
+    "name": "oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 54,
+    "displayName": "Chest",
+    "name": "chest",
+    "stackSize": 64
+  },
+  {
+    "id": 55,
+    "displayName": "Redstone Wire",
+    "name": "redstone_wire",
+    "stackSize": 64
+  },
+  {
+    "id": 56,
+    "displayName": "Diamond Ore",
+    "name": "diamond_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 57,
+    "displayName": "Block of Diamond",
+    "name": "diamond_block",
+    "stackSize": 64
+  },
+  {
+    "id": 58,
+    "displayName": "Crafting Table",
+    "name": "crafting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 60,
+    "displayName": "Farmland",
+    "name": "farmland",
+    "stackSize": 64
+  },
+  {
+    "id": 61,
+    "displayName": "Furnace",
+    "name": "furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 62,
+    "displayName": "Burning Furnace",
+    "name": "lit_furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 63,
+    "displayName": "Standing Sign",
+    "name": "standing_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 65,
+    "displayName": "Ladder",
+    "name": "ladder",
+    "stackSize": 64
+  },
+  {
+    "id": 66,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 67,
+    "displayName": "Cobblestone Stairs",
+    "name": "stone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 68,
+    "displayName": "Wall Sign",
+    "name": "wall_sign",
+    "stackSize": 64
+  },
+  {
+    "id": 69,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 70,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 72,
+    "displayName": "Wooden Pressure Plate",
+    "name": "wooden_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 73,
+    "displayName": "Redstone Ore",
+    "name": "redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 74,
+    "displayName": "Glowing Redstone Ore",
+    "name": "lit_redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 75,
+    "displayName": "Redstone Torch (inactive)",
+    "name": "unlit_redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 76,
+    "displayName": "Redstone Torch (active)",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 77,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 78,
+    "displayName": "Snow (layer)",
+    "name": "snow_layer",
+    "stackSize": 64
+  },
+  {
+    "id": 79,
+    "displayName": "Ice",
+    "name": "ice",
+    "stackSize": 64
+  },
+  {
+    "id": 80,
+    "displayName": "Snow",
+    "name": "snow",
+    "stackSize": 64
+  },
+  {
+    "id": 81,
+    "displayName": "Cactus",
+    "name": "cactus",
+    "stackSize": 64
+  },
+  {
+    "id": 82,
+    "displayName": "Clay",
+    "name": "clay",
+    "stackSize": 64
+  },
+  {
+    "id": 84,
+    "displayName": "Jukebox",
+    "name": "jukebox",
+    "stackSize": 64
+  },
+  {
+    "id": 85,
+    "displayName": "Fence",
+    "name": "fence",
+    "stackSize": 64
+  },
+  {
+    "id": 86,
+    "displayName": "Pumpkin",
+    "name": "pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 87,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 88,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 89,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 90,
+    "displayName": "Nether Portal",
+    "name": "portal",
+    "stackSize": 64
+  },
+  {
+    "id": 91,
+    "displayName": "Jack o'Lantern",
+    "name": "lit_pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 93,
+    "displayName": "Redstone Repeater (inactive)",
+    "name": "unpowered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 94,
+    "displayName": "Redstone Repeater (active)",
+    "name": "powered_repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 95,
+    "displayName": "Stained Glass",
+    "name": "stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 96,
+    "displayName": "Trapdoor",
+    "name": "trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 97,
+    "displayName": "Monster Egg",
+    "name": "monster_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 98,
+    "displayName": "Stone Bricks",
+    "name": "stonebrick",
+    "stackSize": 64
+  },
+  {
+    "id": 99,
+    "displayName": "Brown Mushroom (block)",
+    "name": "brown_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 100,
+    "displayName": "Red Mushroom (block)",
+    "name": "red_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 101,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 102,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 103,
+    "displayName": "Melon",
+    "name": "melon_block",
+    "stackSize": 64
+  },
+  {
+    "id": 104,
+    "displayName": "Pumpkin Stem",
+    "name": "pumpkin_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 105,
+    "displayName": "Melon Stem",
+    "name": "melon_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 106,
+    "displayName": "Vines",
+    "name": "vine",
+    "stackSize": 64
+  },
+  {
+    "id": 107,
+    "displayName": "Fence Gate",
+    "name": "fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 108,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 109,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 110,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 111,
+    "displayName": "Lily Pad",
+    "name": "waterlily",
+    "stackSize": 64
+  },
+  {
+    "id": 112,
+    "displayName": "Nether Brick",
+    "name": "nether_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 113,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 114,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 116,
+    "displayName": "Enchantment Table",
+    "name": "enchanting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 119,
+    "displayName": "End Portal",
+    "name": "end_portal",
+    "stackSize": 64
+  },
+  {
+    "id": 120,
+    "displayName": "End Portal Frame",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 121,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 122,
+    "displayName": "Dragon Egg",
+    "name": "dragon_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 123,
+    "displayName": "Redstone Lamp (inactive)",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 124,
+    "displayName": "Redstone Lamp (active)",
+    "name": "lit_redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 125,
+    "displayName": "Double Wooden Slab",
+    "name": "double_wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 126,
+    "displayName": "Wooden Slab",
+    "name": "wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 127,
+    "displayName": "Cocoa",
+    "name": "cocoa",
+    "stackSize": 64
+  },
+  {
+    "id": 128,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 129,
+    "displayName": "Emerald Ore",
+    "name": "emerald_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 130,
+    "displayName": "Ender Chest",
+    "name": "ender_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 131,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 132,
+    "displayName": "Tripwire",
+    "name": "tripwire",
+    "stackSize": 64
+  },
+  {
+    "id": 133,
+    "displayName": "Block of Emerald",
+    "name": "emerald_block",
+    "stackSize": 64
+  },
+  {
+    "id": 134,
+    "displayName": "Spruce Wood Stairs",
+    "name": "spruce_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 135,
+    "displayName": "Birch Wood Stairs",
+    "name": "birch_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 136,
+    "displayName": "Jungle Wood Stairs",
+    "name": "jungle_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 137,
+    "displayName": "Command Block",
+    "name": "command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 138,
+    "displayName": "Beacon",
+    "name": "beacon",
+    "stackSize": 64
+  },
+  {
+    "id": 139,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 141,
+    "displayName": "Carrot",
+    "name": "carrots",
+    "stackSize": 64
+  },
+  {
+    "id": 142,
+    "displayName": "Potato",
+    "name": "potatoes",
+    "stackSize": 64
+  },
+  {
+    "id": 143,
+    "displayName": "Wooden Button",
+    "name": "wooden_button",
+    "stackSize": 64
+  },
+  {
+    "id": 145,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 146,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 147,
+    "displayName": "Weighted Pressure Plate (Light)",
+    "name": "light_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 148,
+    "displayName": "Weighted Pressure Plate (Heavy)",
+    "name": "heavy_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 149,
+    "displayName": "Redstone Comparator",
+    "name": "unpowered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 150,
+    "displayName": "Redstone Comparator (deprecated)",
+    "name": "powered_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 151,
+    "displayName": "Daylight Sensor",
+    "name": "daylight_detector",
+    "stackSize": 64
+  },
+  {
+    "id": 152,
+    "displayName": "Block of Redstone",
+    "name": "redstone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 153,
+    "displayName": "Nether Quartz Ore",
+    "name": "quartz_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 154,
+    "displayName": "Hopper",
+    "name": "hopper",
+    "stackSize": 64
+  },
+  {
+    "id": 155,
+    "displayName": "Block of Quartz",
+    "name": "quartz_block",
+    "stackSize": 64
+  },
+  {
+    "id": 156,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 157,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 158,
+    "displayName": "Dropper",
+    "name": "dropper",
+    "stackSize": 64
+  },
+  {
+    "id": 159,
+    "displayName": "Stained Clay",
+    "name": "stained_hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 160,
+    "displayName": "Stained Glass Pane",
+    "name": "stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 161,
+    "displayName": "Leaves (Acacia/Dark Oak)",
+    "name": "leaves2",
+    "stackSize": 64
+  },
+  {
+    "id": 162,
+    "displayName": "Wood (Acacia/Dark Oak)",
+    "name": "log2",
+    "stackSize": 64
+  },
+  {
+    "id": 163,
+    "displayName": "Acacia Wood Stairs",
+    "name": "acacia_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 164,
+    "displayName": "Dark Oak Wood Stairs",
+    "name": "dark_oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 165,
+    "displayName": "Slime Block",
+    "name": "slime",
+    "stackSize": 64
+  },
+  {
+    "id": 166,
+    "displayName": "Barrier",
+    "name": "barrier",
+    "stackSize": 64
+  },
+  {
+    "id": 167,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 168,
+    "displayName": "Prismarine",
+    "name": "prismarine",
+    "stackSize": 64
+  },
+  {
+    "id": 169,
+    "displayName": "Sea Lantern",
+    "name": "sea_lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 170,
+    "displayName": "Hay Bale",
+    "name": "hay_block",
+    "stackSize": 64
+  },
+  {
+    "id": 171,
+    "displayName": "Carpet",
+    "name": "carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 172,
+    "displayName": "Hardened Clay",
+    "name": "hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 173,
+    "displayName": "Block of Coal",
+    "name": "coal_block",
+    "stackSize": 64
+  },
+  {
+    "id": 174,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 175,
+    "displayName": "Large Flowers",
+    "name": "double_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 176,
+    "displayName": "Standing Banner",
+    "name": "standing_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 177,
+    "displayName": "Wall Banner",
+    "name": "wall_banner",
+    "stackSize": 64
+  },
+  {
+    "id": 178,
+    "displayName": "Inverted Daylight Sensor",
+    "name": "daylight_detector_inverted",
+    "stackSize": 64
+  },
+  {
+    "id": 179,
+    "displayName": "Red Sandstone",
+    "name": "red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 180,
+    "displayName": "Red Sandstone Stairs",
+    "name": "red_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 181,
+    "displayName": "Double Red Sandstone Slab",
+    "name": "double_stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 182,
+    "displayName": "Red Sandstone Slab",
+    "name": "stone_slab2",
+    "stackSize": 64
+  },
+  {
+    "id": 183,
+    "displayName": "Spruce Fence Gate",
+    "name": "spruce_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 184,
+    "displayName": "Birch Fence Gate",
+    "name": "birch_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 185,
+    "displayName": "Jungle Fence Gate",
+    "name": "jungle_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 186,
+    "displayName": "Dark Oak Fence Gate",
+    "name": "dark_oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 187,
+    "displayName": "Acacia Fence Gate",
+    "name": "acacia_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 188,
+    "displayName": "Spruce Fence",
+    "name": "spruce_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 189,
+    "displayName": "Birch Fence",
+    "name": "birch_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 190,
+    "displayName": "Jungle Fence",
+    "name": "jungle_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 191,
+    "displayName": "Dark Oak Fence",
+    "name": "dark_oak_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 192,
+    "displayName": "Acacia Fence",
+    "name": "acacia_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 198,
+    "displayName": "End Rod",
+    "name": "end_rod",
+    "stackSize": 64
+  },
+  {
+    "id": 199,
+    "displayName": "Chorus Plant",
+    "name": "chorus_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 200,
+    "displayName": "Chorus Flower",
+    "name": "chorus_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 201,
+    "displayName": "Purpur Block",
+    "name": "purpur_block",
+    "stackSize": 64
+  },
+  {
+    "id": 202,
+    "displayName": "Purpur Pillar",
+    "name": "purpur_pillar",
+    "stackSize": 64
+  },
+  {
+    "id": 203,
+    "displayName": "Purpur Stairs",
+    "name": "purpur_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 204,
+    "displayName": "Purpur Double Slab",
+    "name": "purpur_double_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 205,
+    "displayName": "Purpur Slab",
+    "name": "purpur_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 206,
+    "displayName": "End Stone Bricks",
+    "name": "end_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 207,
+    "displayName": "Beetroot Seeds",
+    "name": "beetroots",
+    "stackSize": 64
+  },
+  {
+    "id": 208,
+    "displayName": "Grass Path",
+    "name": "grass_path",
+    "stackSize": 64
+  },
+  {
+    "id": 209,
+    "displayName": "End Gateway",
+    "name": "end_gateway",
+    "stackSize": 64
+  },
+  {
+    "id": 210,
+    "displayName": "Repeating Command Block",
+    "name": "repeating_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 211,
+    "displayName": "Chain Command Block",
+    "name": "chain_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 212,
+    "displayName": "Frosted Ice",
+    "name": "frosted_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 255,
+    "displayName": "Structure Block",
+    "name": "structure_block",
+    "stackSize": 64
+  },
+  {
     "id": 256,
     "displayName": "Iron Shovel",
     "stackSize": 1,

--- a/data/pe/0.14/items.json
+++ b/data/pe/0.14/items.json
@@ -1,5 +1,869 @@
 [
   {
+    "id": 0,
+    "displayName": "Air",
+    "name": "air",
+    "stackSize": 64
+  },
+  {
+    "id": 1,
+    "displayName": "Stone",
+    "name": "stone",
+    "stackSize": 64
+  },
+  {
+    "id": 2,
+    "displayName": "Grass Block",
+    "name": "grass_block",
+    "stackSize": 64
+  },
+  {
+    "id": 3,
+    "displayName": "Dirt",
+    "name": "dirt",
+    "stackSize": 64
+  },
+  {
+    "id": 4,
+    "displayName": "Cobblestone",
+    "name": "cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 5,
+    "displayName": "Wood Planks",
+    "name": "wood_planks",
+    "stackSize": 64
+  },
+  {
+    "id": 6,
+    "displayName": "Sapling",
+    "name": "sapling",
+    "stackSize": 64
+  },
+  {
+    "id": 7,
+    "displayName": "Bedrock",
+    "name": "bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 8,
+    "displayName": "Water",
+    "name": "water",
+    "stackSize": 64
+  },
+  {
+    "id": 10,
+    "displayName": "Lava",
+    "name": "lava",
+    "stackSize": 64
+  },
+  {
+    "id": 12,
+    "displayName": "Sand",
+    "name": "sand",
+    "stackSize": 64
+  },
+  {
+    "id": 13,
+    "displayName": "Gravel",
+    "name": "gravel",
+    "stackSize": 64
+  },
+  {
+    "id": 14,
+    "displayName": "Gold Ore",
+    "name": "gold_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 15,
+    "displayName": "Iron Ore",
+    "name": "iron_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 16,
+    "displayName": "Coal Ore",
+    "name": "coal_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 17,
+    "displayName": "Wood",
+    "name": "wood",
+    "stackSize": 64
+  },
+  {
+    "id": 18,
+    "displayName": "Leaves",
+    "name": "leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 19,
+    "displayName": "Sponge",
+    "name": "sponge",
+    "stackSize": 64
+  },
+  {
+    "id": 20,
+    "displayName": "Glass",
+    "name": "glass",
+    "stackSize": 64
+  },
+  {
+    "id": 21,
+    "displayName": "Lapis Lazuli Ore",
+    "name": "lapis_lazuli_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 22,
+    "displayName": "Lapis Lazuli Block",
+    "name": "lapis_lazuli_block",
+    "stackSize": 64
+  },
+  {
+    "id": 23,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 24,
+    "displayName": "Sandstone",
+    "name": "sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 25,
+    "displayName": "Note Block",
+    "name": "note_block",
+    "stackSize": 64
+  },
+  {
+    "id": 27,
+    "displayName": "Powered Rail",
+    "name": "powered_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 28,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 30,
+    "displayName": "Cobweb",
+    "name": "cobweb",
+    "stackSize": 64
+  },
+  {
+    "id": 31,
+    "displayName": "Tall Grass",
+    "name": "tall_grass",
+    "stackSize": 64
+  },
+  {
+    "id": 32,
+    "displayName": "Dead Bush",
+    "name": "dead_bush",
+    "stackSize": 64
+  },
+  {
+    "id": 35,
+    "displayName": "Wool",
+    "name": "wool",
+    "stackSize": 64
+  },
+  {
+    "id": 37,
+    "displayName": "Dandelion",
+    "name": "dandelion",
+    "stackSize": 64
+  },
+  {
+    "id": 38,
+    "displayName": "Flower",
+    "name": "flower",
+    "stackSize": 64
+  },
+  {
+    "id": 39,
+    "displayName": "Brown Mushroom",
+    "name": "brown_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 40,
+    "displayName": "Red Mushroom",
+    "name": "red_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 41,
+    "displayName": "Block of Gold",
+    "name": "block_of_gold",
+    "stackSize": 64
+  },
+  {
+    "id": 42,
+    "displayName": "Block of Iron",
+    "name": "block_of_iron",
+    "stackSize": 64
+  },
+  {
+    "id": 43,
+    "displayName": "Double Stone Slab",
+    "name": "double_stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 44,
+    "displayName": "Stone Slab",
+    "name": "stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 45,
+    "displayName": "Bricks",
+    "name": "bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 46,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 47,
+    "displayName": "Bookshelf",
+    "name": "bookshelf",
+    "stackSize": 64
+  },
+  {
+    "id": 48,
+    "displayName": "Moss Stone",
+    "name": "moss_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 49,
+    "displayName": "Obsidian",
+    "name": "obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 50,
+    "displayName": "Torch",
+    "name": "torch",
+    "stackSize": 64
+  },
+  {
+    "id": 51,
+    "displayName": "Fire",
+    "name": "fire",
+    "stackSize": 64
+  },
+  {
+    "id": 52,
+    "displayName": "Monster Spawner",
+    "name": "monster_spawner",
+    "stackSize": 64
+  },
+  {
+    "id": 53,
+    "displayName": "Oak Wood Stairs",
+    "name": "oak_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 54,
+    "displayName": "Chest",
+    "name": "chest",
+    "stackSize": 64
+  },
+  {
+    "id": 55,
+    "displayName": "Redstone Wire",
+    "name": "redstone_wire",
+    "stackSize": 64
+  },
+  {
+    "id": 56,
+    "displayName": "Diamond Ore",
+    "name": "diamond_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 57,
+    "displayName": "Block of Diamond",
+    "name": "block_of_diamond",
+    "stackSize": 64
+  },
+  {
+    "id": 58,
+    "displayName": "Crafting Table",
+    "name": "crafting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 59,
+    "displayName": "Crops",
+    "name": "crops",
+    "stackSize": 64
+  },
+  {
+    "id": 60,
+    "displayName": "Farmland",
+    "name": "farmland",
+    "stackSize": 64
+  },
+  {
+    "id": 61,
+    "displayName": "Furnace",
+    "name": "furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 65,
+    "displayName": "Ladder",
+    "name": "ladder",
+    "stackSize": 64
+  },
+  {
+    "id": 66,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 67,
+    "displayName": "Cobblestone Stairs",
+    "name": "cobblestone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 69,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 70,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 72,
+    "displayName": "Wooden Pressure Plate",
+    "name": "wooden_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 73,
+    "displayName": "Redstone Ore",
+    "name": "redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 75,
+    "displayName": "Redstone Torch (inactive)",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 77,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 78,
+    "displayName": "Top Snow",
+    "name": "top_snow",
+    "stackSize": 64
+  },
+  {
+    "id": 79,
+    "displayName": "Ice",
+    "name": "ice",
+    "stackSize": 64
+  },
+  {
+    "id": 80,
+    "displayName": "Snow",
+    "name": "snow",
+    "stackSize": 64
+  },
+  {
+    "id": 81,
+    "displayName": "Cactus",
+    "name": "cactus",
+    "stackSize": 64
+  },
+  {
+    "id": 85,
+    "displayName": "Fence",
+    "name": "fence",
+    "stackSize": 64
+  },
+  {
+    "id": 86,
+    "displayName": "Pumpkin",
+    "name": "pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 87,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 88,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 89,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 90,
+    "displayName": "Portal",
+    "name": "portal",
+    "stackSize": 64
+  },
+  {
+    "id": 91,
+    "displayName": "Jack o'Lantern",
+    "name": "jack_o'lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 95,
+    "displayName": "Invisible Bedrock",
+    "name": "invisible_bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 96,
+    "displayName": "Trapdoor",
+    "name": "trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 97,
+    "displayName": "Monster Egg",
+    "name": "monster_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 98,
+    "displayName": "Stone Brick",
+    "name": "stone_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 101,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 102,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 104,
+    "displayName": "Pumpkin Stem",
+    "name": "pumpkin_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 105,
+    "displayName": "Melon Stem",
+    "name": "melon_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 106,
+    "displayName": "Vines",
+    "name": "vines",
+    "stackSize": 64
+  },
+  {
+    "id": 107,
+    "displayName": "Fence Gate",
+    "name": "fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 108,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 109,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 110,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 111,
+    "displayName": "Lily Pad",
+    "name": "lily_pad",
+    "stackSize": 64
+  },
+  {
+    "id": 113,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 114,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 116,
+    "displayName": "Enchantment Table",
+    "name": "enchantment_table",
+    "stackSize": 64
+  },
+  {
+    "id": 120,
+    "displayName": "End Portal Frame",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 121,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 122,
+    "displayName": "Redstone Lamp (inactive)",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 126,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 127,
+    "displayName": "Cocoa",
+    "name": "cocoa",
+    "stackSize": 64
+  },
+  {
+    "id": 128,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 129,
+    "displayName": "Emerald Ore",
+    "name": "emerald_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 131,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 132,
+    "displayName": "Tripwire",
+    "name": "tripwire",
+    "stackSize": 64
+  },
+  {
+    "id": 133,
+    "displayName": "Block of Emerald",
+    "name": "block_of_emerald",
+    "stackSize": 64
+  },
+  {
+    "id": 134,
+    "displayName": "Spruce Wood Stairs",
+    "name": "spruce_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 135,
+    "displayName": "Birch Wood Stairs",
+    "name": "birch_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 136,
+    "displayName": "Jungle Wood Stairs",
+    "name": "jungle_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 139,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 141,
+    "displayName": "Carrots",
+    "name": "carrots",
+    "stackSize": 64
+  },
+  {
+    "id": 143,
+    "displayName": "Wooden Button",
+    "name": "wooden_button",
+    "stackSize": 64
+  },
+  {
+    "id": 145,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 146,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 147,
+    "displayName": "Weighted Pressure Plate (Light)",
+    "name": "weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 151,
+    "displayName": "Daylight Sensor",
+    "name": "daylight_sensor",
+    "stackSize": 64
+  },
+  {
+    "id": 152,
+    "displayName": "Block of Redstone",
+    "name": "block_of_redstone",
+    "stackSize": 64
+  },
+  {
+    "id": 153,
+    "displayName": "Nether Quartz Ore",
+    "name": "nether_quartz_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 155,
+    "displayName": "Block of Quartz",
+    "name": "block_of_quartz",
+    "stackSize": 64
+  },
+  {
+    "id": 156,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 157,
+    "displayName": "Wooden Double Slab",
+    "name": "wooden_double_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 158,
+    "displayName": "Wooden Slab",
+    "name": "wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 159,
+    "displayName": "Stained Clay",
+    "name": "stained_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 161,
+    "displayName": "Acacia Leaves",
+    "name": "acacia_leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 162,
+    "displayName": "Acacia Wood",
+    "name": "acacia_wood",
+    "stackSize": 64
+  },
+  {
+    "id": 163,
+    "displayName": "Acacia Wood Stairs",
+    "name": "acacia_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 164,
+    "displayName": "Dark Oak Wood Stairs",
+    "name": "dark_oak_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 167,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 170,
+    "displayName": "Hay Bale",
+    "name": "hay_bale",
+    "stackSize": 64
+  },
+  {
+    "id": 171,
+    "displayName": "Carpet",
+    "name": "carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 172,
+    "displayName": "Hardened Clay",
+    "name": "hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 173,
+    "displayName": "Block of Coal",
+    "name": "block_of_coal",
+    "stackSize": 64
+  },
+  {
+    "id": 174,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 175,
+    "displayName": "Sunflower",
+    "name": "sunflower",
+    "stackSize": 64
+  },
+  {
+    "id": 178,
+    "displayName": "Inverted Daylight Sensor",
+    "name": "inverted_daylight_sensor",
+    "stackSize": 64
+  },
+  {
+    "id": 183,
+    "displayName": "Spruce Fence Gate",
+    "name": "spruce_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 184,
+    "displayName": "Birch Fence Gate",
+    "name": "birch_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 185,
+    "displayName": "Jungle Fence Gate",
+    "name": "jungle_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 186,
+    "displayName": "Dark Oak Fence Gate",
+    "name": "dark_oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 187,
+    "displayName": "Acacia Fence Gate",
+    "name": "acacia_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 198,
+    "displayName": "Grass Path",
+    "name": "grass_path",
+    "stackSize": 64
+  },
+  {
+    "id": 199,
+    "displayName": "Item Frame",
+    "name": "item_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 243,
+    "displayName": "Podzol",
+    "name": "podzol",
+    "stackSize": 64
+  },
+  {
+    "id": 245,
+    "displayName": "Stonecutter",
+    "name": "stonecutter",
+    "stackSize": 64
+  },
+  {
+    "id": 246,
+    "displayName": "Glowing Obsidian",
+    "name": "glowing_obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 247,
+    "displayName": "Nether Reactor Core",
+    "name": "nether_reactor_core",
+    "stackSize": 64
+  },
+  {
+    "id": 248,
+    "displayName": "Update Game Block (update!)",
+    "name": "update_game_block",
+    "stackSize": 64
+  },
+  {
+    "id": 255,
+    "displayName": "info_reserved6",
+    "name": "info_reserved6",
+    "stackSize": 64
+  },
+  {
     "id": 256,
     "displayName": "Iron Shovel",
     "stackSize": 1,

--- a/data/pe/0.15/items.json
+++ b/data/pe/0.15/items.json
@@ -1,5 +1,935 @@
 [
   {
+    "id": 0,
+    "displayName": "Air",
+    "name": "air",
+    "stackSize": 64
+  },
+  {
+    "id": 1,
+    "displayName": "Stone",
+    "name": "stone",
+    "stackSize": 64
+  },
+  {
+    "id": 2,
+    "displayName": "Grass Block",
+    "name": "grass_block",
+    "stackSize": 64
+  },
+  {
+    "id": 3,
+    "displayName": "Dirt",
+    "name": "dirt",
+    "stackSize": 64
+  },
+  {
+    "id": 4,
+    "displayName": "Cobblestone",
+    "name": "cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 5,
+    "displayName": "Wood Planks",
+    "name": "wood_planks",
+    "stackSize": 64
+  },
+  {
+    "id": 6,
+    "displayName": "Sapling",
+    "name": "sapling",
+    "stackSize": 64
+  },
+  {
+    "id": 7,
+    "displayName": "Bedrock",
+    "name": "bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 8,
+    "displayName": "Water",
+    "name": "water",
+    "stackSize": 64
+  },
+  {
+    "id": 10,
+    "displayName": "Lava",
+    "name": "lava",
+    "stackSize": 64
+  },
+  {
+    "id": 12,
+    "displayName": "Sand",
+    "name": "sand",
+    "stackSize": 64
+  },
+  {
+    "id": 13,
+    "displayName": "Gravel",
+    "name": "gravel",
+    "stackSize": 64
+  },
+  {
+    "id": 14,
+    "displayName": "Gold Ore",
+    "name": "gold_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 15,
+    "displayName": "Iron Ore",
+    "name": "iron_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 16,
+    "displayName": "Coal Ore",
+    "name": "coal_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 17,
+    "displayName": "Wood",
+    "name": "wood",
+    "stackSize": 64
+  },
+  {
+    "id": 18,
+    "displayName": "Leaves",
+    "name": "leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 19,
+    "displayName": "Sponge",
+    "name": "sponge",
+    "stackSize": 64
+  },
+  {
+    "id": 20,
+    "displayName": "Glass",
+    "name": "glass",
+    "stackSize": 64
+  },
+  {
+    "id": 21,
+    "displayName": "Lapis Lazuli Ore",
+    "name": "lapis_lazuli_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 22,
+    "displayName": "Lapis Lazuli Block",
+    "name": "lapis_lazuli_block",
+    "stackSize": 64
+  },
+  {
+    "id": 23,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 24,
+    "displayName": "Sandstone",
+    "name": "sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 25,
+    "displayName": "Note Block",
+    "name": "note_block",
+    "stackSize": 64
+  },
+  {
+    "id": 27,
+    "displayName": "Powered Rail",
+    "name": "powered_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 28,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 29,
+    "displayName": "Sticky Piston",
+    "name": "sticky_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 30,
+    "displayName": "Cobweb",
+    "name": "cobweb",
+    "stackSize": 64
+  },
+  {
+    "id": 31,
+    "displayName": "Tall Grass",
+    "name": "tall_grass",
+    "stackSize": 64
+  },
+  {
+    "id": 32,
+    "displayName": "Dead Bush",
+    "name": "dead_bush",
+    "stackSize": 64
+  },
+  {
+    "id": 33,
+    "displayName": "Piston",
+    "name": "piston",
+    "stackSize": 64
+  },
+  {
+    "id": 34,
+    "displayName": "Piston Head",
+    "name": "piston_head",
+    "stackSize": 64
+  },
+  {
+    "id": 35,
+    "displayName": "Wool",
+    "name": "wool",
+    "stackSize": 64
+  },
+  {
+    "id": 37,
+    "displayName": "Dandelion",
+    "name": "dandelion",
+    "stackSize": 64
+  },
+  {
+    "id": 38,
+    "displayName": "Flower",
+    "name": "flower",
+    "stackSize": 64
+  },
+  {
+    "id": 39,
+    "displayName": "Brown Mushroom",
+    "name": "brown_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 40,
+    "displayName": "Red Mushroom",
+    "name": "red_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 41,
+    "displayName": "Block of Gold",
+    "name": "block_of_gold",
+    "stackSize": 64
+  },
+  {
+    "id": 42,
+    "displayName": "Block of Iron",
+    "name": "block_of_iron",
+    "stackSize": 64
+  },
+  {
+    "id": 43,
+    "displayName": "Double Stone Slab",
+    "name": "double_stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 44,
+    "displayName": "Stone Slab",
+    "name": "stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 45,
+    "displayName": "Bricks",
+    "name": "bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 46,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 47,
+    "displayName": "Bookshelf",
+    "name": "bookshelf",
+    "stackSize": 64
+  },
+  {
+    "id": 48,
+    "displayName": "Moss Stone",
+    "name": "moss_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 49,
+    "displayName": "Obsidian",
+    "name": "obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 50,
+    "displayName": "Torch",
+    "name": "torch",
+    "stackSize": 64
+  },
+  {
+    "id": 51,
+    "displayName": "Fire",
+    "name": "fire",
+    "stackSize": 64
+  },
+  {
+    "id": 52,
+    "displayName": "Monster Spawner",
+    "name": "monster_spawner",
+    "stackSize": 64
+  },
+  {
+    "id": 53,
+    "displayName": "Oak Wood Stairs",
+    "name": "oak_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 54,
+    "displayName": "Chest",
+    "name": "chest",
+    "stackSize": 64
+  },
+  {
+    "id": 55,
+    "displayName": "Redstone Wire",
+    "name": "redstone_wire",
+    "stackSize": 64
+  },
+  {
+    "id": 56,
+    "displayName": "Diamond Ore",
+    "name": "diamond_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 57,
+    "displayName": "Block of Diamond",
+    "name": "block_of_diamond",
+    "stackSize": 64
+  },
+  {
+    "id": 58,
+    "displayName": "Crafting Table",
+    "name": "crafting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 59,
+    "displayName": "Crops",
+    "name": "crops",
+    "stackSize": 64
+  },
+  {
+    "id": 60,
+    "displayName": "Farmland",
+    "name": "farmland",
+    "stackSize": 64
+  },
+  {
+    "id": 61,
+    "displayName": "Furnace",
+    "name": "furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 65,
+    "displayName": "Ladder",
+    "name": "ladder",
+    "stackSize": 64
+  },
+  {
+    "id": 66,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 67,
+    "displayName": "Cobblestone Stairs",
+    "name": "cobblestone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 69,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 70,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 72,
+    "displayName": "Wooden Pressure Plate",
+    "name": "wooden_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 73,
+    "displayName": "Redstone Ore",
+    "name": "redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 75,
+    "displayName": "Redstone Torch (inactive)",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 77,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 78,
+    "displayName": "Top Snow",
+    "name": "top_snow",
+    "stackSize": 64
+  },
+  {
+    "id": 79,
+    "displayName": "Ice",
+    "name": "ice",
+    "stackSize": 64
+  },
+  {
+    "id": 80,
+    "displayName": "Snow",
+    "name": "snow",
+    "stackSize": 64
+  },
+  {
+    "id": 81,
+    "displayName": "Cactus",
+    "name": "cactus",
+    "stackSize": 64
+  },
+  {
+    "id": 85,
+    "displayName": "Fence",
+    "name": "fence",
+    "stackSize": 64
+  },
+  {
+    "id": 86,
+    "displayName": "Pumpkin",
+    "name": "pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 87,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 88,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 89,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 90,
+    "displayName": "Portal",
+    "name": "portal",
+    "stackSize": 64
+  },
+  {
+    "id": 91,
+    "displayName": "Jack o'Lantern",
+    "name": "jack_o'lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 95,
+    "displayName": "Invisible Bedrock",
+    "name": "invisible_bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 96,
+    "displayName": "Trapdoor",
+    "name": "trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 97,
+    "displayName": "Monster Egg",
+    "name": "monster_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 98,
+    "displayName": "Stone Brick",
+    "name": "stone_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 101,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 102,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 104,
+    "displayName": "Pumpkin Stem",
+    "name": "pumpkin_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 105,
+    "displayName": "Melon Stem",
+    "name": "melon_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 106,
+    "displayName": "Vines",
+    "name": "vines",
+    "stackSize": 64
+  },
+  {
+    "id": 107,
+    "displayName": "Fence Gate",
+    "name": "fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 108,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 109,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 110,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 111,
+    "displayName": "Lily Pad",
+    "name": "lily_pad",
+    "stackSize": 64
+  },
+  {
+    "id": 113,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 114,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 116,
+    "displayName": "Enchantment Table",
+    "name": "enchantment_table",
+    "stackSize": 64
+  },
+  {
+    "id": 120,
+    "displayName": "End Portal Frame",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 121,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 123,
+    "displayName": "Redstone Lamp (inactive)",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 125,
+    "displayName": "Dropper",
+    "name": "dropper",
+    "stackSize": 64
+  },
+  {
+    "id": 126,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 127,
+    "displayName": "Cocoa",
+    "name": "cocoa",
+    "stackSize": 64
+  },
+  {
+    "id": 128,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 129,
+    "displayName": "Emerald Ore",
+    "name": "emerald_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 131,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 132,
+    "displayName": "Tripwire",
+    "name": "tripwire",
+    "stackSize": 64
+  },
+  {
+    "id": 133,
+    "displayName": "Block of Emerald",
+    "name": "block_of_emerald",
+    "stackSize": 64
+  },
+  {
+    "id": 134,
+    "displayName": "Spruce Wood Stairs",
+    "name": "spruce_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 135,
+    "displayName": "Birch Wood Stairs",
+    "name": "birch_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 136,
+    "displayName": "Jungle Wood Stairs",
+    "name": "jungle_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 139,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 141,
+    "displayName": "Carrots",
+    "name": "carrots",
+    "stackSize": 64
+  },
+  {
+    "id": 143,
+    "displayName": "Wooden Button",
+    "name": "wooden_button",
+    "stackSize": 64
+  },
+  {
+    "id": 145,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 146,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 147,
+    "displayName": "Weighted Pressure Plate (Light)",
+    "name": "weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 149,
+    "displayName": "Redstone Comparator (unpowered)",
+    "name": "redstone_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 151,
+    "displayName": "Daylight Sensor",
+    "name": "daylight_sensor",
+    "stackSize": 64
+  },
+  {
+    "id": 152,
+    "displayName": "Block of Redstone",
+    "name": "block_of_redstone",
+    "stackSize": 64
+  },
+  {
+    "id": 153,
+    "displayName": "Nether Quartz Ore",
+    "name": "nether_quartz_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 155,
+    "displayName": "Block of Quartz",
+    "name": "block_of_quartz",
+    "stackSize": 64
+  },
+  {
+    "id": 156,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 157,
+    "displayName": "Wooden Double Slab",
+    "name": "wooden_double_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 158,
+    "displayName": "Wooden Slab",
+    "name": "wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 159,
+    "displayName": "Stained Clay",
+    "name": "stained_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 161,
+    "displayName": "Acacia Leaves",
+    "name": "acacia_leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 162,
+    "displayName": "Acacia Wood",
+    "name": "acacia_wood",
+    "stackSize": 64
+  },
+  {
+    "id": 163,
+    "displayName": "Acacia Wood Stairs",
+    "name": "acacia_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 164,
+    "displayName": "Dark Oak Wood Stairs",
+    "name": "dark_oak_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 165,
+    "displayName": "Slime Block",
+    "name": "slime_block",
+    "stackSize": 64
+  },
+  {
+    "id": 167,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 170,
+    "displayName": "Hay Bale",
+    "name": "hay_bale",
+    "stackSize": 64
+  },
+  {
+    "id": 171,
+    "displayName": "Carpet",
+    "name": "carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 172,
+    "displayName": "Hardened Clay",
+    "name": "hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 173,
+    "displayName": "Block of Coal",
+    "name": "block_of_coal",
+    "stackSize": 64
+  },
+  {
+    "id": 174,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 175,
+    "displayName": "Sunflower",
+    "name": "sunflower",
+    "stackSize": 64
+  },
+  {
+    "id": 178,
+    "displayName": "Inverted Daylight Sensor",
+    "name": "inverted_daylight_sensor",
+    "stackSize": 64
+  },
+  {
+    "id": 179,
+    "displayName": "Red Sandstone",
+    "name": "red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 180,
+    "displayName": "Red Sandstone Stairs",
+    "name": "red_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 181,
+    "displayName": "Double Red Sandstone Slab",
+    "name": "double_red_sandstone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 182,
+    "displayName": "Red Sandstone Slab",
+    "name": "red_sandstone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 183,
+    "displayName": "Spruce Fence Gate",
+    "name": "spruce_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 184,
+    "displayName": "Birch Fence Gate",
+    "name": "birch_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 185,
+    "displayName": "Jungle Fence Gate",
+    "name": "jungle_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 186,
+    "displayName": "Dark Oak Fence Gate",
+    "name": "dark_oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 187,
+    "displayName": "Acacia Fence Gate",
+    "name": "acacia_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 198,
+    "displayName": "Grass Path",
+    "name": "grass_path",
+    "stackSize": 64
+  },
+  {
+    "id": 243,
+    "displayName": "Podzol",
+    "name": "podzol",
+    "stackSize": 64
+  },
+  {
+    "id": 245,
+    "displayName": "Stonecutter",
+    "name": "stonecutter",
+    "stackSize": 64
+  },
+  {
+    "id": 246,
+    "displayName": "Glowing Obsidian",
+    "name": "glowing_obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 247,
+    "displayName": "Nether Reactor Core",
+    "name": "nether_reactor_core",
+    "stackSize": 64
+  },
+  {
+    "id": 248,
+    "displayName": "Update Game Block (update!)",
+    "name": "update_game_block",
+    "stackSize": 64
+  },
+  {
+    "id": 250,
+    "displayName": "Block moved by Piston",
+    "name": "block_moved_by_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 251,
+    "displayName": "Observer",
+    "name": "observer",
+    "stackSize": 64
+  },
+  {
+    "id": 255,
+    "displayName": "info_reserved6",
+    "name": "info_reserved6",
+    "stackSize": 64
+  },
+  {
     "id": 256,
     "displayName": "Iron Shovel",
     "stackSize": 1,

--- a/data/pe/1.0/items.json
+++ b/data/pe/1.0/items.json
@@ -1,5 +1,1043 @@
 [
   {
+    "id": 0,
+    "displayName": "Air",
+    "name": "air",
+    "stackSize": 64
+  },
+  {
+    "id": 1,
+    "displayName": "Stone",
+    "name": "stone",
+    "stackSize": 64
+  },
+  {
+    "id": 2,
+    "displayName": "Grass Block",
+    "name": "grass_block",
+    "stackSize": 64
+  },
+  {
+    "id": 3,
+    "displayName": "Dirt",
+    "name": "dirt",
+    "stackSize": 64
+  },
+  {
+    "id": 4,
+    "displayName": "Cobblestone",
+    "name": "cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 5,
+    "displayName": "Wood Planks",
+    "name": "wood_planks",
+    "stackSize": 64
+  },
+  {
+    "id": 6,
+    "displayName": "Sapling",
+    "name": "sapling",
+    "stackSize": 64
+  },
+  {
+    "id": 7,
+    "displayName": "Bedrock",
+    "name": "bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 8,
+    "displayName": "Water",
+    "name": "water",
+    "stackSize": 64
+  },
+  {
+    "id": 10,
+    "displayName": "Lava",
+    "name": "lava",
+    "stackSize": 64
+  },
+  {
+    "id": 12,
+    "displayName": "Sand",
+    "name": "sand",
+    "stackSize": 64
+  },
+  {
+    "id": 13,
+    "displayName": "Gravel",
+    "name": "gravel",
+    "stackSize": 64
+  },
+  {
+    "id": 14,
+    "displayName": "Gold Ore",
+    "name": "gold_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 15,
+    "displayName": "Iron Ore",
+    "name": "iron_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 16,
+    "displayName": "Coal Ore",
+    "name": "coal_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 17,
+    "displayName": "Wood",
+    "name": "wood",
+    "stackSize": 64
+  },
+  {
+    "id": 18,
+    "displayName": "Leaves",
+    "name": "leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 19,
+    "displayName": "Sponge",
+    "name": "sponge",
+    "stackSize": 64
+  },
+  {
+    "id": 20,
+    "displayName": "Glass",
+    "name": "glass",
+    "stackSize": 64
+  },
+  {
+    "id": 21,
+    "displayName": "Lapis Lazuli Ore",
+    "name": "lapis_lazuli_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 22,
+    "displayName": "Lapis Lazuli Block",
+    "name": "lapis_lazuli_block",
+    "stackSize": 64
+  },
+  {
+    "id": 23,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 24,
+    "displayName": "Sandstone",
+    "name": "sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 25,
+    "displayName": "Note Block",
+    "name": "note_block",
+    "stackSize": 64
+  },
+  {
+    "id": 27,
+    "displayName": "Powered Rail",
+    "name": "powered_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 28,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 29,
+    "displayName": "Sticky Piston",
+    "name": "sticky_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 30,
+    "displayName": "Cobweb",
+    "name": "cobweb",
+    "stackSize": 64
+  },
+  {
+    "id": 31,
+    "displayName": "Tall Grass",
+    "name": "tall_grass",
+    "stackSize": 64
+  },
+  {
+    "id": 32,
+    "displayName": "Dead Bush",
+    "name": "dead_bush",
+    "stackSize": 64
+  },
+  {
+    "id": 33,
+    "displayName": "Piston",
+    "name": "piston",
+    "stackSize": 64
+  },
+  {
+    "id": 34,
+    "displayName": "Piston Head",
+    "name": "piston_head",
+    "stackSize": 64
+  },
+  {
+    "id": 35,
+    "displayName": "Wool",
+    "name": "wool",
+    "stackSize": 64
+  },
+  {
+    "id": 37,
+    "displayName": "Dandelion",
+    "name": "dandelion",
+    "stackSize": 64
+  },
+  {
+    "id": 38,
+    "displayName": "Flower",
+    "name": "flower",
+    "stackSize": 64
+  },
+  {
+    "id": 39,
+    "displayName": "Brown Mushroom",
+    "name": "brown_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 40,
+    "displayName": "Red Mushroom",
+    "name": "red_mushroom",
+    "stackSize": 64
+  },
+  {
+    "id": 41,
+    "displayName": "Block of Gold",
+    "name": "block_of_gold",
+    "stackSize": 64
+  },
+  {
+    "id": 42,
+    "displayName": "Block of Iron",
+    "name": "block_of_iron",
+    "stackSize": 64
+  },
+  {
+    "id": 43,
+    "displayName": "Double Stone Slab",
+    "name": "double_stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 44,
+    "displayName": "Stone Slab",
+    "name": "stone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 45,
+    "displayName": "Bricks",
+    "name": "bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 46,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 47,
+    "displayName": "Bookshelf",
+    "name": "bookshelf",
+    "stackSize": 64
+  },
+  {
+    "id": 48,
+    "displayName": "Moss Stone",
+    "name": "moss_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 49,
+    "displayName": "Obsidian",
+    "name": "obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 50,
+    "displayName": "Torch",
+    "name": "torch",
+    "stackSize": 64
+  },
+  {
+    "id": 51,
+    "displayName": "Fire",
+    "name": "fire",
+    "stackSize": 64
+  },
+  {
+    "id": 52,
+    "displayName": "Monster Spawner",
+    "name": "monster_spawner",
+    "stackSize": 64
+  },
+  {
+    "id": 53,
+    "displayName": "Oak Wood Stairs",
+    "name": "oak_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 54,
+    "displayName": "Chest",
+    "name": "chest",
+    "stackSize": 64
+  },
+  {
+    "id": 55,
+    "displayName": "Redstone Wire",
+    "name": "redstone_wire",
+    "stackSize": 64
+  },
+  {
+    "id": 56,
+    "displayName": "Diamond Ore",
+    "name": "diamond_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 57,
+    "displayName": "Block of Diamond",
+    "name": "block_of_diamond",
+    "stackSize": 64
+  },
+  {
+    "id": 58,
+    "displayName": "Crafting Table",
+    "name": "crafting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 59,
+    "displayName": "Crops",
+    "name": "crops",
+    "stackSize": 64
+  },
+  {
+    "id": 60,
+    "displayName": "Farmland",
+    "name": "farmland",
+    "stackSize": 64
+  },
+  {
+    "id": 61,
+    "displayName": "Furnace",
+    "name": "furnace",
+    "stackSize": 64
+  },
+  {
+    "id": 65,
+    "displayName": "Ladder",
+    "name": "ladder",
+    "stackSize": 64
+  },
+  {
+    "id": 66,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 67,
+    "displayName": "Cobblestone Stairs",
+    "name": "cobblestone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 69,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 70,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 72,
+    "displayName": "Wooden Pressure Plate",
+    "name": "wooden_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 73,
+    "displayName": "Redstone Ore",
+    "name": "redstone_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 75,
+    "displayName": "Redstone Torch (inactive)",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 77,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 78,
+    "displayName": "Top Snow",
+    "name": "top_snow",
+    "stackSize": 64
+  },
+  {
+    "id": 79,
+    "displayName": "Ice",
+    "name": "ice",
+    "stackSize": 64
+  },
+  {
+    "id": 80,
+    "displayName": "Snow",
+    "name": "snow",
+    "stackSize": 64
+  },
+  {
+    "id": 81,
+    "displayName": "Cactus",
+    "name": "cactus",
+    "stackSize": 64
+  },
+  {
+    "id": 85,
+    "displayName": "Fence",
+    "name": "fence",
+    "stackSize": 64
+  },
+  {
+    "id": 86,
+    "displayName": "Pumpkin",
+    "name": "pumpkin",
+    "stackSize": 64
+  },
+  {
+    "id": 87,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 88,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 89,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 90,
+    "displayName": "Portal",
+    "name": "portal",
+    "stackSize": 64
+  },
+  {
+    "id": 91,
+    "displayName": "Jack o'Lantern",
+    "name": "jack_o'lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 95,
+    "displayName": "Invisible Bedrock",
+    "name": "invisible_bedrock",
+    "stackSize": 64
+  },
+  {
+    "id": 96,
+    "displayName": "Trapdoor",
+    "name": "trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 97,
+    "displayName": "Monster Egg",
+    "name": "monster_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 98,
+    "displayName": "Stone Brick",
+    "name": "stone_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 101,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 102,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 104,
+    "displayName": "Pumpkin Stem",
+    "name": "pumpkin_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 105,
+    "displayName": "Melon Stem",
+    "name": "melon_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 106,
+    "displayName": "Vines",
+    "name": "vines",
+    "stackSize": 64
+  },
+  {
+    "id": 107,
+    "displayName": "Fence Gate",
+    "name": "fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 108,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 109,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 110,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 111,
+    "displayName": "Lily Pad",
+    "name": "lily_pad",
+    "stackSize": 64
+  },
+  {
+    "id": 113,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 114,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 116,
+    "displayName": "Enchantment Table",
+    "name": "enchantment_table",
+    "stackSize": 64
+  },
+  {
+    "id": 119,
+    "displayName": "End Portal",
+    "name": "end_portal",
+    "stackSize": 64
+  },
+  {
+    "id": 120,
+    "displayName": "End Portal Frame",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 121,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 122,
+    "displayName": "Dragon Egg",
+    "name": "dragon_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 123,
+    "displayName": "Redstone Lamp (inactive)",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 125,
+    "displayName": "Dropper",
+    "name": "dropper",
+    "stackSize": 64
+  },
+  {
+    "id": 126,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 127,
+    "displayName": "Cocoa",
+    "name": "cocoa",
+    "stackSize": 64
+  },
+  {
+    "id": 128,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 129,
+    "displayName": "Emerald Ore",
+    "name": "emerald_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 130,
+    "displayName": "Ender Chest",
+    "name": "ender_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 131,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 132,
+    "displayName": "Tripwire",
+    "name": "tripwire",
+    "stackSize": 64
+  },
+  {
+    "id": 133,
+    "displayName": "Block of Emerald",
+    "name": "block_of_emerald",
+    "stackSize": 64
+  },
+  {
+    "id": 134,
+    "displayName": "Spruce Wood Stairs",
+    "name": "spruce_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 135,
+    "displayName": "Birch Wood Stairs",
+    "name": "birch_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 136,
+    "displayName": "Jungle Wood Stairs",
+    "name": "jungle_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 138,
+    "displayName": "Beacon",
+    "name": "beacon",
+    "stackSize": 64
+  },
+  {
+    "id": 139,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 141,
+    "displayName": "Carrots",
+    "name": "carrots",
+    "stackSize": 64
+  },
+  {
+    "id": 143,
+    "displayName": "Wooden Button",
+    "name": "wooden_button",
+    "stackSize": 64
+  },
+  {
+    "id": 145,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 146,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 147,
+    "displayName": "Weighted Pressure Plate (Light)",
+    "name": "weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 149,
+    "displayName": "Redstone Comparator (unpowered)",
+    "name": "redstone_comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 151,
+    "displayName": "Daylight Sensor",
+    "name": "daylight_sensor",
+    "stackSize": 64
+  },
+  {
+    "id": 152,
+    "displayName": "Block of Redstone",
+    "name": "block_of_redstone",
+    "stackSize": 64
+  },
+  {
+    "id": 153,
+    "displayName": "Nether Quartz Ore",
+    "name": "nether_quartz_ore",
+    "stackSize": 64
+  },
+  {
+    "id": 155,
+    "displayName": "Block of Quartz",
+    "name": "block_of_quartz",
+    "stackSize": 64
+  },
+  {
+    "id": 156,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 157,
+    "displayName": "Wooden Double Slab",
+    "name": "wooden_double_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 158,
+    "displayName": "Wooden Slab",
+    "name": "wooden_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 159,
+    "displayName": "Stained Clay",
+    "name": "stained_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 160,
+    "displayName": "Stained Glass Pane",
+    "name": "stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 161,
+    "displayName": "Acacia Leaves",
+    "name": "acacia_leaves",
+    "stackSize": 64
+  },
+  {
+    "id": 162,
+    "displayName": "Acacia Wood",
+    "name": "acacia_wood",
+    "stackSize": 64
+  },
+  {
+    "id": 163,
+    "displayName": "Acacia Wood Stairs",
+    "name": "acacia_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 164,
+    "displayName": "Dark Oak Wood Stairs",
+    "name": "dark_oak_wood_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 165,
+    "displayName": "Slime Block",
+    "name": "slime_block",
+    "stackSize": 64
+  },
+  {
+    "id": 167,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 168,
+    "displayName": "Prismarine",
+    "name": "prismarine",
+    "stackSize": 64
+  },
+  {
+    "id": 169,
+    "displayName": "Sea Lantern",
+    "name": "sea_lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 170,
+    "displayName": "Hay Bale",
+    "name": "hay_bale",
+    "stackSize": 64
+  },
+  {
+    "id": 171,
+    "displayName": "Carpet",
+    "name": "carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 172,
+    "displayName": "Hardened Clay",
+    "name": "hardened_clay",
+    "stackSize": 64
+  },
+  {
+    "id": 173,
+    "displayName": "Block of Coal",
+    "name": "block_of_coal",
+    "stackSize": 64
+  },
+  {
+    "id": 174,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 175,
+    "displayName": "Sunflower",
+    "name": "sunflower",
+    "stackSize": 64
+  },
+  {
+    "id": 178,
+    "displayName": "Inverted Daylight Sensor",
+    "name": "inverted_daylight_sensor",
+    "stackSize": 64
+  },
+  {
+    "id": 179,
+    "displayName": "Red Sandstone",
+    "name": "red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 180,
+    "displayName": "Red Sandstone Stairs",
+    "name": "red_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 181,
+    "displayName": "Double Red Sandstone Slab",
+    "name": "double_red_sandstone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 182,
+    "displayName": "Red Sandstone Slab",
+    "name": "red_sandstone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 183,
+    "displayName": "Spruce Fence Gate",
+    "name": "spruce_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 184,
+    "displayName": "Birch Fence Gate",
+    "name": "birch_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 185,
+    "displayName": "Jungle Fence Gate",
+    "name": "jungle_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 186,
+    "displayName": "Dark Oak Fence Gate",
+    "name": "dark_oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 187,
+    "displayName": "Acacia Fence Gate",
+    "name": "acacia_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 198,
+    "displayName": "Grass Path",
+    "name": "grass_path",
+    "stackSize": 64
+  },
+  {
+    "id": 200,
+    "displayName": "Chorus Flower",
+    "name": "chorus_flower",
+    "stackSize": 64
+  },
+  {
+    "id": 201,
+    "displayName": "Purpur Block",
+    "name": "purpur_block",
+    "stackSize": 64
+  },
+  {
+    "id": 203,
+    "displayName": "Purpur Stairs",
+    "name": "purpur_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 206,
+    "displayName": "End Bricks",
+    "name": "end_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 208,
+    "displayName": "End Rod",
+    "name": "end_rod",
+    "stackSize": 64
+  },
+  {
+    "id": 209,
+    "displayName": "End Gateway",
+    "name": "end_gateway",
+    "stackSize": 64
+  },
+  {
+    "id": 210,
+    "displayName": "Allow",
+    "name": "allow",
+    "stackSize": 64
+  },
+  {
+    "id": 211,
+    "displayName": "Deny",
+    "name": "deny",
+    "stackSize": 64
+  },
+  {
+    "id": 212,
+    "displayName": "Border Block",
+    "name": "border_block",
+    "stackSize": 64
+  },
+  {
+    "id": 240,
+    "displayName": "Chorus Plant",
+    "name": "chorus_plant",
+    "stackSize": 64
+  },
+  {
+    "id": 241,
+    "displayName": "Stained Glass",
+    "name": "stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 243,
+    "displayName": "Podzol",
+    "name": "podzol",
+    "stackSize": 64
+  },
+  {
+    "id": 245,
+    "displayName": "Stonecutter",
+    "name": "stonecutter",
+    "stackSize": 64
+  },
+  {
+    "id": 246,
+    "displayName": "Glowing Obsidian",
+    "name": "glowing_obsidian",
+    "stackSize": 64
+  },
+  {
+    "id": 247,
+    "displayName": "Nether Reactor Core",
+    "name": "nether_reactor_core",
+    "stackSize": 64
+  },
+  {
+    "id": 248,
+    "displayName": "Update Game Block (update!)",
+    "name": "update_game_block",
+    "stackSize": 64
+  },
+  {
+    "id": 250,
+    "displayName": "Block moved by Piston",
+    "name": "block_moved_by_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 251,
+    "displayName": "Observer",
+    "name": "observer",
+    "stackSize": 64
+  },
+  {
+    "id": 255,
+    "displayName": "reserved6",
+    "name": "reserved6",
+    "stackSize": 64
+  },
+  {
     "id": 256,
     "displayName": "Iron Shovel",
     "stackSize": 1,
@@ -1228,6 +2266,18 @@
     "name": "shulker_shell"
   },
   {
+    "id": 454,
+    "displayName": "Chalkboard",
+    "stackSize": 0,
+    "name": "chalkboard"
+  },
+  {
+    "id": 456,
+    "displayName": "Portfolio",
+    "stackSize": 0,
+    "name": "portfolio"
+  },
+  {
     "id": 457,
     "displayName": "Beetroot",
     "stackSize": 64,
@@ -1284,18 +2334,6 @@
         "displayName": "Enchanted Golden Apple"
       }
     ]
-  },
-  {
-    "id": 454,
-    "displayName": "Chalkboard",
-    "stackSize": 0,
-    "name": "chalkboard"
-  },
-  {
-    "id": 456,
-    "displayName": "Portfolio",
-    "stackSize": 0,
-    "name": "portfolio"
   },
   {
     "id": 498,

--- a/tools/js/test/audit_blockitems.js
+++ b/tools/js/test/audit_blockitems.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+
+const fs = require('fs')
+const path = require('path')
+
+require('./version_iterator')(function (p, versionString) {
+  describe('audit blockitems ' + versionString, function () {
+    it('audit blockitems', function () {
+      const itemsFile = path.join(p, 'items.json')
+      if (!fs.existsSync(itemsFile)) return
+      const items = require(itemsFile)
+
+      const blocksFile = path.join(p, 'blocks.json')
+      if (!fs.existsSync(blocksFile)) return
+      const blocks = require(blocksFile)
+
+      if (items[0].id === 0) return
+
+      let rewriteItems = false
+      for (const block of blocks) {
+        let blockitem = null
+        for (const item of items) {
+          if (item.name === block.name) {
+            blockitem = item
+            break
+          }
+        }
+        if (!blockitem) {
+          console.log('Missing item for block ' + block.name)
+          rewriteItems = true
+          items.push({
+            id: block.id,
+            displayName: block.displayName,
+            name: block.name,
+            stackSize: 64
+          })
+        }
+      }
+
+      items.sort((a, b) => { return a.id - b.id })
+
+      // Automatically fix item data, if necessary
+      if (rewriteItems) {
+        fs.writeFileSync(itemsFile, JSON.stringify(items, null, 2))
+      }
+    })
+  })
+})


### PR DESCRIPTION
Before 1.13 (the flattening), all blocks had a corresponding item with the same id (some of them were unobtainable, but the item existed). In mineflayer, when we wanted to get the item corresponding to a block, we had to query the id in blocksByName instead of itemsByName.

With the flattening, things became more complicated as an item could have a different id from its block. So to get a blockitem id, we now have to use itemsByName. This lead to complicated code like this, everywhere in mineflayer :

```js
  let grassName
  let itemsByName

  if (bot.supportFeature('itemsAreNotBlocks')) {
    grassName = 'grass_block'
    itemsByName = 'itemsByName'
  } else if (bot.supportFeature('itemsAreAlsoBlocks')) {
    grassName = 'grass'
    itemsByName = 'blocksByName'
  }
```

This PR adds all the missing items from blocks for versions <1.13 so we are able to use itemsByName for blocks in whatever version we use (no more specialized code).

The items are generated using the corresponding blocks.json and the script audit_blockitems.js