### PR TITLE
Adding Minecraft Item Browser project

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ These are the projects that use minecraft-data:
 | [McEx](https://github.com/hansihe/McEx) | Elixir | server | blocks |
 | [VoxelGamesLib](https://github.com/MiniDigger/VoxelGamesLib) | Java | minigames server library | blocks, items |
 | [Phpcraft](https://github.com/Phpcraft/core) | PHP | all-around library | blocks, items, entities, protocol |
-| [Minecraft Item Browser](https://njt1982.github.io/minecraft-item-browser/) | Javascript | Web-based recipe search tool | blocks, items, recipes |
+| [Minecraft Item Browser](https://njt1982.github.io/minecraft-item-browser/) ([Repo](https://github.com/njt1982/minecraft-item-browser)) | Javascript | Web-based recipe search tool | blocks, items, recipes |
 
 ## Extraction
 


### PR DESCRIPTION
Adding site for https://github.com/njt1982/minecraft-item-browser to the list.

Closes njt1982/minecraft-item-browser#9