### PR TITLE
Fix 1.16.2 block states

### DIFF
--- a/data/pc/1.16.2/blocks.json
+++ b/data/pc/1.16.2/blocks.json
@@ -1807,7 +1807,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -1983,7 +1983,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2027,7 +2027,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2071,7 +2071,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2115,7 +2115,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2159,7 +2159,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2203,7 +2203,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2247,7 +2247,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2291,7 +2291,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2335,7 +2335,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2379,7 +2379,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2423,7 +2423,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2467,7 +2467,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2511,7 +2511,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2555,7 +2555,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2599,7 +2599,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2643,7 +2643,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2763,7 +2763,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2932,7 +2932,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -2969,7 +2969,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -3317,7 +3317,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -3823,7 +3823,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -3942,7 +3942,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -3999,7 +3999,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4224,7 +4224,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4456,7 +4456,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4506,7 +4506,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4578,7 +4578,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4642,7 +4642,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4678,7 +4678,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4714,7 +4714,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4750,7 +4750,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4786,7 +4786,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4822,7 +4822,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4868,7 +4868,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -4944,7 +4944,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -5204,7 +5204,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -5239,7 +5239,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -5676,7 +5676,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -5750,7 +5750,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -5781,7 +5781,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -5836,7 +5836,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -6169,7 +6169,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -6224,7 +6224,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -6279,7 +6279,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -6334,7 +6334,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -6389,7 +6389,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -6444,7 +6444,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7066,7 +7066,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7095,7 +7095,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7219,7 +7219,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7265,7 +7265,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7329,7 +7329,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7515,7 +7515,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7720,7 +7720,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7823,7 +7823,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7859,7 +7859,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7946,7 +7946,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -7989,7 +7989,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -8106,7 +8106,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -8163,7 +8163,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -8220,7 +8220,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -8277,7 +8277,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9011,7 +9011,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9057,7 +9057,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9103,7 +9103,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9149,7 +9149,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9195,7 +9195,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9241,7 +9241,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9311,7 +9311,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9365,7 +9365,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9419,7 +9419,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9473,7 +9473,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9527,7 +9527,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9581,7 +9581,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9611,7 +9611,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9649,7 +9649,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9687,7 +9687,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9725,7 +9725,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9835,7 +9835,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -9961,7 +9961,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "DOWN",
           "NORTH",
