### PR TITLE
Fix "feet_eyes" field of packet_face_player

### DIFF
--- a/data/pc/1.13.1/protocol.json
+++ b/data/pc/1.13.1/protocol.json
@@ -1518,7 +1518,7 @@
             [
               {
                 "name": "feet_eyes",
-                "type": "string"
+                "type": "varint"
               },
               {
                 "name": "x",

--- a/data/pc/1.13.2-pre1/protocol.json
+++ b/data/pc/1.13.2-pre1/protocol.json
@@ -1523,7 +1523,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.13.2-pre2/protocol.json
+++ b/data/pc/1.13.2-pre2/protocol.json
@@ -1523,7 +1523,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.13.2/protocol.json
+++ b/data/pc/1.13.2/protocol.json
@@ -1523,7 +1523,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.13/protocol.json
+++ b/data/pc/1.13/protocol.json
@@ -1518,7 +1518,7 @@
             [
               {
                 "name": "feet_eyes",
-                "type": "string"
+                "type": "varint"
               },
               {
                 "name": "x",

--- a/data/pc/1.14.1/protocol.json
+++ b/data/pc/1.14.1/protocol.json
@@ -1546,7 +1546,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.14.3/protocol.json
+++ b/data/pc/1.14.3/protocol.json
@@ -1546,7 +1546,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.14.4/protocol.json
+++ b/data/pc/1.14.4/protocol.json
@@ -1546,7 +1546,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.14/protocol.json
+++ b/data/pc/1.14/protocol.json
@@ -1546,7 +1546,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.15.1/protocol.json
+++ b/data/pc/1.15.1/protocol.json
@@ -1538,7 +1538,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.15.2/protocol.json
+++ b/data/pc/1.15.2/protocol.json
@@ -1538,7 +1538,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.15/protocol.json
+++ b/data/pc/1.15/protocol.json
@@ -1538,7 +1538,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.16-rc1/protocol.json
+++ b/data/pc/1.16-rc1/protocol.json
@@ -1514,7 +1514,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.16.1/protocol.json
+++ b/data/pc/1.16.1/protocol.json
@@ -1514,7 +1514,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/1.16/protocol.json
+++ b/data/pc/1.16/protocol.json
@@ -1514,7 +1514,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",

--- a/data/pc/20w13b/protocol.json
+++ b/data/pc/20w13b/protocol.json
@@ -1538,7 +1538,7 @@
           [
             {
               "name": "feet_eyes",
-              "type": "string"
+              "type": "varint"
             },
             {
               "name": "x",


### PR DESCRIPTION
"feet_eyes" is wrong for packet_face_player, it's a varint encoded enum according to [wiki.vg](https://wiki.vg/Protocol#Face_Player) as well as Burger:

```
"PLAY_CLIENTBOUND_34": {
    "class": "pj.class",
    "direction": "CLIENTBOUND",
    "from_client": false,
    "from_server": true,
    "id": 52,
    "instructions": [
        {
            "field": "e",
            "operation": "write",
            "type": "enum"
        },
        {
            "field": "a",
            "operation": "write",
            "type": "double"
        },
        {
            "field": "b",
            "operation": "write",
            "type": "double"
        },
        {
            "field": "c",
            "operation": "write",
            "type": "double"
        },
        {
            "field": "g",
            "operation": "write",
            "type": "boolean"
        },
        {
            "condition": "g",
            "instructions": [
                {
                    "field": "d",
                    "operation": "write",
                    "type": "varint"
                },
                {
                    "field": "f",
                    "operation": "write",
                    "type": "enum"
                }
            ],
            "operation": "if"
        }
    ],
    "state": "PLAY"
},
```

Checked every version with Burger, the only thing that changes is the packet id, it's always been a varint.