### PR TITLE
Get rid of a dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Minecraft-data is language independent, you can use it with these language speci
 | [python-minecraft-data](https://github.com/SpockBotMC/python-minecraft-data) | python | everything |
 | [McData](https://github.com/McEx/McData) | Elixir | protocol |
 | [ProtocolGen](https://github.com/Johni0702/ProtocolGen) | java | generated java files from protocol.json to read and write minecraft packets |
-| [hs-minecraft-protocol](https://github.com/oldmanmike/hs-minecraft-protocol) | haskell | protocol.json haskell compiler |
 
 If you want to use minecraft-data in a new language, we advise you to [create a new wrapper](doc/make-a-new-wrapper.md)
 


### PR DESCRIPTION
Was an example, but I guess the repo was deleted, so I got rid of it from the readme