@@ -10094,7 +10094,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -10196,7 +10196,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -11361,7 +11361,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -11418,7 +11418,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -11511,7 +11511,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -11651,7 +11651,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -11715,7 +11715,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -11779,7 +11779,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -12956,7 +12956,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -12987,7 +12987,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13018,7 +13018,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13049,7 +13049,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13080,7 +13080,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13111,7 +13111,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13142,7 +13142,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13173,7 +13173,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13204,7 +13204,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13235,7 +13235,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13266,7 +13266,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13297,7 +13297,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13328,7 +13328,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13359,7 +13359,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13390,7 +13390,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13421,7 +13421,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -13530,7 +13530,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -14496,7 +14496,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -14542,7 +14542,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -14588,7 +14588,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -14634,7 +14634,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -14680,7 +14680,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -14960,7 +14960,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15019,7 +15019,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15078,7 +15078,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15137,7 +15137,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15196,7 +15196,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15246,7 +15246,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15412,7 +15412,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15561,7 +15561,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15598,7 +15598,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15779,7 +15779,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15823,7 +15823,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15855,7 +15855,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15887,7 +15887,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15919,7 +15919,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15951,7 +15951,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -15983,7 +15983,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16015,7 +16015,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16047,7 +16047,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16079,7 +16079,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16111,7 +16111,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16143,7 +16143,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16175,7 +16175,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16207,7 +16207,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16239,7 +16239,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16271,7 +16271,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16303,7 +16303,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16335,7 +16335,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16367,7 +16367,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16405,7 +16405,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16443,7 +16443,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16481,7 +16481,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16519,7 +16519,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16557,7 +16557,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16595,7 +16595,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16633,7 +16633,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16671,7 +16671,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16709,7 +16709,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16747,7 +16747,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16785,7 +16785,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16823,7 +16823,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16861,7 +16861,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16899,7 +16899,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -16937,7 +16937,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18524,7 +18524,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18559,7 +18559,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18594,7 +18594,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18629,7 +18629,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18664,7 +18664,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18699,7 +18699,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18734,7 +18734,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18769,7 +18769,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18804,7 +18804,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -18839,7 +18839,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19076,7 +19076,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19133,7 +19133,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19190,7 +19190,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19247,7 +19247,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19304,7 +19304,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19361,7 +19361,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19418,7 +19418,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19475,7 +19475,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19532,7 +19532,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19589,7 +19589,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19646,7 +19646,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19703,7 +19703,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19767,7 +19767,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -19824,7 +19824,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21385,7 +21385,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21416,7 +21416,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21454,7 +21454,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21497,7 +21497,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21578,7 +21578,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21626,7 +21626,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21686,7 +21686,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21717,7 +21717,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21853,7 +21853,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -21899,7 +21899,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -22715,7 +22715,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -22770,7 +22770,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -22825,7 +22825,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -22871,7 +22871,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -22917,7 +22917,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -22974,7 +22974,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -23031,7 +23031,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -23076,7 +23076,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -23130,7 +23130,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -23189,7 +23189,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -23299,7 +23299,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -23335,7 +23335,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -23495,7 +23495,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -23531,7 +23531,7 @@
       },
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -23820,7 +23820,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -24120,7 +24120,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -24280,7 +24280,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",
@@ -24404,7 +24404,7 @@
     "states": [
       {
         "name": "facing",
-        "type": "direction",
+        "type": "enum",
         "values": [
           "NORTH",
           "EAST",

--- a/data/pc/1.16.2/blocks.json
+++ b/data/pc/1.16.2/blocks.json
@@ -1952,14 +1952,14 @@
         "num_values": 16
       },
       {
-        "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "note",
         "type": "int",
         "num_values": 25
+      },
+      {
+        "name": "powered",
+        "type": "bool",
+        "num_values": 2
       }
     ],
     "drops": [
@@ -1993,17 +1993,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2037,17 +2037,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2081,17 +2081,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2125,17 +2125,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2169,17 +2169,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2213,17 +2213,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2257,17 +2257,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2301,17 +2301,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2345,17 +2345,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2389,17 +2389,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2433,17 +2433,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2477,17 +2477,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2521,17 +2521,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2565,17 +2565,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2609,17 +2609,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2653,17 +2653,17 @@
         "num_values": 4
       },
       {
+        "name": "occupied",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "part",
         "type": "enum",
         "values": [
           "head",
           "foot"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "occupied",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -2686,6 +2686,11 @@
     "maxStateId": 1316,
     "states": [
       {
+        "name": "powered",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "shape",
         "type": "enum",
         "values": [
@@ -2697,11 +2702,6 @@
           "ascending_south"
         ],
         "num_values": 6
-      },
-      {
-        "name": "powered",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -2724,6 +2724,11 @@
     "maxStateId": 1328,
     "states": [
       {
+        "name": "powered",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "shape",
         "type": "enum",
         "values": [
@@ -2735,11 +2740,6 @@
           "ascending_south"
         ],
         "num_values": 6
-      },
-      {
-        "name": "powered",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -2762,6 +2762,11 @@
     "maxStateId": 1340,
     "states": [
       {
+        "name": "extended",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -2773,11 +2778,6 @@
           "down"
         ],
         "num_values": 6
-      },
-      {
-        "name": "extended",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -2931,6 +2931,11 @@
     "maxStateId": 1359,
     "states": [
       {
+        "name": "extended",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -2942,11 +2947,6 @@
           "down"
         ],
         "num_values": 6
-      },
-      {
-        "name": "extended",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -2981,17 +2981,17 @@
         "num_values": 6
       },
       {
+        "name": "short",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "type",
         "type": "enum",
         "values": [
           "normal",
           "sticky"
         ],
-        "num_values": 2
-      },
-      {
-        "name": "short",
-        "type": "bool",
         "num_values": 2
       }
     ],
@@ -3857,12 +3857,12 @@
         "num_values": 16
       },
       {
-        "name": "north",
+        "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "east",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -3872,12 +3872,12 @@
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "up",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "up",
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -4044,6 +4044,16 @@
     "maxStateId": 3353,
     "states": [
       {
+        "name": "east",
+        "type": "enum",
+        "values": [
+          "up",
+          "side",
+          "none"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "north",
         "type": "enum",
         "values": [
@@ -4054,14 +4064,9 @@
         "num_values": 3
       },
       {
-        "name": "east",
-        "type": "enum",
-        "values": [
-          "up",
-          "side",
-          "none"
-        ],
-        "num_values": 3
+        "name": "power",
+        "type": "int",
+        "num_values": 16
       },
       {
         "name": "south",
@@ -4082,11 +4087,6 @@
           "none"
         ],
         "num_values": 3
-      },
-      {
-        "name": "power",
-        "type": "int",
-        "num_values": 16
       }
     ],
     "drops": [
@@ -4446,15 +4446,6 @@
     "maxStateId": 3636,
     "states": [
       {
-        "name": "half",
-        "type": "enum",
-        "values": [
-          "upper",
-          "lower"
-        ],
-        "num_values": 2
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -4466,8 +4457,12 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
+        "name": "half",
+        "type": "enum",
+        "values": [
+          "upper",
+          "lower"
+        ],
         "num_values": 2
       },
       {
@@ -4477,6 +4472,11 @@
           "left",
           "right"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -4934,15 +4934,6 @@
     "maxStateId": 3872,
     "states": [
       {
-        "name": "half",
-        "type": "enum",
-        "values": [
-          "upper",
-          "lower"
-        ],
-        "num_values": 2
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -4954,8 +4945,12 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
+        "name": "half",
+        "type": "enum",
+        "values": [
+          "upper",
+          "lower"
+        ],
         "num_values": 2
       },
       {
@@ -4965,6 +4960,11 @@
           "left",
           "right"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -5238,6 +5238,16 @@
     "maxStateId": 3920,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -5252,16 +5262,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -5455,17 +5455,12 @@
     "maxStateId": 3997,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -5476,6 +5471,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -5835,6 +5835,11 @@
     "maxStateId": 4094,
     "states": [
       {
+        "name": "delay",
+        "type": "int",
+        "num_values": 4
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -5843,11 +5848,6 @@
           "west",
           "east"
         ],
-        "num_values": 4
-      },
-      {
-        "name": "delay",
-        "type": "int",
         "num_values": 4
       },
       {
@@ -6179,17 +6179,17 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "half",
         "type": "enum",
         "values": [
           "top",
           "bottom"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -6234,17 +6234,17 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "half",
         "type": "enum",
         "values": [
           "top",
           "bottom"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -6289,17 +6289,17 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "half",
         "type": "enum",
         "values": [
           "top",
           "bottom"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -6344,17 +6344,17 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "half",
         "type": "enum",
         "values": [
           "top",
           "bottom"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -6399,17 +6399,17 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "half",
         "type": "enum",
         "values": [
           "top",
           "bottom"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -6454,17 +6454,17 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "half",
         "type": "enum",
         "values": [
           "top",
           "bottom"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -6758,17 +6758,7 @@
     "maxStateId": 4568,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "down",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -6778,7 +6768,17 @@
         "num_values": 2
       },
       {
+        "name": "north",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "south",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "up",
         "type": "bool",
         "num_values": 2
       },
@@ -6808,17 +6808,7 @@
     "maxStateId": 4632,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "down",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -6828,7 +6818,17 @@
         "num_values": 2
       },
       {
+        "name": "north",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "south",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "up",
         "type": "bool",
         "num_values": 2
       },
@@ -6858,17 +6858,7 @@
     "maxStateId": 4696,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "down",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -6878,7 +6868,17 @@
         "num_values": 2
       },
       {
+        "name": "north",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "south",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "up",
         "type": "bool",
         "num_values": 2
       },
@@ -6908,17 +6908,12 @@
     "maxStateId": 4728,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -6929,6 +6924,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -6960,11 +6960,6 @@
     "maxStateId": 4734,
     "states": [
       {
-        "name": "waterlogged",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "axis",
         "type": "enum",
         "values": [
@@ -6973,6 +6968,11 @@
           "z"
         ],
         "num_values": 3
+      },
+      {
+        "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
       }
     ],
     "drops": [
@@ -7002,17 +7002,12 @@
     "maxStateId": 4766,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -7023,6 +7018,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -7173,7 +7173,7 @@
     "maxStateId": 4823,
     "states": [
       {
-        "name": "up",
+        "name": "east",
         "type": "bool",
         "num_values": 2
       },
@@ -7183,12 +7183,12 @@
         "num_values": 2
       },
       {
-        "name": "east",
+        "name": "south",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "south",
+        "name": "up",
         "type": "bool",
         "num_values": 2
       },
@@ -7229,17 +7229,17 @@
         "num_values": 4
       },
       {
+        "name": "in_wall",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "open",
         "type": "bool",
         "num_values": 2
       },
       {
         "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "in_wall",
         "type": "bool",
         "num_values": 2
       }
@@ -7462,17 +7462,12 @@
     "maxStateId": 5051,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -7483,6 +7478,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -7719,6 +7719,11 @@
     "maxStateId": 5157,
     "states": [
       {
+        "name": "eye",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -7728,11 +7733,6 @@
           "east"
         ],
         "num_values": 4
-      },
-      {
-        "name": "eye",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -7822,6 +7822,11 @@
     "maxStateId": 5173,
     "states": [
       {
+        "name": "age",
+        "type": "int",
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -7831,11 +7836,6 @@
           "east"
         ],
         "num_values": 4
-      },
-      {
-        "name": "age",
-        "type": "int",
-        "num_values": 3
       }
     ],
     "drops": [
@@ -7988,6 +7988,11 @@
     "maxStateId": 5278,
     "states": [
       {
+        "name": "attached",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -8000,11 +8005,6 @@
       },
       {
         "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "attached",
         "type": "bool",
         "num_values": 2
       }
@@ -8028,11 +8028,6 @@
     "maxStateId": 5406,
     "states": [
       {
-        "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "attached",
         "type": "bool",
         "num_values": 2
@@ -8043,22 +8038,27 @@
         "num_values": 2
       },
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "powered",
         "type": "bool",
         "num_values": 2
       },
       {
         "name": "south",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -8276,6 +8276,11 @@
     "maxStateId": 5659,
     "states": [
       {
+        "name": "conditional",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -8287,11 +8292,6 @@
           "down"
         ],
         "num_values": 6
-      },
-      {
-        "name": "conditional",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -8331,21 +8331,6 @@
     "maxStateId": 5984,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -8356,7 +8341,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -8376,9 +8361,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -8408,21 +8408,6 @@
     "maxStateId": 6308,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -8433,7 +8418,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -8453,9 +8438,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -9010,6 +9010,16 @@
     "maxStateId": 6373,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -9024,16 +9034,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -9056,6 +9056,16 @@
     "maxStateId": 6397,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -9070,16 +9080,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -9102,6 +9102,16 @@
     "maxStateId": 6421,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -9116,16 +9126,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -9148,6 +9148,16 @@
     "maxStateId": 6445,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -9162,16 +9172,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -9194,6 +9194,16 @@
     "maxStateId": 6469,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -9208,16 +9218,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -9240,6 +9240,16 @@
     "maxStateId": 6493,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -9254,16 +9264,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -9878,14 +9878,14 @@
     "maxStateId": 6729,
     "states": [
       {
-        "name": "power",
-        "type": "int",
-        "num_values": 16
-      },
-      {
         "name": "inverted",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "power",
+        "type": "int",
+        "num_values": 16
       }
     ],
     "drops": [
@@ -9960,6 +9960,11 @@
     "maxStateId": 6741,
     "states": [
       {
+        "name": "enabled",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -9970,11 +9975,6 @@
           "east"
         ],
         "num_values": 5
-      },
-      {
-        "name": "enabled",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -10157,6 +10157,11 @@
     "maxStateId": 6838,
     "states": [
       {
+        "name": "powered",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "shape",
         "type": "enum",
         "values": [
@@ -10168,11 +10173,6 @@
           "ascending_south"
         ],
         "num_values": 6
-      },
-      {
-        "name": "powered",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -10656,17 +10656,12 @@
     "maxStateId": 6898,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -10677,6 +10672,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -10700,17 +10700,12 @@
     "maxStateId": 6930,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -10721,6 +10716,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -10744,17 +10744,12 @@
     "maxStateId": 6962,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -10765,6 +10760,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -10788,17 +10788,12 @@
     "maxStateId": 6994,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -10809,6 +10804,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -10832,17 +10832,12 @@
     "maxStateId": 7026,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -10853,6 +10848,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -10876,17 +10876,12 @@
     "maxStateId": 7058,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -10897,6 +10892,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -10920,17 +10920,12 @@
     "maxStateId": 7090,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -10941,6 +10936,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -10964,17 +10964,12 @@
     "maxStateId": 7122,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -10985,6 +10980,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -11008,17 +11008,12 @@
     "maxStateId": 7154,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -11029,6 +11024,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -11052,17 +11052,12 @@
     "maxStateId": 7186,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -11073,6 +11068,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -11096,17 +11096,12 @@
     "maxStateId": 7218,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -11117,6 +11112,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -11140,17 +11140,12 @@
     "maxStateId": 7250,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -11161,6 +11156,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -11184,17 +11184,12 @@
     "maxStateId": 7282,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -11205,6 +11200,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -11228,17 +11228,12 @@
     "maxStateId": 7314,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -11249,6 +11244,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -11272,17 +11272,12 @@
     "maxStateId": 7346,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -11293,6 +11288,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -11316,17 +11316,12 @@
     "maxStateId": 7378,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -11337,6 +11332,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -11521,17 +11521,17 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "half",
         "type": "enum",
         "values": [
           "top",
           "bottom"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -14506,17 +14506,17 @@
         "num_values": 4
       },
       {
+        "name": "in_wall",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "open",
         "type": "bool",
         "num_values": 2
       },
       {
         "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "in_wall",
         "type": "bool",
         "num_values": 2
       }
@@ -14552,17 +14552,17 @@
         "num_values": 4
       },
       {
+        "name": "in_wall",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "open",
         "type": "bool",
         "num_values": 2
       },
       {
         "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "in_wall",
         "type": "bool",
         "num_values": 2
       }
@@ -14598,17 +14598,17 @@
         "num_values": 4
       },
       {
+        "name": "in_wall",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "open",
         "type": "bool",
         "num_values": 2
       },
       {
         "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "in_wall",
         "type": "bool",
         "num_values": 2
       }
@@ -14644,17 +14644,17 @@
         "num_values": 4
       },
       {
+        "name": "in_wall",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "open",
         "type": "bool",
         "num_values": 2
       },
       {
         "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "in_wall",
         "type": "bool",
         "num_values": 2
       }
@@ -14690,17 +14690,17 @@
         "num_values": 4
       },
       {
+        "name": "in_wall",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "open",
         "type": "bool",
         "num_values": 2
       },
       {
         "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "in_wall",
         "type": "bool",
         "num_values": 2
       }
@@ -14725,17 +14725,12 @@
     "maxStateId": 8613,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -14746,6 +14741,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -14770,17 +14770,12 @@
     "maxStateId": 8645,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -14791,6 +14786,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -14815,17 +14815,12 @@
     "maxStateId": 8677,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -14836,6 +14831,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -14860,17 +14860,12 @@
     "maxStateId": 8709,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -14881,6 +14876,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -14905,17 +14905,12 @@
     "maxStateId": 8741,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -14926,6 +14921,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -14950,15 +14950,6 @@
     "maxStateId": 8805,
     "states": [
       {
-        "name": "half",
-        "type": "enum",
-        "values": [
-          "upper",
-          "lower"
-        ],
-        "num_values": 2
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -14970,8 +14961,12 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
+        "name": "half",
+        "type": "enum",
+        "values": [
+          "upper",
+          "lower"
+        ],
         "num_values": 2
       },
       {
@@ -14981,6 +14976,11 @@
           "left",
           "right"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -15009,15 +15009,6 @@
     "maxStateId": 8869,
     "states": [
       {
-        "name": "half",
-        "type": "enum",
-        "values": [
-          "upper",
-          "lower"
-        ],
-        "num_values": 2
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -15029,8 +15020,12 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
+        "name": "half",
+        "type": "enum",
+        "values": [
+          "upper",
+          "lower"
+        ],
         "num_values": 2
       },
       {
@@ -15040,6 +15035,11 @@
           "left",
           "right"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -15068,15 +15068,6 @@
     "maxStateId": 8933,
     "states": [
       {
-        "name": "half",
-        "type": "enum",
-        "values": [
-          "upper",
-          "lower"
-        ],
-        "num_values": 2
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -15088,8 +15079,12 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
+        "name": "half",
+        "type": "enum",
+        "values": [
+          "upper",
+          "lower"
+        ],
         "num_values": 2
       },
       {
@@ -15099,6 +15094,11 @@
           "left",
           "right"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -15127,15 +15127,6 @@
     "maxStateId": 8997,
     "states": [
       {
-        "name": "half",
-        "type": "enum",
-        "values": [
-          "upper",
-          "lower"
-        ],
-        "num_values": 2
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -15147,8 +15138,12 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
+        "name": "half",
+        "type": "enum",
+        "values": [
+          "upper",
+          "lower"
+        ],
         "num_values": 2
       },
       {
@@ -15158,6 +15153,11 @@
           "left",
           "right"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -15186,15 +15186,6 @@
     "maxStateId": 9061,
     "states": [
       {
-        "name": "half",
-        "type": "enum",
-        "values": [
-          "upper",
-          "lower"
-        ],
-        "num_values": 2
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -15206,8 +15197,12 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
+        "name": "half",
+        "type": "enum",
+        "values": [
+          "upper",
+          "lower"
+        ],
         "num_values": 2
       },
       {
@@ -15217,6 +15212,11 @@
           "left",
           "right"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -15277,7 +15277,7 @@
     "maxStateId": 9131,
     "states": [
       {
-        "name": "north",
+        "name": "down",
         "type": "bool",
         "num_values": 2
       },
@@ -15287,12 +15287,12 @@
         "num_values": 2
       },
       {
-        "name": "south",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "south",
         "type": "bool",
         "num_values": 2
       },
@@ -15302,7 +15302,7 @@
         "num_values": 2
       },
       {
-        "name": "down",
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -15560,6 +15560,11 @@
     "maxStateId": 9240,
     "states": [
       {
+        "name": "conditional",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -15571,11 +15576,6 @@
           "down"
         ],
         "num_values": 6
-      },
-      {
-        "name": "conditional",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -15597,6 +15597,11 @@
     "maxStateId": 9252,
     "states": [
       {
+        "name": "conditional",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -15608,11 +15613,6 @@
           "down"
         ],
         "num_values": 6
-      },
-      {
-        "name": "conditional",
-        "type": "bool",
-        "num_values": 2
       }
     ],
     "drops": [
@@ -17754,14 +17754,14 @@
     "maxStateId": 9513,
     "states": [
       {
-        "name": "hatch",
-        "type": "int",
-        "num_values": 3
-      },
-      {
         "name": "eggs",
         "type": "int",
         "num_values": 4
+      },
+      {
+        "name": "hatch",
+        "type": "int",
+        "num_values": 3
       }
     ],
     "drops": [
@@ -20426,21 +20426,6 @@
     "maxStateId": 11194,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -20451,7 +20436,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -20471,9 +20456,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -20503,21 +20503,6 @@
     "maxStateId": 11518,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -20528,7 +20513,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -20548,9 +20533,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -20580,21 +20580,6 @@
     "maxStateId": 11842,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -20605,7 +20590,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -20625,9 +20610,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -20657,21 +20657,6 @@
     "maxStateId": 12166,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -20682,7 +20667,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -20702,9 +20687,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -20734,21 +20734,6 @@
     "maxStateId": 12490,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -20759,7 +20744,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -20779,9 +20764,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -20811,21 +20811,6 @@
     "maxStateId": 12814,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -20836,7 +20821,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -20856,9 +20841,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -20888,21 +20888,6 @@
     "maxStateId": 13138,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -20913,7 +20898,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -20933,9 +20918,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -20965,21 +20965,6 @@
     "maxStateId": 13462,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -20990,7 +20975,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -21010,9 +20995,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -21042,21 +21042,6 @@
     "maxStateId": 13786,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -21067,7 +21052,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -21087,9 +21072,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -21119,21 +21119,6 @@
     "maxStateId": 14110,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -21144,7 +21129,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -21164,9 +21149,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -21196,21 +21196,6 @@
     "maxStateId": 14434,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -21221,7 +21206,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -21241,9 +21226,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -21273,21 +21273,6 @@
     "maxStateId": 14758,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -21298,7 +21283,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -21318,9 +21303,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -21350,17 +21350,17 @@
     "maxStateId": 14790,
     "states": [
       {
+        "name": "bottom",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "distance",
         "type": "int",
         "num_values": 8
       },
       {
         "name": "waterlogged",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "bottom",
         "type": "bool",
         "num_values": 2
       }
@@ -21577,6 +21577,16 @@
     "maxStateId": 14836,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -21586,16 +21596,6 @@
           "east"
         ],
         "num_values": 4
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -21636,12 +21636,12 @@
         "num_values": 4
       },
       {
-        "name": "powered",
+        "name": "has_book",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "has_book",
+        "name": "powered",
         "type": "bool",
         "num_values": 2
       }
@@ -21716,17 +21716,6 @@
     "maxStateId": 14889,
     "states": [
       {
-        "name": "facing",
-        "type": "enum",
-        "values": [
-          "north",
-          "south",
-          "west",
-          "east"
-        ],
-        "num_values": 4
-      },
-      {
         "name": "attachment",
         "type": "enum",
         "values": [
@@ -21734,6 +21723,17 @@
           "ceiling",
           "single_wall",
           "double_wall"
+        ],
+        "num_values": 4
+      },
+      {
+        "name": "facing",
+        "type": "enum",
+        "values": [
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -21837,6 +21837,17 @@
     "maxStateId": 14929,
     "states": [
       {
+        "name": "facing",
+        "type": "enum",
+        "values": [
+          "north",
+          "south",
+          "west",
+          "east"
+        ],
+        "num_values": 4
+      },
+      {
         "name": "lit",
         "type": "bool",
         "num_values": 2
@@ -21850,17 +21861,6 @@
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "facing",
-        "type": "enum",
-        "values": [
-          "north",
-          "south",
-          "west",
-          "east"
-        ],
-        "num_values": 4
       }
     ],
     "drops": [
@@ -21883,6 +21883,17 @@
     "maxStateId": 14961,
     "states": [
       {
+        "name": "facing",
+        "type": "enum",
+        "values": [
+          "north",
+          "south",
+          "west",
+          "east"
+        ],
+        "num_values": 4
+      },
+      {
         "name": "lit",
         "type": "bool",
         "num_values": 2
@@ -21896,17 +21907,6 @@
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "facing",
-        "type": "enum",
-        "values": [
-          "north",
-          "south",
-          "west",
-          "east"
-        ],
-        "num_values": 4
       }
     ],
     "drops": [
@@ -22624,17 +22624,12 @@
     "maxStateId": 15102,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -22645,6 +22640,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -22669,17 +22669,12 @@
     "maxStateId": 15134,
     "states": [
       {
-        "name": "north",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "east",
         "type": "bool",
         "num_values": 2
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "bool",
         "num_values": 2
       },
@@ -22690,6 +22685,11 @@
       },
       {
         "name": "waterlogged",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
+        "name": "west",
         "type": "bool",
         "num_values": 2
       }
@@ -22725,17 +22725,17 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "half",
         "type": "enum",
         "values": [
           "top",
           "bottom"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -22780,17 +22780,17 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
         "name": "half",
         "type": "enum",
         "values": [
           "top",
           "bottom"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -22835,17 +22835,17 @@
         "num_values": 4
       },
       {
+        "name": "in_wall",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "open",
         "type": "bool",
         "num_values": 2
       },
       {
         "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "in_wall",
         "type": "bool",
         "num_values": 2
       }
@@ -22881,17 +22881,17 @@
         "num_values": 4
       },
       {
+        "name": "in_wall",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "open",
         "type": "bool",
         "num_values": 2
       },
       {
         "name": "powered",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "in_wall",
         "type": "bool",
         "num_values": 2
       }
@@ -23030,6 +23030,16 @@
     "maxStateId": 15510,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -23044,16 +23054,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -23075,6 +23075,16 @@
     "maxStateId": 15534,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -23089,16 +23099,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -23120,15 +23120,6 @@
     "maxStateId": 15598,
     "states": [
       {
-        "name": "half",
-        "type": "enum",
-        "values": [
-          "upper",
-          "lower"
-        ],
-        "num_values": 2
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -23140,8 +23131,12 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
+        "name": "half",
+        "type": "enum",
+        "values": [
+          "upper",
+          "lower"
+        ],
         "num_values": 2
       },
       {
@@ -23151,6 +23146,11 @@
           "left",
           "right"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -23179,15 +23179,6 @@
     "maxStateId": 15662,
     "states": [
       {
-        "name": "half",
-        "type": "enum",
-        "values": [
-          "upper",
-          "lower"
-        ],
-        "num_values": 2
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -23199,8 +23190,12 @@
         "num_values": 4
       },
       {
-        "name": "open",
-        "type": "bool",
+        "name": "half",
+        "type": "enum",
+        "values": [
+          "upper",
+          "lower"
+        ],
         "num_values": 2
       },
       {
@@ -23210,6 +23205,11 @@
           "left",
           "right"
         ],
+        "num_values": 2
+      },
+      {
+        "name": "open",
+        "type": "bool",
         "num_values": 2
       },
       {
@@ -23489,11 +23489,6 @@
     "maxStateId": 15807,
     "states": [
       {
-        "name": "honey_level",
-        "type": "int",
-        "num_values": 6
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -23503,6 +23498,11 @@
           "east"
         ],
         "num_values": 4
+      },
+      {
+        "name": "honey_level",
+        "type": "int",
+        "num_values": 6
       }
     ],
     "drops": [
@@ -23525,11 +23525,6 @@
     "maxStateId": 15831,
     "states": [
       {
-        "name": "honey_level",
-        "type": "int",
-        "num_values": 6
-      },
-      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -23539,6 +23534,11 @@
           "east"
         ],
         "num_values": 4
+      },
+      {
+        "name": "honey_level",
+        "type": "int",
+        "num_values": 6
       }
     ],
     "drops": [
@@ -23876,21 +23876,6 @@
     "maxStateId": 16251,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -23901,7 +23886,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -23921,9 +23906,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -24176,21 +24176,6 @@
     "maxStateId": 16671,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -24201,7 +24186,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -24221,9 +24206,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [
@@ -24403,6 +24403,16 @@
     "maxStateId": 16784,
     "states": [
       {
+        "name": "face",
+        "type": "enum",
+        "values": [
+          "floor",
+          "wall",
+          "ceiling"
+        ],
+        "num_values": 3
+      },
+      {
         "name": "facing",
         "type": "enum",
         "values": [
@@ -24417,16 +24427,6 @@
         "name": "powered",
         "type": "bool",
         "num_values": 2
-      },
-      {
-        "name": "face",
-        "type": "enum",
-        "values": [
-          "floor",
-          "wall",
-          "ceiling"
-        ],
-        "num_values": 3
       }
     ],
     "drops": [
@@ -24448,21 +24448,6 @@
     "maxStateId": 17108,
     "states": [
       {
-        "name": "up",
-        "type": "bool",
-        "num_values": 2
-      },
-      {
-        "name": "north",
-        "type": "enum",
-        "values": [
-          "none",
-          "low",
-          "tall"
-        ],
-        "num_values": 3
-      },
-      {
         "name": "east",
         "type": "enum",
         "values": [
@@ -24473,7 +24458,7 @@
         "num_values": 3
       },
       {
-        "name": "west",
+        "name": "north",
         "type": "enum",
         "values": [
           "none",
@@ -24493,9 +24478,24 @@
         "num_values": 3
       },
       {
+        "name": "up",
+        "type": "bool",
+        "num_values": 2
+      },
+      {
         "name": "waterlogged",
         "type": "bool",
         "num_values": 2
+      },
+      {
+        "name": "west",
+        "type": "enum",
+        "values": [
+          "none",
+          "low",
+          "tall"
+        ],
+        "num_values": 3
       }
     ],
     "drops": [

--- a/data/pc/1.16.2/blocks.json
+++ b/data/pc/1.16.2/blocks.json
@@ -15,7 +15,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 0
   },
   {
     "id": 1,
@@ -41,7 +42,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 1
   },
   {
     "id": 2,
@@ -67,7 +69,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 2
   },
   {
     "id": 3,
@@ -93,7 +96,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 3
   },
   {
     "id": 4,
@@ -119,7 +123,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4
   },
   {
     "id": 5,
@@ -145,7 +150,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5
   },
   {
     "id": 6,
@@ -171,7 +177,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6
   },
   {
     "id": 7,
@@ -197,7 +204,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7
   },
   {
     "id": 8,
@@ -222,7 +230,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9
   },
   {
     "id": 9,
@@ -241,7 +250,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 10
   },
   {
     "id": 10,
@@ -260,7 +270,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 11
   },
   {
     "id": 11,
@@ -285,7 +296,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 13
   },
   {
     "id": 12,
@@ -311,7 +323,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14
   },
   {
     "id": 13,
@@ -330,7 +343,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15
   },
   {
     "id": 14,
@@ -349,7 +363,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 16
   },
   {
     "id": 15,
@@ -368,7 +383,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 17
   },
   {
     "id": 16,
@@ -387,7 +403,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 18
   },
   {
     "id": 17,
@@ -406,7 +423,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 19
   },
   {
     "id": 18,
@@ -425,7 +443,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 20
   },
   {
     "id": 19,
@@ -450,7 +469,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 21
   },
   {
     "id": 20,
@@ -475,7 +495,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 23
   },
   {
     "id": 21,
@@ -500,7 +521,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 25
   },
   {
     "id": 22,
@@ -525,7 +547,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 27
   },
   {
     "id": 23,
@@ -550,7 +573,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 29
   },
   {
     "id": 24,
@@ -575,7 +599,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 31
   },
   {
     "id": 25,
@@ -593,7 +618,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 33
   },
   {
     "id": 26,
@@ -615,7 +641,8 @@
     "filterLight": 2,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 34
   },
   {
     "id": 27,
@@ -637,7 +664,8 @@
     "filterLight": 0,
     "emitLight": 15,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 50
   },
   {
     "id": 28,
@@ -656,7 +684,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 0,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 66
   },
   {
     "id": 29,
@@ -675,7 +704,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 0,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 67
   },
   {
     "id": 30,
@@ -694,7 +724,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 68
   },
   {
     "id": 31,
@@ -717,7 +748,8 @@
     "harvestTools": {
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 69
   },
   {
     "id": 32,
@@ -741,7 +773,8 @@
       "590": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 70
   },
   {
     "id": 33,
@@ -767,7 +800,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 71
   },
   {
     "id": 34,
@@ -793,7 +827,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 72
   },
   {
     "id": 35,
@@ -806,12 +841,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -823,7 +858,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 74
   },
   {
     "id": 36,
@@ -836,12 +872,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -853,7 +889,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 77
   },
   {
     "id": 37,
@@ -866,12 +903,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -883,7 +920,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 80
   },
   {
     "id": 38,
@@ -896,12 +934,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -913,7 +951,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 83
   },
   {
     "id": 39,
@@ -926,12 +965,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -943,7 +982,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 86
   },
   {
     "id": 40,
@@ -956,12 +996,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -973,7 +1013,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 89
   },
   {
     "id": 41,
@@ -986,12 +1027,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1003,7 +1044,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 92
   },
   {
     "id": 42,
@@ -1016,12 +1058,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1033,7 +1075,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 95
   },
   {
     "id": 43,
@@ -1046,12 +1089,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1063,7 +1106,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 98
   },
   {
     "id": 44,
@@ -1076,12 +1120,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1093,7 +1137,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 101
   },
   {
     "id": 45,
@@ -1106,12 +1151,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1123,7 +1168,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 104
   },
   {
     "id": 46,
@@ -1136,12 +1182,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1153,7 +1199,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 107
   },
   {
     "id": 47,
@@ -1166,12 +1213,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1183,7 +1230,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 110
   },
   {
     "id": 48,
@@ -1196,12 +1244,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1213,7 +1261,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 113
   },
   {
     "id": 49,
@@ -1226,12 +1275,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1243,7 +1292,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 116
   },
   {
     "id": 50,
@@ -1256,12 +1306,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1273,7 +1323,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 119
   },
   {
     "id": 51,
@@ -1286,12 +1337,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1303,7 +1354,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 122
   },
   {
     "id": 52,
@@ -1316,12 +1368,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1333,7 +1385,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 125
   },
   {
     "id": 53,
@@ -1346,12 +1399,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1363,7 +1416,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 128
   },
   {
     "id": 54,
@@ -1376,12 +1430,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1393,7 +1447,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 131
   },
   {
     "id": 55,
@@ -1406,12 +1461,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1423,7 +1478,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 134
   },
   {
     "id": 56,
@@ -1436,12 +1492,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1453,7 +1509,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 137
   },
   {
     "id": 57,
@@ -1466,12 +1523,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1483,7 +1540,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 140
   },
   {
     "id": 58,
@@ -1496,12 +1554,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -1513,7 +1571,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 143
   },
   {
     "id": 59,
@@ -1525,8 +1584,17 @@
     "states": [
       {
         "name": "distance",
-        "type": "int",
-        "num_values": 7
+        "type": "enum",
+        "num_values": 7,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7"
+        ]
       },
       {
         "name": "persistent",
@@ -1543,7 +1611,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 158
   },
   {
     "id": 60,
@@ -1555,8 +1624,17 @@
     "states": [
       {
         "name": "distance",
-        "type": "int",
-        "num_values": 7
+        "type": "enum",
+        "num_values": 7,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7"
+        ]
       },
       {
         "name": "persistent",
@@ -1573,7 +1651,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 172
   },
   {
     "id": 61,
@@ -1585,8 +1664,17 @@
     "states": [
       {
         "name": "distance",
-        "type": "int",
-        "num_values": 7
+        "type": "enum",
+        "num_values": 7,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7"
+        ]
       },
       {
         "name": "persistent",
@@ -1603,7 +1691,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 186
   },
   {
     "id": 62,
@@ -1615,8 +1704,17 @@
     "states": [
       {
         "name": "distance",
-        "type": "int",
-        "num_values": 7
+        "type": "enum",
+        "num_values": 7,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7"
+        ]
       },
       {
         "name": "persistent",
@@ -1633,7 +1731,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 200
   },
   {
     "id": 63,
@@ -1645,8 +1744,17 @@
     "states": [
       {
         "name": "distance",
-        "type": "int",
-        "num_values": 7
+        "type": "enum",
+        "num_values": 7,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7"
+        ]
       },
       {
         "name": "persistent",
@@ -1663,7 +1771,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 214
   },
   {
     "id": 64,
@@ -1675,8 +1784,17 @@
     "states": [
       {
         "name": "distance",
-        "type": "int",
-        "num_values": 7
+        "type": "enum",
+        "num_values": 7,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7"
+        ]
       },
       {
         "name": "persistent",
@@ -1693,7 +1811,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 228
   },
   {
     "id": 65,
@@ -1711,7 +1830,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 229
   },
   {
     "id": 66,
@@ -1729,7 +1849,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 230
   },
   {
     "id": 67,
@@ -1747,7 +1868,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 231
   },
   {
     "id": 68,
@@ -1771,7 +1893,8 @@
       "590": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 232
   },
   {
     "id": 69,
@@ -1795,7 +1918,8 @@
       "590": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 233
   },
   {
     "id": 70,
@@ -1808,6 +1932,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -1815,8 +1940,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       },
       {
         "name": "triggered",
@@ -1840,7 +1964,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 235
   },
   {
     "id": 71,
@@ -1866,7 +1991,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 246
   },
   {
     "id": 72,
@@ -1892,7 +2018,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 247
   },
   {
     "id": 73,
@@ -1918,7 +2045,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 248
   },
   {
     "id": 74,
@@ -1931,6 +2059,7 @@
       {
         "name": "instrument",
         "type": "enum",
+        "num_values": 16,
         "values": [
           "harp",
           "basedrum",
@@ -1948,8 +2077,7 @@
           "bit",
           "banjo",
           "pling"
-        ],
-        "num_values": 16
+        ]
       },
       {
         "name": "note",
@@ -1971,7 +2099,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 250
   },
   {
     "id": 75,
@@ -1984,13 +2113,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2000,11 +2129,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2015,7 +2144,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1052
   },
   {
     "id": 76,
@@ -2028,13 +2158,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2044,11 +2174,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2059,7 +2189,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1068
   },
   {
     "id": 77,
@@ -2072,13 +2203,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2088,11 +2219,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2103,7 +2234,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1084
   },
   {
     "id": 78,
@@ -2116,13 +2248,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2132,11 +2264,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2147,7 +2279,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1100
   },
   {
     "id": 79,
@@ -2160,13 +2293,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2176,11 +2309,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2191,7 +2324,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1116
   },
   {
     "id": 80,
@@ -2204,13 +2338,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2220,11 +2354,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2235,7 +2369,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1132
   },
   {
     "id": 81,
@@ -2248,13 +2383,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2264,11 +2399,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2279,7 +2414,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1148
   },
   {
     "id": 82,
@@ -2292,13 +2428,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2308,11 +2444,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2323,7 +2459,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1164
   },
   {
     "id": 83,
@@ -2336,13 +2473,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2352,11 +2489,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2367,7 +2504,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1180
   },
   {
     "id": 84,
@@ -2380,13 +2518,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2396,11 +2534,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2411,7 +2549,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1196
   },
   {
     "id": 85,
@@ -2424,13 +2563,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2440,11 +2579,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2455,7 +2594,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1212
   },
   {
     "id": 86,
@@ -2468,13 +2608,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2484,11 +2624,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2499,7 +2639,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1228
   },
   {
     "id": 87,
@@ -2512,13 +2653,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2528,11 +2669,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2543,7 +2684,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1244
   },
   {
     "id": 88,
@@ -2556,13 +2698,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2572,11 +2714,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2587,7 +2729,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1260
   },
   {
     "id": 89,
@@ -2600,13 +2743,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2616,11 +2759,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2631,7 +2774,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1276
   },
   {
     "id": 90,
@@ -2644,13 +2788,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "occupied",
@@ -2660,11 +2804,11 @@
       {
         "name": "part",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "head",
           "foot"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2675,7 +2819,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 1292
   },
   {
     "id": 91,
@@ -2693,6 +2838,7 @@
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north_south",
           "east_west",
@@ -2700,8 +2846,7 @@
           "ascending_west",
           "ascending_north",
           "ascending_south"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -2713,7 +2858,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 1311
   },
   {
     "id": 92,
@@ -2731,6 +2877,7 @@
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north_south",
           "east_west",
@@ -2738,8 +2885,7 @@
           "ascending_west",
           "ascending_north",
           "ascending_south"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -2751,7 +2897,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 1323
   },
   {
     "id": 93,
@@ -2769,6 +2916,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -2776,8 +2924,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -2788,7 +2935,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 1335
   },
   {
     "id": 94,
@@ -2815,7 +2963,8 @@
       "598": true,
       "603": true,
       "734": true
-    }
+    },
+    "defaultState": 1341
   },
   {
     "id": 95,
@@ -2834,7 +2983,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1342
   },
   {
     "id": 96,
@@ -2853,7 +3003,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1343
   },
   {
     "id": 97,
@@ -2872,7 +3023,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1344
   },
   {
     "id": 98,
@@ -2891,7 +3043,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1345
   },
   {
     "id": 99,
@@ -2904,11 +3057,11 @@
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -2920,7 +3073,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1347
   },
   {
     "id": 100,
@@ -2938,6 +3092,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -2945,8 +3100,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -2957,7 +3111,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 1354
   },
   {
     "id": 101,
@@ -2970,6 +3125,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -2977,8 +3133,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       },
       {
         "name": "short",
@@ -2988,11 +3143,11 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "normal",
           "sticky"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [],
@@ -3001,7 +3156,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 1362
   },
   {
     "id": 102,
@@ -3020,7 +3176,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1384
   },
   {
     "id": 103,
@@ -3039,7 +3196,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1385
   },
   {
     "id": 104,
@@ -3058,7 +3216,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1386
   },
   {
     "id": 105,
@@ -3077,7 +3236,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1387
   },
   {
     "id": 106,
@@ -3096,7 +3256,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1388
   },
   {
     "id": 107,
@@ -3115,7 +3276,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1389
   },
   {
     "id": 108,
@@ -3134,7 +3296,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1390
   },
   {
     "id": 109,
@@ -3153,7 +3316,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1391
   },
   {
     "id": 110,
@@ -3172,7 +3336,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1392
   },
   {
     "id": 111,
@@ -3191,7 +3356,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1393
   },
   {
     "id": 112,
@@ -3210,7 +3376,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1394
   },
   {
     "id": 113,
@@ -3229,7 +3396,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1395
   },
   {
     "id": 114,
@@ -3248,7 +3416,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1396
   },
   {
     "id": 115,
@@ -3267,7 +3436,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1397
   },
   {
     "id": 116,
@@ -3286,7 +3456,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1398
   },
   {
     "id": 117,
@@ -3305,7 +3476,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wool"
+    "material": "wool",
+    "defaultState": 1399
   },
   {
     "id": 118,
@@ -3318,6 +3490,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -3325,17 +3498,16 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       },
       {
         "name": "type",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "normal",
           "sticky"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [],
@@ -3344,7 +3516,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 1400
   },
   {
     "id": 119,
@@ -3363,7 +3536,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1412
   },
   {
     "id": 120,
@@ -3382,7 +3556,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1413
   },
   {
     "id": 121,
@@ -3401,7 +3576,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1414
   },
   {
     "id": 122,
@@ -3420,7 +3596,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1415
   },
   {
     "id": 123,
@@ -3439,7 +3616,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1416
   },
   {
     "id": 124,
@@ -3458,7 +3636,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1417
   },
   {
     "id": 125,
@@ -3477,7 +3656,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1418
   },
   {
     "id": 126,
@@ -3496,7 +3676,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1419
   },
   {
     "id": 127,
@@ -3515,7 +3696,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1420
   },
   {
     "id": 128,
@@ -3534,7 +3716,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1421
   },
   {
     "id": 129,
@@ -3553,7 +3736,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1422
   },
   {
     "id": 130,
@@ -3572,7 +3756,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1423
   },
   {
     "id": 131,
@@ -3591,7 +3776,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1424
   },
   {
     "id": 132,
@@ -3610,7 +3796,8 @@
     "emitLight": 1,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1425
   },
   {
     "id": 133,
@@ -3629,7 +3816,8 @@
     "emitLight": 1,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 1426
   },
   {
     "id": 134,
@@ -3652,7 +3840,8 @@
     "harvestTools": {
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 1427
   },
   {
     "id": 135,
@@ -3676,7 +3865,8 @@
       "590": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 1428
   },
   {
     "id": 136,
@@ -3702,7 +3892,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 1429
   },
   {
     "id": 137,
@@ -3726,7 +3917,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 1431
   },
   {
     "id": 138,
@@ -3745,7 +3937,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 1432
   },
   {
     "id": 139,
@@ -3771,7 +3964,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 1433
   },
   {
     "id": 140,
@@ -3793,7 +3987,8 @@
     "material": "rock",
     "harvestTools": {
       "605": true
-    }
+    },
+    "defaultState": 1434
   },
   {
     "id": 141,
@@ -3811,7 +4006,8 @@
     "filterLight": 0,
     "emitLight": 14,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 1435
   },
   {
     "id": 142,
@@ -3824,13 +4020,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -3841,7 +4037,8 @@
     "filterLight": 0,
     "emitLight": 14,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 1436
   },
   {
     "id": 143,
@@ -3888,7 +4085,8 @@
     "filterLight": 0,
     "emitLight": 15,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 1471
   },
   {
     "id": 144,
@@ -3904,7 +4102,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 1952
   },
   {
     "id": 145,
@@ -3930,7 +4129,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 1953
   },
   {
     "id": 146,
@@ -3943,34 +4143,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -3987,7 +4187,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 1965
   },
   {
     "id": 147,
@@ -4000,23 +4201,23 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "single",
           "left",
           "right"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -4033,7 +4234,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 2035
   },
   {
     "id": 148,
@@ -4046,22 +4248,22 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "up",
           "side",
           "none"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "up",
           "side",
           "none"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "power",
@@ -4071,22 +4273,22 @@
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "up",
           "side",
           "none"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "up",
           "side",
           "none"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -4097,7 +4299,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 3218
   },
   {
     "id": 149,
@@ -4120,7 +4323,8 @@
     "harvestTools": {
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 3354
   },
   {
     "id": 150,
@@ -4143,7 +4347,8 @@
     "harvestTools": {
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 3355
   },
   {
     "id": 151,
@@ -4162,7 +4367,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3356
   },
   {
     "id": 152,
@@ -4187,7 +4393,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 3357
   },
   {
     "id": 153,
@@ -4212,7 +4419,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 3365
   },
   {
     "id": 154,
@@ -4225,13 +4433,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "lit",
@@ -4255,7 +4463,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 3374
   },
   {
     "id": 155,
@@ -4285,7 +4494,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3382
   },
   {
     "id": 156,
@@ -4315,7 +4525,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3414
   },
   {
     "id": 157,
@@ -4345,7 +4556,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3446
   },
   {
     "id": 158,
@@ -4375,7 +4587,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3478
   },
   {
     "id": 159,
@@ -4405,7 +4618,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3510
   },
   {
     "id": 160,
@@ -4435,7 +4649,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3542
   },
   {
     "id": 161,
@@ -4448,31 +4663,31 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "hinge",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "left",
           "right"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -4494,7 +4709,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3584
   },
   {
     "id": 162,
@@ -4507,13 +4723,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -4529,7 +4745,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 3638
   },
   {
     "id": 163,
@@ -4542,6 +4759,7 @@
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 10,
         "values": [
           "north_south",
           "east_west",
@@ -4553,8 +4771,7 @@
           "south_west",
           "north_west",
           "north_east"
-        ],
-        "num_values": 10
+        ]
       }
     ],
     "drops": [
@@ -4566,7 +4783,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 3645
   },
   {
     "id": 164,
@@ -4579,34 +4797,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -4630,7 +4848,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 3666
   },
   {
     "id": 165,
@@ -4643,13 +4862,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -4666,7 +4885,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3736
   },
   {
     "id": 166,
@@ -4679,13 +4899,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -4702,7 +4922,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3744
   },
   {
     "id": 167,
@@ -4715,13 +4936,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -4738,7 +4959,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3752
   },
   {
     "id": 168,
@@ -4751,13 +4973,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -4774,7 +4996,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3760
   },
   {
     "id": 169,
@@ -4787,13 +5010,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -4810,7 +5033,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3768
   },
   {
     "id": 170,
@@ -4823,13 +5047,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -4846,7 +5070,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3776
   },
   {
     "id": 171,
@@ -4859,23 +5084,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -4891,7 +5116,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 3792
   },
   {
     "id": 172,
@@ -4923,7 +5149,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 3808
   },
   {
     "id": 173,
@@ -4936,31 +5163,31 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "hinge",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "left",
           "right"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -4989,7 +5216,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 3820
   },
   {
     "id": 174,
@@ -5014,7 +5242,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3874
   },
   {
     "id": 175,
@@ -5039,7 +5268,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3876
   },
   {
     "id": 176,
@@ -5064,7 +5294,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3878
   },
   {
     "id": 177,
@@ -5089,7 +5320,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3880
   },
   {
     "id": 178,
@@ -5114,7 +5346,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3882
   },
   {
     "id": 179,
@@ -5139,7 +5372,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3884
   },
   {
     "id": 180,
@@ -5168,7 +5402,8 @@
     "harvestTools": {
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 3886
   },
   {
     "id": 181,
@@ -5192,7 +5427,8 @@
     "filterLight": 0,
     "emitLight": 7,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 3887
   },
   {
     "id": 182,
@@ -5205,13 +5441,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "lit",
@@ -5227,7 +5463,8 @@
     "filterLight": 0,
     "emitLight": 7,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 3889
   },
   {
     "id": 183,
@@ -5240,23 +5477,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -5273,7 +5510,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 3906
   },
   {
     "id": 184,
@@ -5285,8 +5523,18 @@
     "states": [
       {
         "name": "layers",
-        "type": "int",
-        "num_values": 8
+        "type": "enum",
+        "num_values": 8,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8"
+        ]
       }
     ],
     "drops": [
@@ -5305,7 +5553,8 @@
       "594": true,
       "599": true,
       "604": true
-    }
+    },
+    "defaultState": 3921
   },
   {
     "id": 185,
@@ -5324,7 +5573,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 3929
   },
   {
     "id": 186,
@@ -5350,7 +5600,8 @@
       "594": true,
       "599": true,
       "604": true
-    }
+    },
+    "defaultState": 3930
   },
   {
     "id": 187,
@@ -5375,7 +5626,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 3931
   },
   {
     "id": 188,
@@ -5394,7 +5646,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 3947
   },
   {
     "id": 189,
@@ -5419,7 +5672,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 3948
   },
   {
     "id": 190,
@@ -5444,7 +5698,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3965
   },
   {
     "id": 191,
@@ -5489,7 +5744,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 3997
   },
   {
     "id": 192,
@@ -5508,7 +5764,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 3998
   },
   {
     "id": 193,
@@ -5534,7 +5791,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 3999
   },
   {
     "id": 194,
@@ -5553,7 +5811,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 4000
   },
   {
     "id": 195,
@@ -5572,7 +5831,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 4001
   },
   {
     "id": 196,
@@ -5585,12 +5845,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -5609,7 +5869,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4003
   },
   {
     "id": 197,
@@ -5622,12 +5883,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -5646,7 +5907,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4006
   },
   {
     "id": 198,
@@ -5664,7 +5926,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4008
   },
   {
     "id": 199,
@@ -5677,13 +5940,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -5694,7 +5957,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4009
   },
   {
     "id": 200,
@@ -5712,7 +5976,8 @@
     "filterLight": 0,
     "emitLight": 15,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4013
   },
   {
     "id": 201,
@@ -5725,11 +5990,11 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "x",
           "z"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [],
@@ -5738,7 +6003,8 @@
     "filterLight": 0,
     "emitLight": 11,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 4014
   },
   {
     "id": 202,
@@ -5751,13 +6017,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -5769,7 +6035,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 4016
   },
   {
     "id": 203,
@@ -5782,13 +6049,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -5800,7 +6067,8 @@
     "emitLight": 15,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 4020
   },
   {
     "id": 204,
@@ -5824,7 +6092,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 4024
   },
   {
     "id": 205,
@@ -5836,19 +6105,25 @@
     "states": [
       {
         "name": "delay",
-        "type": "int",
-        "num_values": 4
+        "type": "enum",
+        "num_values": 4,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "locked",
@@ -5869,7 +6144,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4034
   },
   {
     "id": 206,
@@ -5887,7 +6163,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4095
   },
   {
     "id": 207,
@@ -5905,7 +6182,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4096
   },
   {
     "id": 208,
@@ -5923,7 +6201,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4097
   },
   {
     "id": 209,
@@ -5941,7 +6220,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4098
   },
   {
     "id": 210,
@@ -5959,7 +6239,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4099
   },
   {
     "id": 211,
@@ -5977,7 +6258,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4100
   },
   {
     "id": 212,
@@ -5995,7 +6277,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4101
   },
   {
     "id": 213,
@@ -6013,7 +6296,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4102
   },
   {
     "id": 214,
@@ -6031,7 +6315,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4103
   },
   {
     "id": 215,
@@ -6049,7 +6334,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4104
   },
   {
     "id": 216,
@@ -6067,7 +6353,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4105
   },
   {
     "id": 217,
@@ -6085,7 +6372,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4106
   },
   {
     "id": 218,
@@ -6103,7 +6391,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4107
   },
   {
     "id": 219,
@@ -6121,7 +6410,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4108
   },
   {
     "id": 220,
@@ -6139,7 +6429,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4109
   },
   {
     "id": 221,
@@ -6157,7 +6448,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4110
   },
   {
     "id": 222,
@@ -6170,22 +6462,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -6212,7 +6504,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4126
   },
   {
     "id": 223,
@@ -6225,22 +6518,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -6267,7 +6560,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4190
   },
   {
     "id": 224,
@@ -6280,22 +6574,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -6322,7 +6616,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4254
   },
   {
     "id": 225,
@@ -6335,22 +6630,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -6377,7 +6672,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4318
   },
   {
     "id": 226,
@@ -6390,22 +6686,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -6432,7 +6728,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4382
   },
   {
     "id": 227,
@@ -6445,22 +6742,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -6487,7 +6784,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4446
   },
   {
     "id": 228,
@@ -6513,7 +6811,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4495
   },
   {
     "id": 229,
@@ -6539,7 +6838,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4496
   },
   {
     "id": 230,
@@ -6565,7 +6865,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4497
   },
   {
     "id": 231,
@@ -6591,7 +6892,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4498
   },
   {
     "id": 232,
@@ -6617,7 +6919,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4499
   },
   {
     "id": 233,
@@ -6643,7 +6946,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4500
   },
   {
     "id": 234,
@@ -6669,7 +6973,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4501
   },
   {
     "id": 235,
@@ -6695,7 +7000,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4502
   },
   {
     "id": 236,
@@ -6721,7 +7027,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4503
   },
   {
     "id": 237,
@@ -6747,7 +7054,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4504
   },
   {
     "id": 238,
@@ -6797,7 +7105,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4505
   },
   {
     "id": 239,
@@ -6847,7 +7156,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4569
   },
   {
     "id": 240,
@@ -6897,7 +7207,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4633
   },
   {
     "id": 241,
@@ -6949,7 +7260,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4728
   },
   {
     "id": 242,
@@ -6962,12 +7274,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -6991,7 +7303,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4732
   },
   {
     "id": 243,
@@ -7035,7 +7348,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 4766
   },
   {
     "id": 244,
@@ -7054,7 +7368,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 4767
   },
   {
     "id": 245,
@@ -7067,13 +7382,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [],
@@ -7083,7 +7398,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 4768
   },
   {
     "id": 246,
@@ -7096,13 +7412,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [],
@@ -7112,7 +7428,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 4772
   },
   {
     "id": 247,
@@ -7137,7 +7454,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 4776
   },
   {
     "id": 248,
@@ -7162,7 +7480,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 4784
   },
   {
     "id": 249,
@@ -7207,7 +7526,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 4823
   },
   {
     "id": 250,
@@ -7220,13 +7540,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "in_wall",
@@ -7253,7 +7573,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 4831
   },
   {
     "id": 251,
@@ -7266,34 +7587,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -7317,7 +7638,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4867
   },
   {
     "id": 252,
@@ -7330,34 +7652,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -7381,7 +7703,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 4947
   },
   {
     "id": 253,
@@ -7406,7 +7729,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 5017
   },
   {
     "id": 254,
@@ -7425,7 +7749,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 5018
   },
   {
     "id": 255,
@@ -7451,7 +7776,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5019
   },
   {
     "id": 256,
@@ -7503,7 +7829,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5051
   },
   {
     "id": 257,
@@ -7516,34 +7843,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -7567,7 +7894,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5063
   },
   {
     "id": 258,
@@ -7592,7 +7920,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 5132
   },
   {
     "id": 259,
@@ -7618,7 +7947,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5136
   },
   {
     "id": 260,
@@ -7660,7 +7990,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5144
   },
   {
     "id": 261,
@@ -7692,7 +8023,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5145
   },
   {
     "id": 262,
@@ -7708,7 +8040,8 @@
     "filterLight": 0,
     "emitLight": 15,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 5149
   },
   {
     "id": 263,
@@ -7726,13 +8059,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -7743,7 +8076,8 @@
     "filterLight": 0,
     "emitLight": 1,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 5154
   },
   {
     "id": 264,
@@ -7769,7 +8103,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5158
   },
   {
     "id": 265,
@@ -7787,7 +8122,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 5159
   },
   {
     "id": 266,
@@ -7811,7 +8147,8 @@
     "filterLight": 0,
     "emitLight": 15,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 5161
   },
   {
     "id": 267,
@@ -7829,13 +8166,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -7847,7 +8184,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 5162
   },
   {
     "id": 268,
@@ -7860,34 +8198,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -7911,7 +8249,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5185
   },
   {
     "id": 269,
@@ -7934,7 +8273,8 @@
     "harvestTools": {
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5254
   },
   {
     "id": 270,
@@ -7947,13 +8287,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -7977,7 +8317,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5256
   },
   {
     "id": 271,
@@ -7995,13 +8336,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -8017,7 +8358,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 5272
   },
   {
     "id": 272,
@@ -8071,7 +8413,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 5406
   },
   {
     "id": 273,
@@ -8094,7 +8437,8 @@
     "harvestTools": {
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5407
   },
   {
     "id": 274,
@@ -8107,34 +8451,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -8151,7 +8495,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 5419
   },
   {
     "id": 275,
@@ -8164,34 +8509,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -8208,7 +8553,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 5499
   },
   {
     "id": 276,
@@ -8221,34 +8567,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -8265,7 +8611,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 5579
   },
   {
     "id": 277,
@@ -8283,6 +8630,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -8290,8 +8638,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -8302,7 +8649,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 5654
   },
   {
     "id": 278,
@@ -8320,7 +8668,8 @@
     "filterLight": 0,
     "emitLight": 15,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 5660
   },
   {
     "id": 279,
@@ -8333,32 +8682,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -8373,12 +8722,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -8397,7 +8746,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5664
   },
   {
     "id": 280,
@@ -8410,32 +8760,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -8450,12 +8800,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -8474,7 +8824,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 5988
   },
   {
     "id": 281,
@@ -8492,7 +8843,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6309
   },
   {
     "id": 282,
@@ -8511,7 +8863,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6310
   },
   {
     "id": 283,
@@ -8530,7 +8883,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6311
   },
   {
     "id": 284,
@@ -8549,7 +8903,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6312
   },
   {
     "id": 285,
@@ -8568,7 +8923,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6313
   },
   {
     "id": 286,
@@ -8587,7 +8943,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6314
   },
   {
     "id": 287,
@@ -8606,7 +8963,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6315
   },
   {
     "id": 288,
@@ -8625,7 +8983,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6316
   },
   {
     "id": 289,
@@ -8645,7 +9004,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 6317
   },
   {
     "id": 290,
@@ -8664,7 +9024,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6318
   },
   {
     "id": 291,
@@ -8683,7 +9044,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6319
   },
   {
     "id": 292,
@@ -8702,7 +9064,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6320
   },
   {
     "id": 293,
@@ -8721,7 +9084,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6321
   },
   {
     "id": 294,
@@ -8740,7 +9104,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6322
   },
   {
     "id": 295,
@@ -8759,7 +9124,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6323
   },
   {
     "id": 296,
@@ -8778,7 +9144,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6324
   },
   {
     "id": 297,
@@ -8797,7 +9164,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6325
   },
   {
     "id": 298,
@@ -8816,7 +9184,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6326
   },
   {
     "id": 299,
@@ -8835,7 +9204,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6327
   },
   {
     "id": 300,
@@ -8854,7 +9224,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6328
   },
   {
     "id": 301,
@@ -8873,7 +9244,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6329
   },
   {
     "id": 302,
@@ -8892,7 +9264,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6330
   },
   {
     "id": 303,
@@ -8911,7 +9284,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6331
   },
   {
     "id": 304,
@@ -8930,7 +9304,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6332
   },
   {
     "id": 305,
@@ -8949,7 +9324,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6333
   },
   {
     "id": 306,
@@ -8974,7 +9350,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 6334
   },
   {
     "id": 307,
@@ -8999,7 +9376,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 6342
   },
   {
     "id": 308,
@@ -9012,23 +9390,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -9045,7 +9423,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 6359
   },
   {
     "id": 309,
@@ -9058,23 +9437,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -9091,7 +9470,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 6383
   },
   {
     "id": 310,
@@ -9104,23 +9484,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -9137,7 +9517,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 6407
   },
   {
     "id": 311,
@@ -9150,23 +9531,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -9183,7 +9564,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 6431
   },
   {
     "id": 312,
@@ -9196,23 +9578,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -9229,7 +9611,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 6455
   },
   {
     "id": 313,
@@ -9242,23 +9625,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -9275,7 +9658,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 6479
   },
   {
     "id": 314,
@@ -9299,7 +9683,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6494
   },
   {
     "id": 315,
@@ -9312,13 +9697,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -9329,7 +9714,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6510
   },
   {
     "id": 316,
@@ -9353,7 +9739,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6514
   },
   {
     "id": 317,
@@ -9366,13 +9753,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -9383,7 +9770,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6530
   },
   {
     "id": 318,
@@ -9407,7 +9795,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6534
   },
   {
     "id": 319,
@@ -9420,13 +9809,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -9437,7 +9826,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6550
   },
   {
     "id": 320,
@@ -9461,7 +9851,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6554
   },
   {
     "id": 321,
@@ -9474,13 +9865,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -9491,7 +9882,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6570
   },
   {
     "id": 322,
@@ -9515,7 +9907,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6574
   },
   {
     "id": 323,
@@ -9528,13 +9921,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -9545,7 +9938,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6590
   },
   {
     "id": 324,
@@ -9569,7 +9963,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6594
   },
   {
     "id": 325,
@@ -9582,13 +9977,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -9599,7 +9994,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6610
   },
   {
     "id": 326,
@@ -9612,13 +10008,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -9637,7 +10033,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6614
   },
   {
     "id": 327,
@@ -9650,13 +10047,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -9675,7 +10072,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6618
   },
   {
     "id": 328,
@@ -9688,13 +10086,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -9713,7 +10111,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6622
   },
   {
     "id": 329,
@@ -9726,23 +10125,23 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "single",
           "left",
           "right"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -9759,7 +10158,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 6627
   },
   {
     "id": 330,
@@ -9791,7 +10191,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6650
   },
   {
     "id": 331,
@@ -9823,7 +10224,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6666
   },
   {
     "id": 332,
@@ -9836,22 +10238,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "mode",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "compare",
           "subtract"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "powered",
@@ -9867,7 +10269,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6683
   },
   {
     "id": 333,
@@ -9897,7 +10300,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 6714
   },
   {
     "id": 334,
@@ -9923,7 +10327,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6730
   },
   {
     "id": 335,
@@ -9949,7 +10354,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6731
   },
   {
     "id": 336,
@@ -9967,14 +10373,14 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "down",
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 5
+        ]
       }
     ],
     "drops": [
@@ -9993,7 +10399,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6732
   },
   {
     "id": 337,
@@ -10019,7 +10426,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6742
   },
   {
     "id": 338,
@@ -10045,7 +10453,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6743
   },
   {
     "id": 339,
@@ -10058,12 +10467,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -10082,7 +10491,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6745
   },
   {
     "id": 340,
@@ -10095,34 +10505,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -10146,7 +10556,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6758
   },
   {
     "id": 341,
@@ -10164,6 +10575,7 @@
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north_south",
           "east_west",
@@ -10171,8 +10583,7 @@
           "ascending_west",
           "ascending_north",
           "ascending_south"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -10184,7 +10595,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 6833
   },
   {
     "id": 342,
@@ -10197,6 +10609,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -10204,8 +10617,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       },
       {
         "name": "triggered",
@@ -10229,7 +10641,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6840
   },
   {
     "id": 343,
@@ -10255,7 +10668,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6851
   },
   {
     "id": 344,
@@ -10281,7 +10695,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6852
   },
   {
     "id": 345,
@@ -10307,7 +10722,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6853
   },
   {
     "id": 346,
@@ -10333,7 +10749,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6854
   },
   {
     "id": 347,
@@ -10359,7 +10776,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6855
   },
   {
     "id": 348,
@@ -10385,7 +10803,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6856
   },
   {
     "id": 349,
@@ -10411,7 +10830,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6857
   },
   {
     "id": 350,
@@ -10437,7 +10857,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6858
   },
   {
     "id": 351,
@@ -10463,7 +10884,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6859
   },
   {
     "id": 352,
@@ -10489,7 +10911,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6860
   },
   {
     "id": 353,
@@ -10515,7 +10938,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6861
   },
   {
     "id": 354,
@@ -10541,7 +10965,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6862
   },
   {
     "id": 355,
@@ -10567,7 +10992,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6863
   },
   {
     "id": 356,
@@ -10593,7 +11019,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6864
   },
   {
     "id": 357,
@@ -10619,7 +11046,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6865
   },
   {
     "id": 358,
@@ -10645,7 +11073,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 6866
   },
   {
     "id": 359,
@@ -10689,7 +11118,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6898
   },
   {
     "id": 360,
@@ -10733,7 +11163,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6930
   },
   {
     "id": 361,
@@ -10777,7 +11208,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6962
   },
   {
     "id": 362,
@@ -10821,7 +11253,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 6994
   },
   {
     "id": 363,
@@ -10865,7 +11298,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7026
   },
   {
     "id": 364,
@@ -10909,7 +11343,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7058
   },
   {
     "id": 365,
@@ -10953,7 +11388,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7090
   },
   {
     "id": 366,
@@ -10997,7 +11433,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7122
   },
   {
     "id": 367,
@@ -11041,7 +11478,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7154
   },
   {
     "id": 368,
@@ -11085,7 +11523,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7186
   },
   {
     "id": 369,
@@ -11129,7 +11568,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7218
   },
   {
     "id": 370,
@@ -11173,7 +11613,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7250
   },
   {
     "id": 371,
@@ -11217,7 +11658,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7282
   },
   {
     "id": 372,
@@ -11261,7 +11703,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7314
   },
   {
     "id": 373,
@@ -11305,7 +11748,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7346
   },
   {
     "id": 374,
@@ -11349,7 +11793,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7378
   },
   {
     "id": 375,
@@ -11362,34 +11807,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -11406,7 +11851,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 7390
   },
   {
     "id": 376,
@@ -11419,34 +11865,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -11463,7 +11909,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 7470
   },
   {
     "id": 377,
@@ -11481,7 +11928,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7539
   },
   {
     "id": 378,
@@ -11499,7 +11947,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7540
   },
   {
     "id": 379,
@@ -11512,22 +11961,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -11561,7 +12010,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7556
   },
   {
     "id": 380,
@@ -11587,7 +12037,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7605
   },
   {
     "id": 381,
@@ -11613,7 +12064,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7606
   },
   {
     "id": 382,
@@ -11639,7 +12091,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7607
   },
   {
     "id": 383,
@@ -11652,34 +12105,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -11703,7 +12156,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7619
   },
   {
     "id": 384,
@@ -11716,34 +12170,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -11767,7 +12221,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7699
   },
   {
     "id": 385,
@@ -11780,34 +12235,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -11831,7 +12286,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7779
   },
   {
     "id": 386,
@@ -11844,12 +12300,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -11873,7 +12329,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7851
   },
   {
     "id": 387,
@@ -11886,12 +12343,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -11915,7 +12372,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7857
   },
   {
     "id": 388,
@@ -11928,12 +12386,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -11957,7 +12415,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7863
   },
   {
     "id": 389,
@@ -11975,7 +12434,8 @@
     "filterLight": 0,
     "emitLight": 15,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7866
   },
   {
     "id": 390,
@@ -11988,12 +12448,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -12004,7 +12464,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7868
   },
   {
     "id": 391,
@@ -12022,7 +12483,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7870
   },
   {
     "id": 392,
@@ -12040,7 +12502,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7871
   },
   {
     "id": 393,
@@ -12058,7 +12521,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7872
   },
   {
     "id": 394,
@@ -12076,7 +12540,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7873
   },
   {
     "id": 395,
@@ -12094,7 +12559,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7874
   },
   {
     "id": 396,
@@ -12112,7 +12578,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7875
   },
   {
     "id": 397,
@@ -12130,7 +12597,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7876
   },
   {
     "id": 398,
@@ -12148,7 +12616,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7877
   },
   {
     "id": 399,
@@ -12166,7 +12635,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7878
   },
   {
     "id": 400,
@@ -12184,7 +12654,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7879
   },
   {
     "id": 401,
@@ -12202,7 +12673,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7880
   },
   {
     "id": 402,
@@ -12220,7 +12692,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7881
   },
   {
     "id": 403,
@@ -12238,7 +12711,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7882
   },
   {
     "id": 404,
@@ -12256,7 +12730,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7883
   },
   {
     "id": 405,
@@ -12274,7 +12749,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7884
   },
   {
     "id": 406,
@@ -12292,7 +12768,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 7885
   },
   {
     "id": 407,
@@ -12318,7 +12795,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7886
   },
   {
     "id": 408,
@@ -12344,7 +12822,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7887
   },
   {
     "id": 409,
@@ -12363,7 +12842,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 7888
   },
   {
     "id": 410,
@@ -12376,11 +12856,11 @@
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -12392,7 +12872,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 7890
   },
   {
     "id": 411,
@@ -12405,11 +12886,11 @@
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -12421,7 +12902,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 7892
   },
   {
     "id": 412,
@@ -12434,11 +12916,11 @@
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -12450,7 +12932,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 7894
   },
   {
     "id": 413,
@@ -12463,11 +12946,11 @@
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -12486,7 +12969,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 7896
   },
   {
     "id": 414,
@@ -12499,11 +12983,11 @@
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -12515,7 +12999,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 7898
   },
   {
     "id": 415,
@@ -12528,11 +13013,11 @@
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       }
     ],
     "drops": [
@@ -12544,7 +13029,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 7900
   },
   {
     "id": 416,
@@ -12569,7 +13055,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 7901
   },
   {
     "id": 417,
@@ -12594,7 +13081,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 7917
   },
   {
     "id": 418,
@@ -12619,7 +13107,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 7933
   },
   {
     "id": 419,
@@ -12644,7 +13133,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 7949
   },
   {
     "id": 420,
@@ -12669,7 +13159,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 7965
   },
   {
     "id": 421,
@@ -12694,7 +13185,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 7981
   },
   {
     "id": 422,
@@ -12719,7 +13211,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 7997
   },
   {
     "id": 423,
@@ -12744,7 +13237,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8013
   },
   {
     "id": 424,
@@ -12769,7 +13263,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8029
   },
   {
     "id": 425,
@@ -12794,7 +13289,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8045
   },
   {
     "id": 426,
@@ -12819,7 +13315,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8061
   },
   {
     "id": 427,
@@ -12844,7 +13341,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8077
   },
   {
     "id": 428,
@@ -12869,7 +13367,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8093
   },
   {
     "id": 429,
@@ -12894,7 +13393,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8109
   },
   {
     "id": 430,
@@ -12919,7 +13419,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8125
   },
   {
     "id": 431,
@@ -12944,7 +13445,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8141
   },
   {
     "id": 432,
@@ -12957,13 +13459,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -12975,7 +13477,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8157
   },
   {
     "id": 433,
@@ -12988,13 +13491,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13006,7 +13509,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8161
   },
   {
     "id": 434,
@@ -13019,13 +13523,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13037,7 +13541,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8165
   },
   {
     "id": 435,
@@ -13050,13 +13555,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13068,7 +13573,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8169
   },
   {
     "id": 436,
@@ -13081,13 +13587,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13099,7 +13605,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8173
   },
   {
     "id": 437,
@@ -13112,13 +13619,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13130,7 +13637,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8177
   },
   {
     "id": 438,
@@ -13143,13 +13651,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13161,7 +13669,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8181
   },
   {
     "id": 439,
@@ -13174,13 +13683,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13192,7 +13701,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8185
   },
   {
     "id": 440,
@@ -13205,13 +13715,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13223,7 +13733,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8189
   },
   {
     "id": 441,
@@ -13236,13 +13747,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13254,7 +13765,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8193
   },
   {
     "id": 442,
@@ -13267,13 +13779,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13285,7 +13797,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8197
   },
   {
     "id": 443,
@@ -13298,13 +13811,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13316,7 +13829,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8201
   },
   {
     "id": 444,
@@ -13329,13 +13843,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13347,7 +13861,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8205
   },
   {
     "id": 445,
@@ -13360,13 +13875,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13378,7 +13893,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8209
   },
   {
     "id": 446,
@@ -13391,13 +13907,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13409,7 +13925,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8213
   },
   {
     "id": 447,
@@ -13422,13 +13939,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -13440,7 +13957,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8217
   },
   {
     "id": 448,
@@ -13466,7 +13984,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8221
   },
   {
     "id": 449,
@@ -13492,7 +14011,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8222
   },
   {
     "id": 450,
@@ -13518,7 +14038,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8223
   },
   {
     "id": 451,
@@ -13531,34 +14052,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -13582,7 +14103,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8235
   },
   {
     "id": 452,
@@ -13595,12 +14117,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -13624,7 +14146,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8307
   },
   {
     "id": 453,
@@ -13637,12 +14160,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -13666,7 +14189,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8313
   },
   {
     "id": 454,
@@ -13679,12 +14203,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -13708,7 +14232,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8319
   },
   {
     "id": 455,
@@ -13721,12 +14246,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -13750,7 +14275,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8325
   },
   {
     "id": 456,
@@ -13763,12 +14289,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -13792,7 +14318,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8331
   },
   {
     "id": 457,
@@ -13805,12 +14332,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -13834,7 +14361,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8337
   },
   {
     "id": 458,
@@ -13847,12 +14375,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -13876,7 +14404,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8343
   },
   {
     "id": 459,
@@ -13889,12 +14418,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -13918,7 +14447,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8349
   },
   {
     "id": 460,
@@ -13931,12 +14461,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -13960,7 +14490,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8355
   },
   {
     "id": 461,
@@ -13973,12 +14504,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14002,7 +14533,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8361
   },
   {
     "id": 462,
@@ -14015,12 +14547,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14044,7 +14576,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8367
   },
   {
     "id": 463,
@@ -14057,12 +14590,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14086,7 +14619,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8373
   },
   {
     "id": 464,
@@ -14099,12 +14633,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14128,7 +14662,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8379
   },
   {
     "id": 465,
@@ -14141,12 +14676,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14170,7 +14705,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8385
   },
   {
     "id": 466,
@@ -14183,12 +14719,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14212,7 +14748,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8391
   },
   {
     "id": 467,
@@ -14225,12 +14762,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14254,7 +14791,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8397
   },
   {
     "id": 468,
@@ -14267,12 +14805,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14296,7 +14834,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8403
   },
   {
     "id": 469,
@@ -14309,12 +14848,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14338,7 +14877,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8409
   },
   {
     "id": 470,
@@ -14351,12 +14891,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -14380,7 +14920,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8415
   },
   {
     "id": 471,
@@ -14406,7 +14947,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8418
   },
   {
     "id": 472,
@@ -14432,7 +14974,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8419
   },
   {
     "id": 473,
@@ -14458,7 +15001,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8420
   },
   {
     "id": 474,
@@ -14484,7 +15028,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 8421
   },
   {
     "id": 475,
@@ -14497,13 +15042,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "in_wall",
@@ -14530,7 +15075,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8429
   },
   {
     "id": 476,
@@ -14543,13 +15089,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "in_wall",
@@ -14576,7 +15122,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8461
   },
   {
     "id": 477,
@@ -14589,13 +15136,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "in_wall",
@@ -14622,7 +15169,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8493
   },
   {
     "id": 478,
@@ -14635,13 +15183,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "in_wall",
@@ -14668,7 +15216,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8525
   },
   {
     "id": 479,
@@ -14681,13 +15230,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "in_wall",
@@ -14714,7 +15263,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8557
   },
   {
     "id": 480,
@@ -14759,7 +15309,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8613
   },
   {
     "id": 481,
@@ -14804,7 +15355,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8645
   },
   {
     "id": 482,
@@ -14849,7 +15401,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8677
   },
   {
     "id": 483,
@@ -14894,7 +15447,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8709
   },
   {
     "id": 484,
@@ -14939,7 +15493,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8741
   },
   {
     "id": 485,
@@ -14952,31 +15507,31 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "hinge",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "left",
           "right"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -14998,7 +15553,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8753
   },
   {
     "id": 486,
@@ -15011,31 +15567,31 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "hinge",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "left",
           "right"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -15057,7 +15613,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8817
   },
   {
     "id": 487,
@@ -15070,31 +15627,31 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "hinge",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "left",
           "right"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -15116,7 +15673,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8881
   },
   {
     "id": 488,
@@ -15129,31 +15687,31 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "hinge",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "left",
           "right"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -15175,7 +15733,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 8945
   },
   {
     "id": 489,
@@ -15188,31 +15747,31 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "hinge",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "left",
           "right"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -15234,7 +15793,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 9009
   },
   {
     "id": 490,
@@ -15247,6 +15807,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15254,8 +15815,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -15266,7 +15826,8 @@
     "filterLight": 15,
     "emitLight": 14,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9066
   },
   {
     "id": 491,
@@ -15315,7 +15876,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9131
   },
   {
     "id": 492,
@@ -15339,7 +15901,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9132
   },
   {
     "id": 493,
@@ -15364,7 +15927,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9138
   },
   {
     "id": 494,
@@ -15377,12 +15941,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -15400,7 +15964,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9140
   },
   {
     "id": 495,
@@ -15413,34 +15978,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -15464,7 +16029,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9153
   },
   {
     "id": 496,
@@ -15490,7 +16056,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9222
   },
   {
     "id": 497,
@@ -15514,7 +16081,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9223
   },
   {
     "id": 498,
@@ -15533,7 +16101,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9227
   },
   {
     "id": 499,
@@ -15549,7 +16118,8 @@
     "filterLight": 15,
     "emitLight": 15,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 9228
   },
   {
     "id": 500,
@@ -15567,6 +16137,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15574,8 +16145,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -15586,7 +16156,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9235
   },
   {
     "id": 501,
@@ -15604,6 +16175,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15611,8 +16183,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -15623,7 +16194,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9247
   },
   {
     "id": 502,
@@ -15645,7 +16217,8 @@
     "filterLight": 2,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 9253
   },
   {
     "id": 503,
@@ -15670,7 +16243,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9257
   },
   {
     "id": 504,
@@ -15688,7 +16262,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9258
   },
   {
     "id": 505,
@@ -15713,7 +16288,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9259
   },
   {
     "id": 506,
@@ -15726,12 +16302,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -15749,7 +16325,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9261
   },
   {
     "id": 507,
@@ -15767,7 +16344,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9263
   },
   {
     "id": 508,
@@ -15780,6 +16358,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15787,8 +16366,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       },
       {
         "name": "powered",
@@ -15811,7 +16389,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9269
   },
   {
     "id": 509,
@@ -15824,6 +16403,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15831,8 +16411,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -15843,7 +16422,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9280
   },
   {
     "id": 510,
@@ -15856,6 +16436,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15863,8 +16444,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -15875,7 +16455,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9286
   },
   {
     "id": 511,
@@ -15888,6 +16469,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15895,8 +16477,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -15907,7 +16488,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9292
   },
   {
     "id": 512,
@@ -15920,6 +16502,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15927,8 +16510,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -15939,7 +16521,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9298
   },
   {
     "id": 513,
@@ -15952,6 +16535,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15959,8 +16543,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -15971,7 +16554,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9304
   },
   {
     "id": 514,
@@ -15984,6 +16568,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -15991,8 +16576,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16003,7 +16587,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9310
   },
   {
     "id": 515,
@@ -16016,6 +16601,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16023,8 +16609,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16035,7 +16620,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9316
   },
   {
     "id": 516,
@@ -16048,6 +16634,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16055,8 +16642,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16067,7 +16653,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9322
   },
   {
     "id": 517,
@@ -16080,6 +16667,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16087,8 +16675,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16099,7 +16686,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9328
   },
   {
     "id": 518,
@@ -16112,6 +16700,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16119,8 +16708,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16131,7 +16719,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9334
   },
   {
     "id": 519,
@@ -16144,6 +16733,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16151,8 +16741,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16163,7 +16752,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9340
   },
   {
     "id": 520,
@@ -16176,6 +16766,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16183,8 +16774,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16195,7 +16785,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9346
   },
   {
     "id": 521,
@@ -16208,6 +16799,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16215,8 +16807,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16227,7 +16818,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9352
   },
   {
     "id": 522,
@@ -16240,6 +16832,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16247,8 +16840,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16259,7 +16851,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9358
   },
   {
     "id": 523,
@@ -16272,6 +16865,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16279,8 +16873,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16291,7 +16884,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9364
   },
   {
     "id": 524,
@@ -16304,6 +16898,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16311,8 +16906,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16323,7 +16917,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9370
   },
   {
     "id": 525,
@@ -16336,6 +16931,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -16343,8 +16939,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       }
     ],
     "drops": [
@@ -16355,7 +16950,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 1
+    "stackSize": 1,
+    "defaultState": 9376
   },
   {
     "id": 526,
@@ -16368,13 +16964,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16393,7 +16989,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9378
   },
   {
     "id": 527,
@@ -16406,13 +17003,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16431,7 +17028,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9382
   },
   {
     "id": 528,
@@ -16444,13 +17042,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16469,7 +17067,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9386
   },
   {
     "id": 529,
@@ -16482,13 +17081,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16507,7 +17106,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9390
   },
   {
     "id": 530,
@@ -16520,13 +17120,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16545,7 +17145,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9394
   },
   {
     "id": 531,
@@ -16558,13 +17159,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16583,7 +17184,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9398
   },
   {
     "id": 532,
@@ -16596,13 +17198,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16621,7 +17223,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9402
   },
   {
     "id": 533,
@@ -16634,13 +17237,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16659,7 +17262,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9406
   },
   {
     "id": 534,
@@ -16672,13 +17276,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16697,7 +17301,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9410
   },
   {
     "id": 535,
@@ -16710,13 +17315,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16735,7 +17340,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9414
   },
   {
     "id": 536,
@@ -16748,13 +17354,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16773,7 +17379,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9418
   },
   {
     "id": 537,
@@ -16786,13 +17393,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16811,7 +17418,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9422
   },
   {
     "id": 538,
@@ -16824,13 +17432,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16849,7 +17457,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9426
   },
   {
     "id": 539,
@@ -16862,13 +17471,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16887,7 +17496,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9430
   },
   {
     "id": 540,
@@ -16900,13 +17510,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16925,7 +17535,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9434
   },
   {
     "id": 541,
@@ -16938,13 +17549,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -16963,7 +17574,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9438
   },
   {
     "id": 542,
@@ -16989,7 +17601,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9442
   },
   {
     "id": 543,
@@ -17015,7 +17628,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9443
   },
   {
     "id": 544,
@@ -17041,7 +17655,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9444
   },
   {
     "id": 545,
@@ -17067,7 +17682,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9445
   },
   {
     "id": 546,
@@ -17093,7 +17709,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9446
   },
   {
     "id": 547,
@@ -17119,7 +17736,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9447
   },
   {
     "id": 548,
@@ -17145,7 +17763,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9448
   },
   {
     "id": 549,
@@ -17171,7 +17790,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9449
   },
   {
     "id": 550,
@@ -17197,7 +17817,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9450
   },
   {
     "id": 551,
@@ -17223,7 +17844,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9451
   },
   {
     "id": 552,
@@ -17249,7 +17871,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9452
   },
   {
     "id": 553,
@@ -17275,7 +17898,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9453
   },
   {
     "id": 554,
@@ -17301,7 +17925,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9454
   },
   {
     "id": 555,
@@ -17327,7 +17952,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9455
   },
   {
     "id": 556,
@@ -17353,7 +17979,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9456
   },
   {
     "id": 557,
@@ -17379,7 +18006,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9457
   },
   {
     "id": 558,
@@ -17398,7 +18026,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9458
   },
   {
     "id": 559,
@@ -17417,7 +18046,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9459
   },
   {
     "id": 560,
@@ -17436,7 +18066,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9460
   },
   {
     "id": 561,
@@ -17455,7 +18086,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9461
   },
   {
     "id": 562,
@@ -17474,7 +18106,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9462
   },
   {
     "id": 563,
@@ -17493,7 +18126,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9463
   },
   {
     "id": 564,
@@ -17512,7 +18146,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9464
   },
   {
     "id": 565,
@@ -17531,7 +18166,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9465
   },
   {
     "id": 566,
@@ -17550,7 +18186,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9466
   },
   {
     "id": 567,
@@ -17569,7 +18206,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9467
   },
   {
     "id": 568,
@@ -17588,7 +18226,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9468
   },
   {
     "id": 569,
@@ -17607,7 +18246,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9469
   },
   {
     "id": 570,
@@ -17626,7 +18266,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9470
   },
   {
     "id": 571,
@@ -17645,7 +18286,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9471
   },
   {
     "id": 572,
@@ -17664,7 +18306,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9472
   },
   {
     "id": 573,
@@ -17683,7 +18326,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "dirt"
+    "material": "dirt",
+    "defaultState": 9473
   },
   {
     "id": 574,
@@ -17707,7 +18351,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9474
   },
   {
     "id": 575,
@@ -17725,7 +18370,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9500
   },
   {
     "id": 576,
@@ -17743,7 +18389,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9501
   },
   {
     "id": 577,
@@ -17755,8 +18402,14 @@
     "states": [
       {
         "name": "eggs",
-        "type": "int",
-        "num_values": 4
+        "type": "enum",
+        "num_values": 4,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
       },
       {
         "name": "hatch",
@@ -17772,7 +18425,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9502
   },
   {
     "id": 578,
@@ -17798,7 +18452,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9514
   },
   {
     "id": 579,
@@ -17824,7 +18479,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9515
   },
   {
     "id": 580,
@@ -17850,7 +18506,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9516
   },
   {
     "id": 581,
@@ -17876,7 +18533,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9517
   },
   {
     "id": 582,
@@ -17902,7 +18560,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9518
   },
   {
     "id": 583,
@@ -17928,7 +18587,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9519
   },
   {
     "id": 584,
@@ -17954,7 +18614,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9520
   },
   {
     "id": 585,
@@ -17980,7 +18641,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9521
   },
   {
     "id": 586,
@@ -18006,7 +18668,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9522
   },
   {
     "id": 587,
@@ -18032,7 +18695,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 9523
   },
   {
     "id": 588,
@@ -18056,7 +18720,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9524
   },
   {
     "id": 589,
@@ -18080,7 +18745,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9526
   },
   {
     "id": 590,
@@ -18104,7 +18770,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9528
   },
   {
     "id": 591,
@@ -18128,7 +18795,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9530
   },
   {
     "id": 592,
@@ -18152,7 +18820,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9532
   },
   {
     "id": 593,
@@ -18176,7 +18845,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9534
   },
   {
     "id": 594,
@@ -18200,7 +18870,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9536
   },
   {
     "id": 595,
@@ -18224,7 +18895,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9538
   },
   {
     "id": 596,
@@ -18248,7 +18920,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9540
   },
   {
     "id": 597,
@@ -18272,7 +18945,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9542
   },
   {
     "id": 598,
@@ -18296,7 +18970,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9544
   },
   {
     "id": 599,
@@ -18320,7 +18995,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9546
   },
   {
     "id": 600,
@@ -18344,7 +19020,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9548
   },
   {
     "id": 601,
@@ -18368,7 +19045,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9550
   },
   {
     "id": 602,
@@ -18392,7 +19070,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9552
   },
   {
     "id": 603,
@@ -18416,7 +19095,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9554
   },
   {
     "id": 604,
@@ -18440,7 +19120,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9556
   },
   {
     "id": 605,
@@ -18464,7 +19145,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9558
   },
   {
     "id": 606,
@@ -18488,7 +19170,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9560
   },
   {
     "id": 607,
@@ -18512,7 +19195,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9562
   },
   {
     "id": 608,
@@ -18525,13 +19209,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18547,7 +19231,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9564
   },
   {
     "id": 609,
@@ -18560,13 +19245,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18582,7 +19267,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9572
   },
   {
     "id": 610,
@@ -18595,13 +19281,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18617,7 +19303,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9580
   },
   {
     "id": 611,
@@ -18630,13 +19317,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18652,7 +19339,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9588
   },
   {
     "id": 612,
@@ -18665,13 +19353,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18687,7 +19375,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9596
   },
   {
     "id": 613,
@@ -18700,13 +19389,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18722,7 +19411,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9604
   },
   {
     "id": 614,
@@ -18735,13 +19425,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18757,7 +19447,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9612
   },
   {
     "id": 615,
@@ -18770,13 +19461,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18792,7 +19483,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9620
   },
   {
     "id": 616,
@@ -18805,13 +19497,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18827,7 +19519,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9628
   },
   {
     "id": 617,
@@ -18840,13 +19533,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -18862,7 +19555,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9636
   },
   {
     "id": 618,
@@ -18874,8 +19568,14 @@
     "states": [
       {
         "name": "pickles",
-        "type": "int",
-        "num_values": 4
+        "type": "enum",
+        "num_values": 4,
+        "values": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
       },
       {
         "name": "waterlogged",
@@ -18891,7 +19591,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9644
   },
   {
     "id": 619,
@@ -18909,7 +19610,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9652
   },
   {
     "id": 620,
@@ -18934,7 +19636,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 9653
   },
   {
     "id": 621,
@@ -18951,7 +19654,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 9655
   },
   {
     "id": 622,
@@ -18969,12 +19673,12 @@
       {
         "name": "leaves",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "small",
           "large"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "stage",
@@ -18991,7 +19695,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 9656
   },
   {
     "id": 623,
@@ -19010,7 +19715,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 9668
   },
   {
     "id": 624,
@@ -19026,7 +19732,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 9669
   },
   {
     "id": 625,
@@ -19042,7 +19749,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 9670
   },
   {
     "id": 626,
@@ -19064,7 +19772,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 9671
   },
   {
     "id": 627,
@@ -19077,34 +19786,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19121,7 +19830,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 9684
   },
   {
     "id": 628,
@@ -19134,34 +19844,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19178,7 +19888,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 9764
   },
   {
     "id": 629,
@@ -19191,34 +19902,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19235,7 +19946,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 9844
   },
   {
     "id": 630,
@@ -19248,34 +19960,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19292,7 +20004,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 9924
   },
   {
     "id": 631,
@@ -19305,34 +20018,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19349,7 +20062,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 10004
   },
   {
     "id": 632,
@@ -19362,34 +20076,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19406,7 +20120,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 10084
   },
   {
     "id": 633,
@@ -19419,34 +20134,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19463,7 +20178,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 10164
   },
   {
     "id": 634,
@@ -19476,34 +20192,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19520,7 +20236,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 10244
   },
   {
     "id": 635,
@@ -19533,34 +20250,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19577,7 +20294,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 10324
   },
   {
     "id": 636,
@@ -19590,34 +20308,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19634,7 +20352,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 10404
   },
   {
     "id": 637,
@@ -19647,34 +20366,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19691,7 +20410,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 10484
   },
   {
     "id": 638,
@@ -19704,34 +20424,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19755,7 +20475,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10564
   },
   {
     "id": 639,
@@ -19768,34 +20489,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19812,7 +20533,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 10644
   },
   {
     "id": 640,
@@ -19825,34 +20547,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -19869,7 +20591,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 10724
   },
   {
     "id": 641,
@@ -19882,12 +20605,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -19911,7 +20634,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10796
   },
   {
     "id": 642,
@@ -19924,12 +20648,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -19953,7 +20677,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10802
   },
   {
     "id": 643,
@@ -19966,12 +20691,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -19995,7 +20720,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10808
   },
   {
     "id": 644,
@@ -20008,12 +20734,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20037,7 +20763,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10814
   },
   {
     "id": 645,
@@ -20050,12 +20777,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20079,7 +20806,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10820
   },
   {
     "id": 646,
@@ -20092,12 +20820,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20121,7 +20849,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10826
   },
   {
     "id": 647,
@@ -20134,12 +20863,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20163,7 +20892,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10832
   },
   {
     "id": 648,
@@ -20176,12 +20906,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20205,7 +20935,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10838
   },
   {
     "id": 649,
@@ -20218,12 +20949,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20247,7 +20978,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10844
   },
   {
     "id": 650,
@@ -20260,12 +20992,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20289,7 +21021,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10850
   },
   {
     "id": 651,
@@ -20302,12 +21035,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20331,7 +21064,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10856
   },
   {
     "id": 652,
@@ -20344,12 +21078,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20373,7 +21107,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10862
   },
   {
     "id": 653,
@@ -20386,12 +21121,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -20415,7 +21150,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10868
   },
   {
     "id": 654,
@@ -20428,32 +21164,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -20468,12 +21204,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -20492,7 +21228,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 10874
   },
   {
     "id": 655,
@@ -20505,32 +21242,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -20545,12 +21282,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -20569,7 +21306,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 11198
   },
   {
     "id": 656,
@@ -20582,32 +21320,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -20622,12 +21360,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -20646,7 +21384,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 11522
   },
   {
     "id": 657,
@@ -20659,32 +21398,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -20699,12 +21438,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -20723,7 +21462,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 11846
   },
   {
     "id": 658,
@@ -20736,32 +21476,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -20776,12 +21516,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -20800,7 +21540,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 12170
   },
   {
     "id": 659,
@@ -20813,32 +21554,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -20853,12 +21594,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -20877,7 +21618,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 12494
   },
   {
     "id": 660,
@@ -20890,32 +21632,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -20930,12 +21672,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -20954,7 +21696,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 12818
   },
   {
     "id": 661,
@@ -20967,32 +21710,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -21007,12 +21750,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -21031,7 +21774,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 13142
   },
   {
     "id": 662,
@@ -21044,32 +21788,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -21084,12 +21828,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -21108,7 +21852,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 13466
   },
   {
     "id": 663,
@@ -21121,32 +21866,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -21161,12 +21906,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -21185,7 +21930,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 13790
   },
   {
     "id": 664,
@@ -21198,32 +21944,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -21238,12 +21984,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -21262,7 +22008,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14114
   },
   {
     "id": 665,
@@ -21275,32 +22022,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -21315,12 +22062,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -21339,7 +22086,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14438
   },
   {
     "id": 666,
@@ -21373,7 +22121,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 14790
   },
   {
     "id": 667,
@@ -21386,13 +22135,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -21404,7 +22153,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 14791
   },
   {
     "id": 668,
@@ -21417,6 +22167,7 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 6,
         "values": [
           "north",
           "east",
@@ -21424,8 +22175,7 @@
           "west",
           "up",
           "down"
-        ],
-        "num_values": 6
+        ]
       },
       {
         "name": "open",
@@ -21442,7 +22192,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 14796
   },
   {
     "id": 669,
@@ -21455,13 +22206,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "lit",
@@ -21485,7 +22236,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14808
   },
   {
     "id": 670,
@@ -21498,13 +22250,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "lit",
@@ -21528,7 +22280,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14816
   },
   {
     "id": 671,
@@ -21547,7 +22300,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 14823
   },
   {
     "id": 672,
@@ -21566,7 +22320,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 14824
   },
   {
     "id": 673,
@@ -21579,23 +22334,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -21614,7 +22369,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14829
   },
   {
     "id": 674,
@@ -21627,13 +22383,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "has_book",
@@ -21655,7 +22411,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 14840
   },
   {
     "id": 675,
@@ -21674,7 +22431,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 14853
   },
   {
     "id": 676,
@@ -21687,13 +22445,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -21705,7 +22463,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 14854
   },
   {
     "id": 677,
@@ -21718,24 +22477,24 @@
       {
         "name": "attachment",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "floor",
           "ceiling",
           "single_wall",
           "double_wall"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -21752,7 +22511,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "rock"
+    "material": "rock",
+    "defaultState": 14859
   },
   {
     "id": 678,
@@ -21789,7 +22549,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14893
   },
   {
     "id": 679,
@@ -21826,7 +22587,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14897
   },
   {
     "id": 680,
@@ -21839,13 +22601,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "lit",
@@ -21872,7 +22634,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 1,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 14901
   },
   {
     "id": 681,
@@ -21885,13 +22648,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "lit",
@@ -21918,7 +22681,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 1,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 14933
   },
   {
     "id": 682,
@@ -21940,7 +22704,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 14962
   },
   {
     "id": 683,
@@ -21953,12 +22718,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -21970,7 +22735,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 14967
   },
   {
     "id": 684,
@@ -21983,12 +22749,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -22000,7 +22766,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 14970
   },
   {
     "id": 685,
@@ -22013,12 +22780,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -22030,7 +22797,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 14973
   },
   {
     "id": 686,
@@ -22043,12 +22811,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -22060,7 +22828,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 14976
   },
   {
     "id": 687,
@@ -22086,7 +22855,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14978
   },
   {
     "id": 688,
@@ -22104,7 +22874,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 14979
   },
   {
     "id": 689,
@@ -22123,7 +22894,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "harvestTools": {}
+    "harvestTools": {},
+    "defaultState": 14980
   },
   {
     "id": 690,
@@ -22141,7 +22913,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 14981
   },
   {
     "id": 691,
@@ -22160,7 +22933,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 64,
-    "material": "plant"
+    "material": "plant",
+    "defaultState": 14982
   },
   {
     "id": 692,
@@ -22173,12 +22947,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -22190,7 +22964,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 14984
   },
   {
     "id": 693,
@@ -22203,12 +22978,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -22220,7 +22995,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 14987
   },
   {
     "id": 694,
@@ -22233,12 +23009,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -22250,7 +23026,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 14990
   },
   {
     "id": 695,
@@ -22263,12 +23040,12 @@
       {
         "name": "axis",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "x",
           "y",
           "z"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -22280,7 +23057,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 14993
   },
   {
     "id": 696,
@@ -22306,7 +23084,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 14995
   },
   {
     "id": 697,
@@ -22324,7 +23103,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 14996
   },
   {
     "id": 698,
@@ -22343,7 +23123,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "harvestTools": {}
+    "harvestTools": {},
+    "defaultState": 14997
   },
   {
     "id": 699,
@@ -22367,7 +23148,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 14998
   },
   {
     "id": 700,
@@ -22383,7 +23165,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15024
   },
   {
     "id": 701,
@@ -22407,7 +23190,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15025
   },
   {
     "id": 702,
@@ -22423,7 +23207,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15051
   },
   {
     "id": 703,
@@ -22441,7 +23226,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15052
   },
   {
     "id": 704,
@@ -22460,7 +23246,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15053
   },
   {
     "id": 705,
@@ -22479,7 +23266,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15054
   },
   {
     "id": 706,
@@ -22492,12 +23280,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -22514,7 +23302,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15058
   },
   {
     "id": 707,
@@ -22527,12 +23316,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -22549,7 +23338,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15064
   },
   {
     "id": 708,
@@ -22581,7 +23371,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 15068
   },
   {
     "id": 709,
@@ -22613,7 +23404,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 15070
   },
   {
     "id": 710,
@@ -22658,7 +23450,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15102
   },
   {
     "id": 711,
@@ -22703,7 +23496,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15134
   },
   {
     "id": 712,
@@ -22716,22 +23510,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -22758,7 +23552,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15150
   },
   {
     "id": 713,
@@ -22771,22 +23566,22 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -22813,7 +23608,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15214
   },
   {
     "id": 714,
@@ -22826,13 +23622,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "in_wall",
@@ -22859,7 +23655,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15270
   },
   {
     "id": 715,
@@ -22872,13 +23669,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "in_wall",
@@ -22905,7 +23702,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15302
   },
   {
     "id": 716,
@@ -22918,34 +23716,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -22962,7 +23760,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15338
   },
   {
     "id": 717,
@@ -22975,34 +23774,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -23019,7 +23818,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15418
   },
   {
     "id": 718,
@@ -23032,23 +23832,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -23064,7 +23864,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15496
   },
   {
     "id": 719,
@@ -23077,23 +23878,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -23109,7 +23910,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15520
   },
   {
     "id": 720,
@@ -23122,31 +23924,31 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "hinge",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "left",
           "right"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -23168,7 +23970,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15546
   },
   {
     "id": 721,
@@ -23181,31 +23984,31 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "upper",
           "lower"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "hinge",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "left",
           "right"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "open",
@@ -23227,7 +24030,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15610
   },
   {
     "id": 722,
@@ -23257,7 +24061,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15664
   },
   {
     "id": 723,
@@ -23287,7 +24092,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15696
   },
   {
     "id": 724,
@@ -23300,13 +24106,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -23323,7 +24129,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15728
   },
   {
     "id": 725,
@@ -23336,13 +24143,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "waterlogged",
@@ -23359,7 +24166,8 @@
     "emitLight": 0,
     "boundingBox": "empty",
     "stackSize": 16,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15736
   },
   {
     "id": 726,
@@ -23372,13 +24180,13 @@
       {
         "name": "mode",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "save",
           "load",
           "corner",
           "data"
-        ],
-        "num_values": 4
+        ]
       }
     ],
     "drops": [
@@ -23389,7 +24197,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15743
   },
   {
     "id": 727,
@@ -23402,6 +24211,7 @@
       {
         "name": "orientation",
         "type": "enum",
+        "num_values": 12,
         "values": [
           "down_east",
           "down_north",
@@ -23415,8 +24225,7 @@
           "east_up",
           "north_up",
           "south_up"
-        ],
-        "num_values": 12
+        ]
       }
     ],
     "drops": [
@@ -23428,7 +24237,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 15757
   },
   {
     "id": 728,
@@ -23453,7 +24263,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 15759
   },
   {
     "id": 729,
@@ -23478,7 +24289,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "harvestTools": {}
+    "harvestTools": {},
+    "defaultState": 15768
   },
   {
     "id": 730,
@@ -23491,13 +24303,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "honey_level",
@@ -23514,7 +24326,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 15784
   },
   {
     "id": 731,
@@ -23527,13 +24340,13 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "honey_level",
@@ -23550,7 +24363,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "UNKNOWN_MATERIAL"
+    "material": "UNKNOWN_MATERIAL",
+    "defaultState": 15808
   },
   {
     "id": 732,
@@ -23568,7 +24382,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15832
   },
   {
     "id": 733,
@@ -23586,7 +24401,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15833
   },
   {
     "id": 734,
@@ -23608,7 +24424,8 @@
     "material": "rock",
     "harvestTools": {
       "605": true
-    }
+    },
+    "defaultState": 15834
   },
   {
     "id": 735,
@@ -23630,7 +24447,8 @@
     "material": "rock",
     "harvestTools": {
       "605": true
-    }
+    },
+    "defaultState": 15835
   },
   {
     "id": 736,
@@ -23652,7 +24470,8 @@
     "material": "rock",
     "harvestTools": {
       "605": true
-    }
+    },
+    "defaultState": 15836
   },
   {
     "id": 737,
@@ -23680,7 +24499,8 @@
     "material": "rock",
     "harvestTools": {
       "605": true
-    }
+    },
+    "defaultState": 15837
   },
   {
     "id": 738,
@@ -23699,7 +24519,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15842
   },
   {
     "id": 739,
@@ -23718,7 +24539,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15843
   },
   {
     "id": 740,
@@ -23737,7 +24559,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15844
   },
   {
     "id": 741,
@@ -23756,7 +24579,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 15845
   },
   {
     "id": 742,
@@ -23782,7 +24606,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 15846
   },
   {
     "id": 743,
@@ -23808,7 +24633,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 15847
   },
   {
     "id": 744,
@@ -23821,34 +24647,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -23865,7 +24691,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 15859
   },
   {
     "id": 745,
@@ -23878,32 +24705,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -23918,12 +24745,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -23942,7 +24769,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 15931
   },
   {
     "id": 746,
@@ -23955,12 +24783,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -23977,7 +24805,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 16255
   },
   {
     "id": 747,
@@ -24003,7 +24832,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 16258
   },
   {
     "id": 748,
@@ -24029,7 +24859,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 16259
   },
   {
     "id": 749,
@@ -24055,7 +24886,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 16260
   },
   {
     "id": 750,
@@ -24073,7 +24905,8 @@
     "filterLight": 15,
     "emitLight": 0,
     "boundingBox": "block",
-    "stackSize": 0
+    "stackSize": 0,
+    "defaultState": 16261
   },
   {
     "id": 751,
@@ -24086,12 +24919,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -24108,7 +24941,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 16265
   },
   {
     "id": 752,
@@ -24121,34 +24955,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -24165,7 +24999,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 16279
   },
   {
     "id": 753,
@@ -24178,32 +25013,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -24218,12 +25053,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -24242,7 +25077,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 16351
   },
   {
     "id": 754,
@@ -24268,7 +25104,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 16672
   },
   {
     "id": 755,
@@ -24281,34 +25118,34 @@
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "half",
         "type": "enum",
+        "num_values": 2,
         "values": [
           "top",
           "bottom"
-        ],
-        "num_values": 2
+        ]
       },
       {
         "name": "shape",
         "type": "enum",
+        "num_values": 5,
         "values": [
           "straight",
           "inner_left",
           "inner_right",
           "outer_left",
           "outer_right"
-        ],
-        "num_values": 5
+        ]
       },
       {
         "name": "waterlogged",
@@ -24325,7 +25162,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 16684
   },
   {
     "id": 756,
@@ -24338,12 +25176,12 @@
       {
         "name": "type",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "top",
           "bottom",
           "double"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "waterlogged",
@@ -24360,7 +25198,8 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "wood"
+    "material": "wood",
+    "defaultState": 16756
   },
   {
     "id": 757,
@@ -24392,7 +25231,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 16760
   },
   {
     "id": 758,
@@ -24405,23 +25245,23 @@
       {
         "name": "face",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "floor",
           "wall",
           "ceiling"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "facing",
         "type": "enum",
+        "num_values": 4,
         "values": [
           "north",
           "south",
           "west",
           "east"
-        ],
-        "num_values": 4
+        ]
       },
       {
         "name": "powered",
@@ -24437,7 +25277,8 @@
     "filterLight": 0,
     "emitLight": 0,
     "boundingBox": "empty",
-    "stackSize": 64
+    "stackSize": 64,
+    "defaultState": 16770
   },
   {
     "id": 759,
@@ -24450,32 +25291,32 @@
       {
         "name": "east",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "north",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "south",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       },
       {
         "name": "up",
@@ -24490,12 +25331,12 @@
       {
         "name": "west",
         "type": "enum",
+        "num_values": 3,
         "values": [
           "none",
           "low",
           "tall"
-        ],
-        "num_values": 3
+        ]
       }
     ],
     "drops": [
@@ -24514,7 +25355,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 16788
   },
   {
     "id": 760,
@@ -24540,7 +25382,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 17109
   },
   {
     "id": 761,
@@ -24566,7 +25409,8 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 17110
   },
   {
     "id": 762,
@@ -24592,6 +25436,7 @@
       "595": true,
       "600": true,
       "605": true
-    }
+    },
+    "defaultState": 17111
   }
 ]

--- a/data/pc/1.16.2/blocks.json
+++ b/data/pc/1.16.2/blocks.json
@@ -807,9 +807,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -837,9 +837,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -867,9 +867,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -897,9 +897,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -927,9 +927,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -957,9 +957,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -987,9 +987,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1017,9 +1017,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1047,9 +1047,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1077,9 +1077,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1107,9 +1107,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1137,9 +1137,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1167,9 +1167,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1197,9 +1197,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1227,9 +1227,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1257,9 +1257,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1287,9 +1287,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1317,9 +1317,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1347,9 +1347,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1377,9 +1377,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1407,9 +1407,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1437,9 +1437,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1467,9 +1467,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1497,9 +1497,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -1809,12 +1809,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -1932,22 +1932,22 @@
         "name": "instrument",
         "type": "enum",
         "values": [
-          "HARP",
-          "BASEDRUM",
-          "SNARE",
-          "HAT",
-          "BASS",
-          "FLUTE",
-          "BELL",
-          "GUITAR",
-          "CHIME",
-          "XYLOPHONE",
-          "IRON_XYLOPHONE",
-          "COW_BELL",
-          "DIDGERIDOO",
-          "BIT",
-          "BANJO",
-          "PLING"
+          "harp",
+          "basedrum",
+          "snare",
+          "hat",
+          "bass",
+          "flute",
+          "bell",
+          "guitar",
+          "chime",
+          "xylophone",
+          "iron_xylophone",
+          "cow_bell",
+          "didgeridoo",
+          "bit",
+          "banjo",
+          "pling"
         ],
         "num_values": 16
       },
@@ -1985,10 +1985,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -1996,8 +1996,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2029,10 +2029,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2040,8 +2040,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2073,10 +2073,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2084,8 +2084,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2117,10 +2117,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2128,8 +2128,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2161,10 +2161,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2172,8 +2172,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2205,10 +2205,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2216,8 +2216,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2249,10 +2249,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2260,8 +2260,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2293,10 +2293,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2304,8 +2304,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2337,10 +2337,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2348,8 +2348,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2381,10 +2381,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2392,8 +2392,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2425,10 +2425,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2436,8 +2436,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2469,10 +2469,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2480,8 +2480,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2513,10 +2513,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2524,8 +2524,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2557,10 +2557,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2568,8 +2568,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2601,10 +2601,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2612,8 +2612,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2645,10 +2645,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -2656,8 +2656,8 @@
         "name": "part",
         "type": "enum",
         "values": [
-          "HEAD",
-          "FOOT"
+          "head",
+          "foot"
         ],
         "num_values": 2
       },
@@ -2689,12 +2689,12 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "NORTH_SOUTH",
-          "EAST_WEST",
-          "ASCENDING_EAST",
-          "ASCENDING_WEST",
-          "ASCENDING_NORTH",
-          "ASCENDING_SOUTH"
+          "north_south",
+          "east_west",
+          "ascending_east",
+          "ascending_west",
+          "ascending_north",
+          "ascending_south"
         ],
         "num_values": 6
       },
@@ -2727,12 +2727,12 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "NORTH_SOUTH",
-          "EAST_WEST",
-          "ASCENDING_EAST",
-          "ASCENDING_WEST",
-          "ASCENDING_NORTH",
-          "ASCENDING_SOUTH"
+          "north_south",
+          "east_west",
+          "ascending_east",
+          "ascending_west",
+          "ascending_north",
+          "ascending_south"
         ],
         "num_values": 6
       },
@@ -2765,12 +2765,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -2905,8 +2905,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       }
@@ -2934,12 +2934,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -2971,12 +2971,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -2984,8 +2984,8 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "DEFAULT",
-          "STICKY"
+          "normal",
+          "sticky"
         ],
         "num_values": 2
       },
@@ -3319,12 +3319,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -3332,8 +3332,8 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "DEFAULT",
-          "STICKY"
+          "normal",
+          "sticky"
         ],
         "num_values": 2
       }
@@ -3825,10 +3825,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -3944,10 +3944,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -3955,8 +3955,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -3964,11 +3964,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -4001,10 +4001,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4012,9 +4012,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "SINGLE",
-          "LEFT",
-          "RIGHT"
+          "single",
+          "left",
+          "right"
         ],
         "num_values": 3
       },
@@ -4047,9 +4047,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "UP",
-          "SIDE",
-          "NONE"
+          "up",
+          "side",
+          "none"
         ],
         "num_values": 3
       },
@@ -4057,9 +4057,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "UP",
-          "SIDE",
-          "NONE"
+          "up",
+          "side",
+          "none"
         ],
         "num_values": 3
       },
@@ -4067,9 +4067,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "UP",
-          "SIDE",
-          "NONE"
+          "up",
+          "side",
+          "none"
         ],
         "num_values": 3
       },
@@ -4077,9 +4077,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "UP",
-          "SIDE",
-          "NONE"
+          "up",
+          "side",
+          "none"
         ],
         "num_values": 3
       },
@@ -4226,10 +4226,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4449,8 +4449,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       },
@@ -4458,10 +4458,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4474,8 +4474,8 @@
         "name": "hinge",
         "type": "enum",
         "values": [
-          "LEFT",
-          "RIGHT"
+          "left",
+          "right"
         ],
         "num_values": 2
       },
@@ -4508,10 +4508,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4543,16 +4543,16 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "NORTH_SOUTH",
-          "EAST_WEST",
-          "ASCENDING_EAST",
-          "ASCENDING_WEST",
-          "ASCENDING_NORTH",
-          "ASCENDING_SOUTH",
-          "SOUTH_EAST",
-          "SOUTH_WEST",
-          "NORTH_WEST",
-          "NORTH_EAST"
+          "north_south",
+          "east_west",
+          "ascending_east",
+          "ascending_west",
+          "ascending_north",
+          "ascending_south",
+          "south_east",
+          "south_west",
+          "north_west",
+          "north_east"
         ],
         "num_values": 10
       }
@@ -4580,10 +4580,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4591,8 +4591,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -4600,11 +4600,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -4644,10 +4644,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4680,10 +4680,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4716,10 +4716,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4752,10 +4752,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4788,10 +4788,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4824,10 +4824,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4860,9 +4860,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       },
@@ -4870,10 +4870,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4937,8 +4937,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       },
@@ -4946,10 +4946,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -4962,8 +4962,8 @@
         "name": "hinge",
         "type": "enum",
         "values": [
-          "LEFT",
-          "RIGHT"
+          "left",
+          "right"
         ],
         "num_values": 2
       },
@@ -5206,10 +5206,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -5241,10 +5241,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -5257,9 +5257,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -5586,9 +5586,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -5623,9 +5623,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -5678,10 +5678,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -5726,8 +5726,8 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Z"
+          "x",
+          "z"
         ],
         "num_values": 2
       }
@@ -5752,10 +5752,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -5783,10 +5783,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -5838,10 +5838,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -6171,10 +6171,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -6187,8 +6187,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -6226,10 +6226,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -6242,8 +6242,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -6281,10 +6281,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -6297,8 +6297,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -6336,10 +6336,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -6352,8 +6352,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -6391,10 +6391,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -6407,8 +6407,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -6446,10 +6446,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -6462,8 +6462,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -6968,9 +6968,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -7068,10 +7068,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -7097,10 +7097,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -7221,10 +7221,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -7267,10 +7267,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -7278,8 +7278,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -7287,11 +7287,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -7331,10 +7331,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -7342,8 +7342,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -7351,11 +7351,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -7517,10 +7517,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -7528,8 +7528,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -7537,11 +7537,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -7722,10 +7722,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -7825,10 +7825,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -7861,10 +7861,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -7872,8 +7872,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -7881,11 +7881,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -7948,10 +7948,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -7991,10 +7991,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -8108,10 +8108,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -8119,8 +8119,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -8128,11 +8128,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -8165,10 +8165,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -8176,8 +8176,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -8185,11 +8185,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -8222,10 +8222,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -8233,8 +8233,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -8242,11 +8242,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -8279,12 +8279,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -8339,9 +8339,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -8349,9 +8349,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -8359,9 +8359,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -8369,9 +8369,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -8416,9 +8416,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -8426,9 +8426,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -8436,9 +8436,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -8446,9 +8446,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -9013,10 +9013,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -9029,9 +9029,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -9059,10 +9059,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -9075,9 +9075,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -9105,10 +9105,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -9121,9 +9121,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -9151,10 +9151,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -9167,9 +9167,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -9197,10 +9197,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -9213,9 +9213,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -9243,10 +9243,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -9259,9 +9259,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -9313,10 +9313,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -9367,10 +9367,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -9421,10 +9421,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -9475,10 +9475,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -9529,10 +9529,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -9583,10 +9583,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -9613,10 +9613,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -9651,10 +9651,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -9689,10 +9689,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -9727,10 +9727,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -9738,9 +9738,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "SINGLE",
-          "LEFT",
-          "RIGHT"
+          "single",
+          "left",
+          "right"
         ],
         "num_values": 3
       },
@@ -9837,10 +9837,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -9848,8 +9848,8 @@
         "name": "mode",
         "type": "enum",
         "values": [
-          "COMPARE",
-          "SUBTRACT"
+          "compare",
+          "subtract"
         ],
         "num_values": 2
       },
@@ -9963,11 +9963,11 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "DOWN",
-          "NORTH",
-          "SOUTH",
-          "EAST",
-          "WEST"
+          "down",
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 5
       },
@@ -10059,9 +10059,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -10096,10 +10096,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -10107,8 +10107,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -10116,11 +10116,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -10160,12 +10160,12 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "NORTH_SOUTH",
-          "EAST_WEST",
-          "ASCENDING_EAST",
-          "ASCENDING_WEST",
-          "ASCENDING_NORTH",
-          "ASCENDING_SOUTH"
+          "north_south",
+          "east_west",
+          "ascending_east",
+          "ascending_west",
+          "ascending_north",
+          "ascending_south"
         ],
         "num_values": 6
       },
@@ -10198,12 +10198,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -11363,10 +11363,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -11374,8 +11374,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -11383,11 +11383,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -11420,10 +11420,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -11431,8 +11431,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -11440,11 +11440,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -11513,10 +11513,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -11529,8 +11529,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -11653,10 +11653,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -11664,8 +11664,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -11673,11 +11673,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -11717,10 +11717,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -11728,8 +11728,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -11737,11 +11737,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -11781,10 +11781,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -11792,8 +11792,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -11801,11 +11801,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -11845,9 +11845,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -11887,9 +11887,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -11929,9 +11929,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -11989,9 +11989,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -12377,8 +12377,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       }
@@ -12406,8 +12406,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       }
@@ -12435,8 +12435,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       }
@@ -12464,8 +12464,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       }
@@ -12500,8 +12500,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       }
@@ -12529,8 +12529,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       }
@@ -12958,10 +12958,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -12989,10 +12989,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13020,10 +13020,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13051,10 +13051,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13082,10 +13082,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13113,10 +13113,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13144,10 +13144,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13175,10 +13175,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13206,10 +13206,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13237,10 +13237,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13268,10 +13268,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13299,10 +13299,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13330,10 +13330,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13361,10 +13361,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13392,10 +13392,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13423,10 +13423,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -13532,10 +13532,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -13543,8 +13543,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -13552,11 +13552,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -13596,9 +13596,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -13638,9 +13638,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -13680,9 +13680,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -13722,9 +13722,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -13764,9 +13764,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -13806,9 +13806,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -13848,9 +13848,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -13890,9 +13890,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -13932,9 +13932,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -13974,9 +13974,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14016,9 +14016,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14058,9 +14058,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14100,9 +14100,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14142,9 +14142,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14184,9 +14184,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14226,9 +14226,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14268,9 +14268,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14310,9 +14310,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14352,9 +14352,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -14498,10 +14498,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -14544,10 +14544,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -14590,10 +14590,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -14636,10 +14636,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -14682,10 +14682,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -14953,8 +14953,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       },
@@ -14962,10 +14962,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -14978,8 +14978,8 @@
         "name": "hinge",
         "type": "enum",
         "values": [
-          "LEFT",
-          "RIGHT"
+          "left",
+          "right"
         ],
         "num_values": 2
       },
