### PR TITLE
Revert "Adding Minecraft Item Browser project"

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ These are the projects that use minecraft-data:
 | [McEx](https://github.com/hansihe/McEx) | Elixir | server | blocks |
 | [VoxelGamesLib](https://github.com/MiniDigger/VoxelGamesLib) | Java | minigames server library | blocks, items |
 | [Phpcraft](https://github.com/Phpcraft/core) | PHP | all-around library | blocks, items, entities, protocol |
-| [Minecraft Item Browser](https://njt1982.github.io/minecraft-item-browser/) ([Repo](https://github.com/njt1982/minecraft-item-browser)) | Javascript | Web-based recipe search tool | blocks, items, recipes |
 
 ## Extraction
 


### PR DESCRIPTION
Reverts PrismarineJS/minecraft-data#329

Hi - quick PR to remove the link... I no longer use Prismarine for a data source; I'm parsing the JAR file manually.

The combination of #290 and #330 meant that I was missing a lot of useful recipe data. I honestly tried to find a way to get the data into the toolchain for this dataset, but I couldn't figure out what I needed to change and where.... (combined with the Burger project resisting adding more recipes).

Thanks for all the help with the data.