@@ -15012,8 +15012,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       },
@@ -15021,10 +15021,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -15037,8 +15037,8 @@
         "name": "hinge",
         "type": "enum",
         "values": [
-          "LEFT",
-          "RIGHT"
+          "left",
+          "right"
         ],
         "num_values": 2
       },
@@ -15071,8 +15071,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       },
@@ -15080,10 +15080,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -15096,8 +15096,8 @@
         "name": "hinge",
         "type": "enum",
         "values": [
-          "LEFT",
-          "RIGHT"
+          "left",
+          "right"
         ],
         "num_values": 2
       },
@@ -15130,8 +15130,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       },
@@ -15139,10 +15139,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -15155,8 +15155,8 @@
         "name": "hinge",
         "type": "enum",
         "values": [
-          "LEFT",
-          "RIGHT"
+          "left",
+          "right"
         ],
         "num_values": 2
       },
@@ -15189,8 +15189,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       },
@@ -15198,10 +15198,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -15214,8 +15214,8 @@
         "name": "hinge",
         "type": "enum",
         "values": [
-          "LEFT",
-          "RIGHT"
+          "left",
+          "right"
         ],
         "num_values": 2
       },
@@ -15248,12 +15248,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -15378,9 +15378,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -15414,10 +15414,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -15425,8 +15425,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -15434,11 +15434,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -15563,12 +15563,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -15600,12 +15600,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -15727,9 +15727,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -15781,12 +15781,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -15825,12 +15825,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -15857,12 +15857,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -15889,12 +15889,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -15921,12 +15921,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -15953,12 +15953,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -15985,12 +15985,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16017,12 +16017,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16049,12 +16049,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16081,12 +16081,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16113,12 +16113,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16145,12 +16145,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16177,12 +16177,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16209,12 +16209,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16241,12 +16241,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16273,12 +16273,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16305,12 +16305,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16337,12 +16337,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       }
@@ -16369,10 +16369,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16407,10 +16407,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16445,10 +16445,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16483,10 +16483,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16521,10 +16521,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16559,10 +16559,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16597,10 +16597,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16635,10 +16635,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16673,10 +16673,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16711,10 +16711,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16749,10 +16749,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16787,10 +16787,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16825,10 +16825,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16863,10 +16863,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16901,10 +16901,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -16939,10 +16939,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -18526,10 +18526,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18561,10 +18561,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18596,10 +18596,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18631,10 +18631,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18666,10 +18666,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18701,10 +18701,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18736,10 +18736,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18771,10 +18771,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18806,10 +18806,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18841,10 +18841,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -18970,9 +18970,9 @@
         "name": "leaves",
         "type": "enum",
         "values": [
-          "NONE",
-          "SMALL",
-          "LARGE"
+          "none",
+          "small",
+          "large"
         ],
         "num_values": 3
       },
@@ -19078,10 +19078,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19089,8 +19089,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19098,11 +19098,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19135,10 +19135,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19146,8 +19146,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19155,11 +19155,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19192,10 +19192,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19203,8 +19203,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19212,11 +19212,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19249,10 +19249,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19260,8 +19260,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19269,11 +19269,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19306,10 +19306,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19317,8 +19317,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19326,11 +19326,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19363,10 +19363,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19374,8 +19374,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19383,11 +19383,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19420,10 +19420,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19431,8 +19431,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19440,11 +19440,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19477,10 +19477,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19488,8 +19488,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19497,11 +19497,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19534,10 +19534,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19545,8 +19545,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19554,11 +19554,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19591,10 +19591,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19602,8 +19602,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19611,11 +19611,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19648,10 +19648,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19659,8 +19659,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19668,11 +19668,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19705,10 +19705,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19716,8 +19716,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19725,11 +19725,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19769,10 +19769,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19780,8 +19780,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19789,11 +19789,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19826,10 +19826,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -19837,8 +19837,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -19846,11 +19846,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -19883,9 +19883,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -19925,9 +19925,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -19967,9 +19967,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20009,9 +20009,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20051,9 +20051,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20093,9 +20093,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20135,9 +20135,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20177,9 +20177,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20219,9 +20219,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20261,9 +20261,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20303,9 +20303,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20345,9 +20345,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20387,9 +20387,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -20434,9 +20434,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20444,9 +20444,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20454,9 +20454,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20464,9 +20464,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20511,9 +20511,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20521,9 +20521,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20531,9 +20531,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20541,9 +20541,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20588,9 +20588,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20598,9 +20598,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20608,9 +20608,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20618,9 +20618,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20665,9 +20665,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20675,9 +20675,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20685,9 +20685,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20695,9 +20695,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20742,9 +20742,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20752,9 +20752,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20762,9 +20762,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20772,9 +20772,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20819,9 +20819,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20829,9 +20829,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20839,9 +20839,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20849,9 +20849,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20896,9 +20896,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20906,9 +20906,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20916,9 +20916,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20926,9 +20926,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20973,9 +20973,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20983,9 +20983,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -20993,9 +20993,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21003,9 +21003,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21050,9 +21050,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21060,9 +21060,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21070,9 +21070,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21080,9 +21080,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21127,9 +21127,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21137,9 +21137,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21147,9 +21147,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21157,9 +21157,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21204,9 +21204,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21214,9 +21214,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21224,9 +21224,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21234,9 +21234,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21281,9 +21281,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21291,9 +21291,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21301,9 +21301,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21311,9 +21311,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -21387,10 +21387,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -21418,12 +21418,12 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST",
-          "UP",
-          "DOWN"
+          "north",
+          "east",
+          "south",
+          "west",
+          "up",
+          "down"
         ],
         "num_values": 6
       },
@@ -21456,10 +21456,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -21499,10 +21499,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -21580,10 +21580,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -21591,9 +21591,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -21628,10 +21628,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -21688,10 +21688,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -21719,10 +21719,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -21730,10 +21730,10 @@
         "name": "attachment",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "CEILING",
-          "SINGLE_WALL",
-          "DOUBLE_WALL"
+          "floor",
+          "ceiling",
+          "single_wall",
+          "double_wall"
         ],
         "num_values": 4
       },
@@ -21855,10 +21855,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -21901,10 +21901,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -21954,9 +21954,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -21984,9 +21984,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -22014,9 +22014,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -22044,9 +22044,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -22174,9 +22174,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -22204,9 +22204,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -22234,9 +22234,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -22264,9 +22264,9 @@
         "name": "axis",
         "type": "enum",
         "values": [
-          "X",
-          "Y",
-          "Z"
+          "x",
+          "y",
+          "z"
         ],
         "num_values": 3
       }
@@ -22493,9 +22493,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -22528,9 +22528,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -22717,10 +22717,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -22733,8 +22733,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -22772,10 +22772,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -22788,8 +22788,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -22827,10 +22827,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -22873,10 +22873,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -22919,10 +22919,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -22930,8 +22930,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -22939,11 +22939,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -22976,10 +22976,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -22987,8 +22987,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -22996,11 +22996,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -23033,10 +23033,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -23049,9 +23049,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -23078,10 +23078,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -23094,9 +23094,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -23123,8 +23123,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       },
@@ -23132,10 +23132,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -23148,8 +23148,8 @@
         "name": "hinge",
         "type": "enum",
         "values": [
-          "LEFT",
-          "RIGHT"
+          "left",
+          "right"
         ],
         "num_values": 2
       },
@@ -23182,8 +23182,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "UPPER",
-          "LOWER"
+          "upper",
+          "lower"
         ],
         "num_values": 2
       },
@@ -23191,10 +23191,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -23207,8 +23207,8 @@
         "name": "hinge",
         "type": "enum",
         "values": [
-          "LEFT",
-          "RIGHT"
+          "left",
+          "right"
         ],
         "num_values": 2
       },
@@ -23301,10 +23301,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -23337,10 +23337,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -23373,10 +23373,10 @@
         "name": "mode",
         "type": "enum",
         "values": [
-          "SAVE",
-          "LOAD",
-          "CORNER",
-          "DATA"
+          "save",
+          "load",
+          "corner",
+          "data"
         ],
         "num_values": 4
       }
@@ -23403,18 +23403,18 @@
         "name": "orientation",
         "type": "enum",
         "values": [
-          "DOWN_EAST",
-          "DOWN_NORTH",
-          "DOWN_SOUTH",
-          "DOWN_WEST",
-          "UP_EAST",
-          "UP_NORTH",
-          "UP_SOUTH",
-          "UP_WEST",
-          "WEST_UP",
-          "EAST_UP",
-          "NORTH_UP",
-          "SOUTH_UP"
+          "down_east",
+          "down_north",
+          "down_south",
+          "down_west",
+          "up_east",
+          "up_north",
+          "up_south",
+          "up_west",
+          "west_up",
+          "east_up",
+          "north_up",
+          "south_up"
         ],
         "num_values": 12
       }
@@ -23497,10 +23497,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -23533,10 +23533,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       }
@@ -23822,10 +23822,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -23833,8 +23833,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -23842,11 +23842,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -23884,9 +23884,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -23894,9 +23894,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -23904,9 +23904,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -23914,9 +23914,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -23956,9 +23956,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -24087,9 +24087,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -24122,10 +24122,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -24133,8 +24133,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -24142,11 +24142,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -24184,9 +24184,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -24194,9 +24194,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -24204,9 +24204,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -24214,9 +24214,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -24282,10 +24282,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -24293,8 +24293,8 @@
         "name": "half",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM"
+          "top",
+          "bottom"
         ],
         "num_values": 2
       },
@@ -24302,11 +24302,11 @@
         "name": "shape",
         "type": "enum",
         "values": [
-          "STRAIGHT",
-          "INNER_LEFT",
-          "INNER_RIGHT",
-          "OUTER_LEFT",
-          "OUTER_RIGHT"
+          "straight",
+          "inner_left",
+          "inner_right",
+          "outer_left",
+          "outer_right"
         ],
         "num_values": 5
       },
@@ -24339,9 +24339,9 @@
         "name": "type",
         "type": "enum",
         "values": [
-          "TOP",
-          "BOTTOM",
-          "DOUBLE"
+          "top",
+          "bottom",
+          "double"
         ],
         "num_values": 3
       },
@@ -24406,10 +24406,10 @@
         "name": "facing",
         "type": "enum",
         "values": [
-          "NORTH",
-          "EAST",
-          "SOUTH",
-          "WEST"
+          "north",
+          "south",
+          "west",
+          "east"
         ],
         "num_values": 4
       },
@@ -24422,9 +24422,9 @@
         "name": "face",
         "type": "enum",
         "values": [
-          "FLOOR",
-          "WALL",
-          "CEILING"
+          "floor",
+          "wall",
+          "ceiling"
         ],
         "num_values": 3
       }
@@ -24456,9 +24456,9 @@
         "name": "north",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -24466,9 +24466,9 @@
         "name": "east",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -24476,9 +24476,9 @@
         "name": "west",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },
@@ -24486,9 +24486,9 @@
         "name": "south",
         "type": "enum",
         "values": [
-          "NONE",
-          "LOW",
-          "TALL"
+          "none",
+          "low",
+          "tall"
         ],
         "num_values": 3
       },

--- a/schemas/blocks_schema.json
+++ b/schemas/blocks_schema.json
@@ -86,7 +86,8 @@
             },
              "type": {
               "description": "The type of the property",
-              "type": "string"
+              "type": "string",
+              "enum": ["enum", "bool", "int"]
             },
             "values": {
               "description": "The possible values of the property",


### PR DESCRIPTION
The enum values are uppercase in the 1.16.2 blocks file, there is also a new "direction" type that is just an enum, and some values dosen't match mojang name

For example the same block in 1.16.2 and 1.16.1 https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.16.2/blocks.json#L1810-L1818
https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.16.1/blocks.json#L1956-L1965