### PR TITLE
Fix 1.13 enchants and add new 1.16.4 enchants

### DIFF
--- a/data/dataPaths.json
+++ b/data/dataPaths.json
@@ -837,7 +837,7 @@
       "biomes": "pc/1.16.2",
       "effects": "pc/1.16.1",
       "items": "pc/1.16.2",
-      "enchantments": "pc/1.13.2",
+      "enchantments": "pc/1.16.4",
       "recipes": "pc/1.16.2",
       "instruments": "pc/1.16.1",
       "materials": "pc/1.16.2",

--- a/data/pc/1.13/enchantments.json
+++ b/data/pc/1.13/enchantments.json
@@ -17,6 +17,7 @@
       "fire_protection",
       "projectile_protection"
     ],
+    "category": "armor",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -40,6 +41,7 @@
       "protection",
       "projectile_protection"
     ],
+    "category": "armor",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -59,6 +61,7 @@
       "b": 5
     },
     "exclude": [],
+    "category": "armor_feet",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -82,6 +85,7 @@
       "protection",
       "projectile_protection"
     ],
+    "category": "armor",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -105,6 +109,7 @@
       "blast_protection",
       "fire_protection"
     ],
+    "category": "armor",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -124,6 +129,7 @@
       "b": 30
     },
     "exclude": [],
+    "category": "armor_head",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -143,6 +149,7 @@
       "b": 41
     },
     "exclude": [],
+    "category": "armor_head",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -162,6 +169,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "armor_chest",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -183,6 +191,7 @@
     "exclude": [
       "frost_walker"
     ],
+    "category": "armor_feet",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -205,6 +214,7 @@
     "exclude": [
       "depth_strider"
     ],
+    "category": "armor_feet",
     "curse": false,
     "tradeable": true,
     "discoverable": true
@@ -225,6 +235,7 @@
     "treasureOnly": true,
     "curse": true,
     "exclude": [],
+    "category": "wearable",
     "tradeable": true,
     "discoverable": true
   },
@@ -245,6 +256,7 @@
       "smite",
       "bane_of_arthropods"
     ],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -267,6 +279,7 @@
       "sharpness",
       "bane_of_arthropods"
     ],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -289,6 +302,7 @@
       "smite",
       "sharpness"
     ],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -308,6 +322,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -327,6 +342,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -346,6 +362,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -365,6 +382,7 @@
       "b": 11
     },
     "exclude": [],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -384,6 +402,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "digger",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -405,6 +424,7 @@
     "exclude": [
       "fortune"
     ],
+    "category": "digger",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -424,6 +444,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "breakable",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -445,6 +466,7 @@
     "exclude": [
       "silk_touch"
     ],
+    "category": "digger",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -464,6 +486,7 @@
       "b": 6
     },
     "exclude": [],
+    "category": "bow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -483,6 +506,7 @@
       "b": 17
     },
     "exclude": [],
+    "category": "bow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -502,6 +526,7 @@
       "b": 50
     },
     "exclude": [],
+    "category": "bow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -523,6 +548,7 @@
     "exclude": [
       "mending"
     ],
+    "category": "bow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -542,6 +568,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "fishing_rod",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -561,6 +588,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "fishing_rod",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -582,6 +610,7 @@
     "exclude": [
       "riptide"
     ],
+    "category": "trident",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -601,6 +630,7 @@
       "b": 13
     },
     "exclude": [],
+    "category": "trident",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -623,6 +653,7 @@
       "loyalty",
       "channeling"
     ],
+    "category": "trident",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -644,6 +675,7 @@
     "exclude": [
       "riptide"
     ],
+    "category": "trident",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -666,6 +698,7 @@
     "exclude": [
       "infinity"
     ],
+    "category": "breakable",
     "curse": false,
     "tradeable": true,
     "discoverable": true
@@ -686,6 +719,7 @@
     "treasureOnly": true,
     "curse": true,
     "exclude": [],
+    "category": "vanishable",
     "tradeable": true,
     "discoverable": true
   }

--- a/data/pc/1.13/enchantments.json
+++ b/data/pc/1.13/enchantments.json
@@ -2,171 +2,691 @@
   {
     "id": 0,
     "name": "protection",
-    "displayName": "Protection"
+    "displayName": "Protection",
+    "maxLevel": 4,
+    "minCost": {
+      "a": 11,
+      "b": -10
+    },
+    "maxCost": {
+      "a": 11,
+      "b": 1
+    },
+    "exclude": [
+      "blast_protection",
+      "fire_protection",
+      "projectile_protection"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 1,
     "name": "fire_protection",
-    "displayName": "Fire Protection"
+    "displayName": "Fire Protection",
+    "maxLevel": 4,
+    "minCost": {
+      "a": 8,
+      "b": 2
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 10
+    },
+    "exclude": [
+      "blast_protection",
+      "protection",
+      "projectile_protection"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 2,
     "name": "feather_falling",
-    "displayName": "Feather Falling"
+    "displayName": "Feather Falling",
+    "maxLevel": 4,
+    "minCost": {
+      "a": 6,
+      "b": -1
+    },
+    "maxCost": {
+      "a": 6,
+      "b": 5
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 3,
     "name": "blast_protection",
-    "displayName": "Blast Protection"
+    "displayName": "Blast Protection",
+    "maxLevel": 4,
+    "minCost": {
+      "a": 8,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 5
+    },
+    "exclude": [
+      "fire_protection",
+      "protection",
+      "projectile_protection"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 4,
     "name": "projectile_protection",
-    "displayName": "Projectile Protection"
+    "displayName": "Projectile Protection",
+    "maxLevel": 4,
+    "minCost": {
+      "a": 6,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 6,
+      "b": 3
+    },
+    "exclude": [
+      "protection",
+      "blast_protection",
+      "fire_protection"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 5,
     "name": "respiration",
-    "displayName": "Respiration"
+    "displayName": "Respiration",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 10,
+      "b": 0
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 30
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 6,
     "name": "aqua_affinity",
-    "displayName": "Aqua Affinity"
+    "displayName": "Aqua Affinity",
+    "maxLevel": 1,
+    "minCost": {
+      "a": 0,
+      "b": 1
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 41
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 7,
     "name": "thorns",
-    "displayName": "Thorns"
+    "displayName": "Thorns",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 20,
+      "b": -10
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 8,
     "name": "depth_strider",
-    "displayName": "Depth Strider"
+    "displayName": "Depth Strider",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 10,
+      "b": 0
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 15
+    },
+    "exclude": [
+      "frost_walker"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 9,
     "name": "frost_walker",
-    "displayName": "Frost Walker"
+    "displayName": "Frost Walker",
+    "maxLevel": 2,
+    "minCost": {
+      "a": 10,
+      "b": 0
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 15
+    },
+    "treasureOnly": true,
+    "exclude": [
+      "depth_strider"
+    ],
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 10,
     "name": "binding_curse",
-    "displayName": "Curse of Binding"
+    "displayName": "Curse of Binding",
+    "maxLevel": 1,
+    "minCost": {
+      "a": 0,
+      "b": 25
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "treasureOnly": true,
+    "curse": true,
+    "exclude": [],
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 11,
     "name": "sharpness",
-    "displayName": "Sharpness"
+    "displayName": "Sharpness",
+    "maxLevel": 5,
+    "minCost": {
+      "a": 11,
+      "b": -10
+    },
+    "maxCost": {
+      "a": 11,
+      "b": 10
+    },
+    "exclude": [
+      "smite",
+      "bane_of_arthropods"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 12,
     "name": "smite",
-    "displayName": "Smite"
+    "displayName": "Smite",
+    "maxLevel": 5,
+    "minCost": {
+      "a": 8,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 17
+    },
+    "exclude": [
+      "sharpness",
+      "bane_of_arthropods"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 13,
     "name": "bane_of_arthropods",
-    "displayName": "Bane of Arthropods"
+    "displayName": "Bane of Arthropods",
+    "maxLevel": 5,
+    "minCost": {
+      "a": 8,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 17
+    },
+    "exclude": [
+      "smite",
+      "sharpness"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 14,
     "name": "knockback",
-    "displayName": "Knockback"
+    "displayName": "Knockback",
+    "maxLevel": 2,
+    "minCost": {
+      "a": 20,
+      "b": -15
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 15,
     "name": "fire_aspect",
-    "displayName": "Fire Aspect"
+    "displayName": "Fire Aspect",
+    "maxLevel": 2,
+    "minCost": {
+      "a": 20,
+      "b": -10
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 16,
     "name": "looting",
-    "displayName": "Looting"
+    "displayName": "Looting",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 9,
+      "b": 6
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 17,
     "name": "sweeping",
-    "displayName": "Sweeping Edge"
+    "displayName": "Sweeping Edge",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 9,
+      "b": -4
+    },
+    "maxCost": {
+      "a": 9,
+      "b": 11
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 18,
     "name": "efficiency",
-    "displayName": "Efficiency"
+    "displayName": "Efficiency",
+    "maxLevel": 5,
+    "minCost": {
+      "a": 10,
+      "b": -9
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 19,
     "name": "silk_touch",
-    "displayName": "Silk Touch"
+    "displayName": "Silk Touch",
+    "maxLevel": 1,
+    "minCost": {
+      "a": 0,
+      "b": 15
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [
+      "fortune"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 20,
     "name": "unbreaking",
-    "displayName": "Unbreaking"
+    "displayName": "Unbreaking",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 8,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 21,
     "name": "fortune",
-    "displayName": "Fortune"
+    "displayName": "Fortune",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 9,
+      "b": 6
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [
+      "silk_touch"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 22,
     "name": "power",
-    "displayName": "Power"
+    "displayName": "Power",
+    "maxLevel": 5,
+    "minCost": {
+      "a": 10,
+      "b": -9
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 6
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 23,
     "name": "punch",
-    "displayName": "Punch"
+    "displayName": "Punch",
+    "maxLevel": 2,
+    "minCost": {
+      "a": 20,
+      "b": -8
+    },
+    "maxCost": {
+      "a": 20,
+      "b": 17
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 24,
     "name": "flame",
-    "displayName": "Flame"
+    "displayName": "Flame",
+    "maxLevel": 1,
+    "minCost": {
+      "a": 0,
+      "b": 20
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 25,
     "name": "infinity",
-    "displayName": "Infinity"
+    "displayName": "Infinity",
+    "maxLevel": 1,
+    "minCost": {
+      "a": 0,
+      "b": 20
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "mending"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 26,
     "name": "luck_of_the_sea",
-    "displayName": "Luck of the Sea"
+    "displayName": "Luck of the Sea",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 9,
+      "b": 6
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 27,
     "name": "lure",
-    "displayName": "Lure"
+    "displayName": "Lure",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 9,
+      "b": 6
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 28,
     "name": "loyalty",
-    "displayName": "Loyalty"
+    "displayName": "Loyalty",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 7,
+      "b": 5
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "riptide"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 29,
     "name": "impaling",
-    "displayName": "Impaling"
+    "displayName": "Impaling",
+    "maxLevel": 5,
+    "minCost": {
+      "a": 8,
+      "b": -7
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 13
+    },
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 30,
     "name": "riptide",
-    "displayName": "Riptide"
+    "displayName": "Riptide",
+    "maxLevel": 3,
+    "minCost": {
+      "a": 7,
+      "b": 10
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "loyalty",
+      "channeling"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 31,
     "name": "channeling",
-    "displayName": "Channeling"
+    "displayName": "Channeling",
+    "maxLevel": 1,
+    "minCost": {
+      "a": 0,
+      "b": 25
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "riptide"
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 32,
     "name": "mending",
-    "displayName": "Mending"
+    "displayName": "Mending",
+    "maxLevel": 1,
+    "minCost": {
+      "a": 25,
+      "b": 0
+    },
+    "maxCost": {
+      "a": 25,
+      "b": 50
+    },
+    "treasureOnly": true,
+    "exclude": [
+      "infinity"
+    ],
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 33,
     "name": "vanishing_curse",
-    "displayName": "Curse of Vanishing"
+    "displayName": "Curse of Vanishing",
+    "maxLevel": 1,
+    "minCost": {
+      "a": 0,
+      "b": 25
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "treasureOnly": true,
+    "curse": true,
+    "exclude": [],
+    "tradeable": true,
+    "discoverable": true
   }
 ]

--- a/data/pc/1.16.4/enchantments.json
+++ b/data/pc/1.16.4/enchantments.json
@@ -56,116 +56,136 @@
   },
   {
     "id": 11,
+    "name": "soul_speed",
+    "displayName": "Soul Speed"
+  },
+  {
+    "id": 12,
     "name": "sharpness",
     "displayName": "Sharpness"
   },
   {
-    "id": 12,
+    "id": 13,
     "name": "smite",
     "displayName": "Smite"
   },
   {
-    "id": 13,
+    "id": 14,
     "name": "bane_of_arthropods",
     "displayName": "Bane of Arthropods"
   },
   {
-    "id": 14,
+    "id": 15,
     "name": "knockback",
     "displayName": "Knockback"
   },
   {
-    "id": 15,
+    "id": 16,
     "name": "fire_aspect",
     "displayName": "Fire Aspect"
   },
   {
-    "id": 16,
+    "id": 17,
     "name": "looting",
     "displayName": "Looting"
   },
   {
-    "id": 17,
+    "id": 18,
     "name": "sweeping",
     "displayName": "Sweeping Edge"
   },
   {
-    "id": 18,
+    "id": 19,
     "name": "efficiency",
     "displayName": "Efficiency"
   },
   {
-    "id": 19,
+    "id": 20,
     "name": "silk_touch",
     "displayName": "Silk Touch"
   },
   {
-    "id": 20,
+    "id": 21,
     "name": "unbreaking",
     "displayName": "Unbreaking"
   },
   {
-    "id": 21,
+    "id": 22,
     "name": "fortune",
     "displayName": "Fortune"
   },
   {
-    "id": 22,
+    "id": 23,
     "name": "power",
     "displayName": "Power"
   },
   {
-    "id": 23,
+    "id": 24,
     "name": "punch",
     "displayName": "Punch"
   },
   {
-    "id": 24,
+    "id": 25,
     "name": "flame",
     "displayName": "Flame"
   },
   {
-    "id": 25,
+    "id": 26,
     "name": "infinity",
     "displayName": "Infinity"
   },
   {
-    "id": 26,
+    "id": 27,
     "name": "luck_of_the_sea",
     "displayName": "Luck of the Sea"
   },
   {
-    "id": 27,
+    "id": 28,
     "name": "lure",
     "displayName": "Lure"
   },
   {
-    "id": 28,
+    "id": 29,
     "name": "loyalty",
     "displayName": "Loyalty"
   },
   {
-    "id": 29,
+    "id": 30,
     "name": "impaling",
     "displayName": "Impaling"
   },
   {
-    "id": 30,
+    "id": 31,
     "name": "riptide",
     "displayName": "Riptide"
   },
   {
-    "id": 31,
+    "id": 32,
     "name": "channeling",
     "displayName": "Channeling"
   },
   {
-    "id": 32,
+    "id": 33,
+    "name": "multishot",
+    "displayName": "Multishot"
+  },
+  {
+    "id": 34,
+    "name": "quick_charge",
+    "displayName": "Quick Charge"
+  },
+  {
+    "id": 35,
+    "name": "piercing",
+    "displayName": "Piercing"
+  },
+  {
+    "id": 36,
     "name": "mending",
     "displayName": "Mending"
   },
   {
-    "id": 33,
+    "id": 37,
     "name": "vanishing_curse",
     "displayName": "Curse of Vanishing"
   }

--- a/data/pc/1.16.4/enchantments.json
+++ b/data/pc/1.16.4/enchantments.json
@@ -17,6 +17,7 @@
       "fire_protection",
       "projectile_protection"
     ],
+    "category": "armor",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -40,6 +41,7 @@
       "protection",
       "projectile_protection"
     ],
+    "category": "armor",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -59,6 +61,7 @@
       "b": 5
     },
     "exclude": [],
+    "category": "armor_feet",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -82,6 +85,7 @@
       "protection",
       "projectile_protection"
     ],
+    "category": "armor",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -105,6 +109,7 @@
       "blast_protection",
       "fire_protection"
     ],
+    "category": "armor",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -124,6 +129,7 @@
       "b": 30
     },
     "exclude": [],
+    "category": "armor_head",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -143,6 +149,7 @@
       "b": 41
     },
     "exclude": [],
+    "category": "armor_head",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -162,6 +169,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "armor_chest",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -183,6 +191,7 @@
     "exclude": [
       "frost_walker"
     ],
+    "category": "armor_feet",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -205,6 +214,7 @@
     "exclude": [
       "depth_strider"
     ],
+    "category": "armor_feet",
     "curse": false,
     "tradeable": true,
     "discoverable": true
@@ -225,6 +235,7 @@
     "treasureOnly": true,
     "curse": true,
     "exclude": [],
+    "category": "wearable",
     "tradeable": true,
     "discoverable": true
   },
@@ -245,6 +256,7 @@
     "tradeable": false,
     "discoverable": false,
     "exclude": [],
+    "category": "armor_feet",
     "curse": false
   },
   {
@@ -264,6 +276,7 @@
       "smite",
       "bane_of_arthropods"
     ],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -286,6 +299,7 @@
       "sharpness",
       "bane_of_arthropods"
     ],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -308,6 +322,7 @@
       "smite",
       "sharpness"
     ],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -327,6 +342,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -346,6 +362,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -365,6 +382,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -384,6 +402,7 @@
       "b": 11
     },
     "exclude": [],
+    "category": "weapon",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -403,6 +422,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "digger",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -424,6 +444,7 @@
     "exclude": [
       "fortune"
     ],
+    "category": "digger",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -443,6 +464,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "breakable",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -464,6 +486,7 @@
     "exclude": [
       "silk_touch"
     ],
+    "category": "digger",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -483,6 +506,7 @@
       "b": 6
     },
     "exclude": [],
+    "category": "bow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -502,6 +526,7 @@
       "b": 17
     },
     "exclude": [],
+    "category": "bow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -521,6 +546,7 @@
       "b": 50
     },
     "exclude": [],
+    "category": "bow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -542,6 +568,7 @@
     "exclude": [
       "mending"
     ],
+    "category": "bow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -561,6 +588,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "fishing_rod",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -580,6 +608,7 @@
       "b": 51
     },
     "exclude": [],
+    "category": "fishing_rod",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -601,6 +630,7 @@
     "exclude": [
       "riptide"
     ],
+    "category": "trident",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -620,6 +650,7 @@
       "b": 13
     },
     "exclude": [],
+    "category": "trident",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -642,6 +673,7 @@
       "loyalty",
       "channeling"
     ],
+    "category": "trident",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -663,6 +695,7 @@
     "exclude": [
       "riptide"
     ],
+    "category": "trident",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -684,6 +717,7 @@
     "exclude": [
       "piercing"
     ],
+    "category": "crossbow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -703,6 +737,7 @@
       "b": 50
     },
     "exclude": [],
+    "category": "crossbow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -724,6 +759,7 @@
     "exclude": [
       "multishot"
     ],
+    "category": "crossbow",
     "treasureOnly": false,
     "curse": false,
     "tradeable": true,
@@ -746,6 +782,7 @@
     "exclude": [
       "infinity"
     ],
+    "category": "breakable",
     "curse": false,
     "tradeable": true,
     "discoverable": true
@@ -766,6 +803,7 @@
     "treasureOnly": true,
     "curse": true,
     "exclude": [],
+    "category": "vanishable",
     "tradeable": true,
     "discoverable": true
   }

--- a/data/pc/1.16.4/enchantments.json
+++ b/data/pc/1.16.4/enchantments.json
@@ -2,191 +2,314 @@
   {
     "id": 0,
     "name": "protection",
-    "displayName": "Protection"
+    "displayName": "Protection",
+    "maxLevel": 4,
+    "minCost": "1 + (level - 1) * 11",
+    "maxCost": "this.minCost(level) + 11"
   },
   {
     "id": 1,
     "name": "fire_protection",
-    "displayName": "Fire Protection"
+    "displayName": "Fire Protection",
+    "maxLevel": 4,
+    "minCost": "10 + (level - 1) * 8",
+    "maxCost": "this.minCost(level) + 8"
   },
   {
     "id": 2,
     "name": "feather_falling",
-    "displayName": "Feather Falling"
+    "displayName": "Feather Falling",
+    "maxLevel": 4,
+    "minCost": "5 + (level - 1) * 6",
+    "maxCost": "this.minCost(level) + 6"
   },
   {
     "id": 3,
     "name": "blast_protection",
-    "displayName": "Blast Protection"
+    "displayName": "Blast Protection",
+    "maxLevel": 4,
+    "minCost": "5 + (level - 1) * 8",
+    "maxCost": "this.minCost(level) + 8"
   },
   {
     "id": 4,
     "name": "projectile_protection",
-    "displayName": "Projectile Protection"
+    "displayName": "Projectile Protection",
+    "maxLevel": 4,
+    "minCost": "3 + (level - 1) * 6",
+    "maxCost": "this.minCost(level) + 6"
   },
   {
     "id": 5,
     "name": "respiration",
-    "displayName": "Respiration"
+    "displayName": "Respiration",
+    "maxLevel": 3,
+    "minCost": "10 * level",
+    "maxCost": "this.minCost(level) + 30"
   },
   {
     "id": 6,
     "name": "aqua_affinity",
-    "displayName": "Aqua Affinity"
+    "displayName": "Aqua Affinity",
+    "maxLevel": 1,
+    "minCost": "1",
+    "maxCost": "this.minCost(level) + 40"
   },
   {
     "id": 7,
     "name": "thorns",
-    "displayName": "Thorns"
+    "displayName": "Thorns",
+    "maxLevel": 3,
+    "minCost": "10 + 20 * (level - 1)",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 8,
     "name": "depth_strider",
-    "displayName": "Depth Strider"
+    "displayName": "Depth Strider",
+    "maxLevel": 3,
+    "minCost": "level * 10",
+    "maxCost": "this.minCost(level) + 15"
   },
   {
     "id": 9,
     "name": "frost_walker",
-    "displayName": "Frost Walker"
+    "displayName": "Frost Walker",
+    "maxLevel": 2,
+    "minCost": "level * 10",
+    "maxCost": "this.minCost(level) + 15",
+    "treasureOnly": true
   },
   {
     "id": 10,
     "name": "binding_curse",
-    "displayName": "Curse of Binding"
+    "displayName": "Curse of Binding",
+    "maxLevel": 1,
+    "minCost": "25",
+    "maxCost": "50",
+    "treasureOnly": true,
+    "curse": true
   },
   {
     "id": 11,
     "name": "soul_speed",
-    "displayName": "Soul Speed"
+    "displayName": "Soul Speed",
+    "maxLevel": 3,
+    "minCost": "level * 10",
+    "maxCost": "this.minCost(level) + 15",
+    "treasureOnly": true,
+    "tradeable": false,
+    "discoverable": false
   },
   {
     "id": 12,
     "name": "sharpness",
-    "displayName": "Sharpness"
+    "displayName": "Sharpness",
+    "maxLevel": 5,
+    "minCost": "1 + (level - 1) * 11",
+    "maxCost": "this.minCost(level) + 20"
   },
   {
     "id": 13,
     "name": "smite",
-    "displayName": "Smite"
+    "displayName": "Smite",
+    "maxLevel": 5,
+    "minCost": "5 + (level - 1) * 8",
+    "maxCost": "this.minCost(level) + 20"
   },
   {
     "id": 14,
     "name": "bane_of_arthropods",
-    "displayName": "Bane of Arthropods"
+    "displayName": "Bane of Arthropods",
+    "maxLevel": 5,
+    "minCost": "5 + (level - 1) * 8",
+    "maxCost": "this.minCost(level) + 20"
   },
   {
     "id": 15,
     "name": "knockback",
-    "displayName": "Knockback"
+    "displayName": "Knockback",
+    "maxLevel": 2,
+    "minCost": "5 + 20 * (level - 1)",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 16,
     "name": "fire_aspect",
-    "displayName": "Fire Aspect"
+    "displayName": "Fire Aspect",
+    "maxLevel": 2,
+    "minCost": "10 + 20 * (level - 1)",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 17,
     "name": "looting",
-    "displayName": "Looting"
+    "displayName": "Looting",
+    "maxLevel": 3,
+    "minCost": "15 + (level - 1) * 9",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 18,
     "name": "sweeping",
-    "displayName": "Sweeping Edge"
+    "displayName": "Sweeping Edge",
+    "maxLevel": 3,
+    "minCost": "5 + (level - 1) * 9",
+    "maxCost": "this.minCost(level) + 15"
   },
   {
     "id": 19,
     "name": "efficiency",
-    "displayName": "Efficiency"
+    "displayName": "Efficiency",
+    "maxLevel": 5,
+    "minCost": "1 + 10 * (level - 1)",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 20,
     "name": "silk_touch",
-    "displayName": "Silk Touch"
+    "displayName": "Silk Touch",
+    "maxLevel": 1,
+    "minCost": "15",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 21,
     "name": "unbreaking",
-    "displayName": "Unbreaking"
+    "displayName": "Unbreaking",
+    "maxLevel": 3,
+    "minCost": "5 + (level - 1) * 8",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 22,
     "name": "fortune",
-    "displayName": "Fortune"
+    "displayName": "Fortune",
+    "maxLevel": 3,
+    "minCost": "15 + (level - 1) * 9",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 23,
     "name": "power",
-    "displayName": "Power"
+    "displayName": "Power",
+    "maxLevel": 5,
+    "minCost": "1 + (level - 1) * 10",
+    "maxCost": "this.minCost(level) + 15"
   },
   {
     "id": 24,
     "name": "punch",
-    "displayName": "Punch"
+    "displayName": "Punch",
+    "maxLevel": 2,
+    "minCost": "12 + (level - 1) * 20",
+    "maxCost": "this.minCost(level) + 25"
   },
   {
     "id": 25,
     "name": "flame",
-    "displayName": "Flame"
+    "displayName": "Flame",
+    "maxLevel": 1,
+    "minCost": "20",
+    "maxCost": "50"
   },
   {
     "id": 26,
     "name": "infinity",
-    "displayName": "Infinity"
+    "displayName": "Infinity",
+    "maxLevel": 1,
+    "minCost": "20",
+    "maxCost": "50"
   },
   {
     "id": 27,
     "name": "luck_of_the_sea",
-    "displayName": "Luck of the Sea"
+    "displayName": "Luck of the Sea",
+    "maxLevel": 3,
+    "minCost": "15 + (level - 1) * 9",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 28,
     "name": "lure",
-    "displayName": "Lure"
+    "displayName": "Lure",
+    "maxLevel": 3,
+    "minCost": "15 + (level - 1) * 9",
+    "maxCost": "super.minCost(level) + 50"
   },
   {
     "id": 29,
     "name": "loyalty",
-    "displayName": "Loyalty"
+    "displayName": "Loyalty",
+    "maxLevel": 3,
+    "minCost": "5 + level * 7",
+    "maxCost": "50"
   },
   {
     "id": 30,
     "name": "impaling",
-    "displayName": "Impaling"
+    "displayName": "Impaling",
+    "maxLevel": 5,
+    "minCost": "1 + (level - 1) * 8",
+    "maxCost": "this.minCost(level) + 20"
   },
   {
     "id": 31,
     "name": "riptide",
-    "displayName": "Riptide"
+    "displayName": "Riptide",
+    "maxLevel": 3,
+    "minCost": "10 + level * 7",
+    "maxCost": "50"
   },
   {
     "id": 32,
     "name": "channeling",
-    "displayName": "Channeling"
+    "displayName": "Channeling",
+    "maxLevel": 1,
+    "minCost": "25",
+    "maxCost": "50"
   },
   {
     "id": 33,
     "name": "multishot",
-    "displayName": "Multishot"
+    "displayName": "Multishot",
+    "maxLevel": 1,
+    "minCost": "20",
+    "maxCost": "50"
   },
   {
     "id": 34,
     "name": "quick_charge",
-    "displayName": "Quick Charge"
+    "displayName": "Quick Charge",
+    "maxLevel": 3,
+    "minCost": "12 + (level - 1) * 20",
+    "maxCost": "50"
   },
   {
     "id": 35,
     "name": "piercing",
-    "displayName": "Piercing"
+    "displayName": "Piercing",
+    "maxLevel": 4,
+    "minCost": "1 + (level - 1) * 10",
+    "maxCost": "50"
   },
   {
     "id": 36,
     "name": "mending",
-    "displayName": "Mending"
+    "displayName": "Mending",
+    "maxLevel": 1,
+    "minCost": "level * 25",
+    "maxCost": "this.minCost(level) + 50",
+    "treasureOnly": true
   },
   {
     "id": 37,
     "name": "vanishing_curse",
-    "displayName": "Curse of Vanishing"
+    "displayName": "Curse of Vanishing",
+    "maxLevel": 1,
+    "minCost": "25",
+    "maxCost": "50",
+    "treasureOnly": true,
+    "curse": true
   }
 ]

--- a/data/pc/1.16.4/enchantments.json
+++ b/data/pc/1.16.4/enchantments.json
@@ -5,7 +5,8 @@
     "displayName": "Protection",
     "maxLevel": 4,
     "minCost": "1 + (level - 1) * 11",
-    "maxCost": "this.minCost(level) + 11"
+    "maxCost": "this.minCost(level) + 11",
+    "exclude": ["blast_protection", "fire_protection", "projectile_protection"]
   },
   {
     "id": 1,
@@ -13,7 +14,8 @@
     "displayName": "Fire Protection",
     "maxLevel": 4,
     "minCost": "10 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 8"
+    "maxCost": "this.minCost(level) + 8",
+    "exclude": ["blast_protection", "protection", "projectile_protection"]
   },
   {
     "id": 2,
@@ -21,7 +23,8 @@
     "displayName": "Feather Falling",
     "maxLevel": 4,
     "minCost": "5 + (level - 1) * 6",
-    "maxCost": "this.minCost(level) + 6"
+    "maxCost": "this.minCost(level) + 6",
+    "exclude": []
   },
   {
     "id": 3,
@@ -29,7 +32,8 @@
     "displayName": "Blast Protection",
     "maxLevel": 4,
     "minCost": "5 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 8"
+    "maxCost": "this.minCost(level) + 8",
+    "exclude": ["fire_protection", "protection", "projectile_protection"]
   },
   {
     "id": 4,
@@ -37,7 +41,8 @@
     "displayName": "Projectile Protection",
     "maxLevel": 4,
     "minCost": "3 + (level - 1) * 6",
-    "maxCost": "this.minCost(level) + 6"
+    "maxCost": "this.minCost(level) + 6",
+    "exclude": ["protection", "blast_protection", "fire_protection"]
   },
   {
     "id": 5,
@@ -45,7 +50,8 @@
     "displayName": "Respiration",
     "maxLevel": 3,
     "minCost": "10 * level",
-    "maxCost": "this.minCost(level) + 30"
+    "maxCost": "this.minCost(level) + 30",
+    "exclude": []
   },
   {
     "id": 6,
@@ -53,7 +59,8 @@
     "displayName": "Aqua Affinity",
     "maxLevel": 1,
     "minCost": "1",
-    "maxCost": "this.minCost(level) + 40"
+    "maxCost": "this.minCost(level) + 40",
+    "exclude": []
   },
   {
     "id": 7,
@@ -61,7 +68,8 @@
     "displayName": "Thorns",
     "maxLevel": 3,
     "minCost": "10 + 20 * (level - 1)",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": []
   },
   {
     "id": 8,
@@ -69,7 +77,8 @@
     "displayName": "Depth Strider",
     "maxLevel": 3,
     "minCost": "level * 10",
-    "maxCost": "this.minCost(level) + 15"
+    "maxCost": "this.minCost(level) + 15",
+    "exclude": ["frost_walker"]
   },
   {
     "id": 9,
@@ -78,7 +87,8 @@
     "maxLevel": 2,
     "minCost": "level * 10",
     "maxCost": "this.minCost(level) + 15",
-    "treasureOnly": true
+    "treasureOnly": true,
+    "exclude": ["depth_strider"]
   },
   {
     "id": 10,
@@ -88,7 +98,8 @@
     "minCost": "25",
     "maxCost": "50",
     "treasureOnly": true,
-    "curse": true
+    "curse": true,
+    "exclude": []
   },
   {
     "id": 11,
@@ -99,7 +110,8 @@
     "maxCost": "this.minCost(level) + 15",
     "treasureOnly": true,
     "tradeable": false,
-    "discoverable": false
+    "discoverable": false,
+    "exclude": []
   },
   {
     "id": 12,
@@ -107,7 +119,8 @@
     "displayName": "Sharpness",
     "maxLevel": 5,
     "minCost": "1 + (level - 1) * 11",
-    "maxCost": "this.minCost(level) + 20"
+    "maxCost": "this.minCost(level) + 20",
+    "exclude": ["smite", "bane_of_arthropods"]
   },
   {
     "id": 13,
@@ -115,7 +128,8 @@
     "displayName": "Smite",
     "maxLevel": 5,
     "minCost": "5 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 20"
+    "maxCost": "this.minCost(level) + 20",
+    "exclude": ["sharpness", "bane_of_arthropods"]
   },
   {
     "id": 14,
@@ -123,7 +137,8 @@
     "displayName": "Bane of Arthropods",
     "maxLevel": 5,
     "minCost": "5 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 20"
+    "maxCost": "this.minCost(level) + 20",
+    "exclude": ["smite", "sharpness"]
   },
   {
     "id": 15,
@@ -131,7 +146,8 @@
     "displayName": "Knockback",
     "maxLevel": 2,
     "minCost": "5 + 20 * (level - 1)",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": []
   },
   {
     "id": 16,
@@ -139,7 +155,8 @@
     "displayName": "Fire Aspect",
     "maxLevel": 2,
     "minCost": "10 + 20 * (level - 1)",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": []
   },
   {
     "id": 17,
@@ -147,7 +164,8 @@
     "displayName": "Looting",
     "maxLevel": 3,
     "minCost": "15 + (level - 1) * 9",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": []
   },
   {
     "id": 18,
@@ -155,7 +173,8 @@
     "displayName": "Sweeping Edge",
     "maxLevel": 3,
     "minCost": "5 + (level - 1) * 9",
-    "maxCost": "this.minCost(level) + 15"
+    "maxCost": "this.minCost(level) + 15",
+    "exclude": []
   },
   {
     "id": 19,
@@ -163,7 +182,8 @@
     "displayName": "Efficiency",
     "maxLevel": 5,
     "minCost": "1 + 10 * (level - 1)",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": []
   },
   {
     "id": 20,
@@ -171,7 +191,8 @@
     "displayName": "Silk Touch",
     "maxLevel": 1,
     "minCost": "15",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": ["fortune"]
   },
   {
     "id": 21,
@@ -179,7 +200,8 @@
     "displayName": "Unbreaking",
     "maxLevel": 3,
     "minCost": "5 + (level - 1) * 8",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": []
   },
   {
     "id": 22,
@@ -187,7 +209,8 @@
     "displayName": "Fortune",
     "maxLevel": 3,
     "minCost": "15 + (level - 1) * 9",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": ["silk_touch"]
   },
   {
     "id": 23,
@@ -195,7 +218,8 @@
     "displayName": "Power",
     "maxLevel": 5,
     "minCost": "1 + (level - 1) * 10",
-    "maxCost": "this.minCost(level) + 15"
+    "maxCost": "this.minCost(level) + 15",
+    "exclude": []
   },
   {
     "id": 24,
@@ -203,7 +227,8 @@
     "displayName": "Punch",
     "maxLevel": 2,
     "minCost": "12 + (level - 1) * 20",
-    "maxCost": "this.minCost(level) + 25"
+    "maxCost": "this.minCost(level) + 25",
+    "exclude": []
   },
   {
     "id": 25,
@@ -211,7 +236,8 @@
     "displayName": "Flame",
     "maxLevel": 1,
     "minCost": "20",
-    "maxCost": "50"
+    "maxCost": "50",
+    "exclude": []
   },
   {
     "id": 26,
@@ -219,7 +245,8 @@
     "displayName": "Infinity",
     "maxLevel": 1,
     "minCost": "20",
-    "maxCost": "50"
+    "maxCost": "50",
+    "exclude": ["mending"]
   },
   {
     "id": 27,
@@ -227,7 +254,8 @@
     "displayName": "Luck of the Sea",
     "maxLevel": 3,
     "minCost": "15 + (level - 1) * 9",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": []
   },
   {
     "id": 28,
@@ -235,7 +263,8 @@
     "displayName": "Lure",
     "maxLevel": 3,
     "minCost": "15 + (level - 1) * 9",
-    "maxCost": "super.minCost(level) + 50"
+    "maxCost": "super.minCost(level) + 50",
+    "exclude": []
   },
   {
     "id": 29,
@@ -243,7 +272,8 @@
     "displayName": "Loyalty",
     "maxLevel": 3,
     "minCost": "5 + level * 7",
-    "maxCost": "50"
+    "maxCost": "50",
+    "exclude": ["riptide"]
   },
   {
     "id": 30,
@@ -251,7 +281,8 @@
     "displayName": "Impaling",
     "maxLevel": 5,
     "minCost": "1 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 20"
+    "maxCost": "this.minCost(level) + 20",
+    "exclude": []
   },
   {
     "id": 31,
@@ -259,7 +290,8 @@
     "displayName": "Riptide",
     "maxLevel": 3,
     "minCost": "10 + level * 7",
-    "maxCost": "50"
+    "maxCost": "50",
+    "exclude": ["loyalty", "channeling"]
   },
   {
     "id": 32,
@@ -267,7 +299,8 @@
     "displayName": "Channeling",
     "maxLevel": 1,
     "minCost": "25",
-    "maxCost": "50"
+    "maxCost": "50",
+    "exclude": ["riptide"]
   },
   {
     "id": 33,
@@ -275,7 +308,8 @@
     "displayName": "Multishot",
     "maxLevel": 1,
     "minCost": "20",
-    "maxCost": "50"
+    "maxCost": "50",
+    "exclude": ["piercing"]
   },
   {
     "id": 34,
@@ -283,7 +317,8 @@
     "displayName": "Quick Charge",
     "maxLevel": 3,
     "minCost": "12 + (level - 1) * 20",
-    "maxCost": "50"
+    "maxCost": "50",
+    "exclude": []
   },
   {
     "id": 35,
@@ -291,7 +326,8 @@
     "displayName": "Piercing",
     "maxLevel": 4,
     "minCost": "1 + (level - 1) * 10",
-    "maxCost": "50"
+    "maxCost": "50",
+    "exclude": ["multishot"]
   },
   {
     "id": 36,
@@ -300,7 +336,8 @@
     "maxLevel": 1,
     "minCost": "level * 25",
     "maxCost": "this.minCost(level) + 50",
-    "treasureOnly": true
+    "treasureOnly": true,
+    "exclude": ["infinity"]
   },
   {
     "id": 37,
@@ -310,6 +347,7 @@
     "minCost": "25",
     "maxCost": "50",
     "treasureOnly": true,
-    "curse": true
+    "curse": true,
+    "exclude": []
   }
 ]

--- a/data/pc/1.16.4/enchantments.json
+++ b/data/pc/1.16.4/enchantments.json
@@ -4,26 +4,52 @@
     "name": "protection",
     "displayName": "Protection",
     "maxLevel": 4,
-    "minCost": "1 + (level - 1) * 11",
-    "maxCost": "this.minCost(level) + 11",
-    "exclude": ["blast_protection", "fire_protection", "projectile_protection"]
+    "minCost": {
+      "a": 11,
+      "b": -10
+    },
+    "maxCost": {
+      "a": 11,
+      "b": 1
+    },
+    "exclude": [
+      "blast_protection",
+      "fire_protection",
+      "projectile_protection"
+    ]
   },
   {
     "id": 1,
     "name": "fire_protection",
     "displayName": "Fire Protection",
     "maxLevel": 4,
-    "minCost": "10 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 8",
-    "exclude": ["blast_protection", "protection", "projectile_protection"]
+    "minCost": {
+      "a": 8,
+      "b": 2
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 10
+    },
+    "exclude": [
+      "blast_protection",
+      "protection",
+      "projectile_protection"
+    ]
   },
   {
     "id": 2,
     "name": "feather_falling",
     "displayName": "Feather Falling",
     "maxLevel": 4,
-    "minCost": "5 + (level - 1) * 6",
-    "maxCost": "this.minCost(level) + 6",
+    "minCost": {
+      "a": 6,
+      "b": -1
+    },
+    "maxCost": {
+      "a": 6,
+      "b": 5
+    },
     "exclude": []
   },
   {
@@ -31,26 +57,52 @@
     "name": "blast_protection",
     "displayName": "Blast Protection",
     "maxLevel": 4,
-    "minCost": "5 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 8",
-    "exclude": ["fire_protection", "protection", "projectile_protection"]
+    "minCost": {
+      "a": 8,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 5
+    },
+    "exclude": [
+      "fire_protection",
+      "protection",
+      "projectile_protection"
+    ]
   },
   {
     "id": 4,
     "name": "projectile_protection",
     "displayName": "Projectile Protection",
     "maxLevel": 4,
-    "minCost": "3 + (level - 1) * 6",
-    "maxCost": "this.minCost(level) + 6",
-    "exclude": ["protection", "blast_protection", "fire_protection"]
+    "minCost": {
+      "a": 6,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 6,
+      "b": 3
+    },
+    "exclude": [
+      "protection",
+      "blast_protection",
+      "fire_protection"
+    ]
   },
   {
     "id": 5,
     "name": "respiration",
     "displayName": "Respiration",
     "maxLevel": 3,
-    "minCost": "10 * level",
-    "maxCost": "this.minCost(level) + 30",
+    "minCost": {
+      "a": 10,
+      "b": 0
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 30
+    },
     "exclude": []
   },
   {
@@ -58,8 +110,14 @@
     "name": "aqua_affinity",
     "displayName": "Aqua Affinity",
     "maxLevel": 1,
-    "minCost": "1",
-    "maxCost": "this.minCost(level) + 40",
+    "minCost": {
+      "a": 0,
+      "b": 1
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 41
+    },
     "exclude": []
   },
   {
@@ -67,8 +125,14 @@
     "name": "thorns",
     "displayName": "Thorns",
     "maxLevel": 3,
-    "minCost": "10 + 20 * (level - 1)",
-    "maxCost": "super.minCost(level) + 50",
+    "minCost": {
+      "a": 20,
+      "b": -10
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
     "exclude": []
   },
   {
@@ -76,27 +140,49 @@
     "name": "depth_strider",
     "displayName": "Depth Strider",
     "maxLevel": 3,
-    "minCost": "level * 10",
-    "maxCost": "this.minCost(level) + 15",
-    "exclude": ["frost_walker"]
+    "minCost": {
+      "a": 10,
+      "b": 0
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 15
+    },
+    "exclude": [
+      "frost_walker"
+    ]
   },
   {
     "id": 9,
     "name": "frost_walker",
     "displayName": "Frost Walker",
     "maxLevel": 2,
-    "minCost": "level * 10",
-    "maxCost": "this.minCost(level) + 15",
+    "minCost": {
+      "a": 10,
+      "b": 0
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 15
+    },
     "treasureOnly": true,
-    "exclude": ["depth_strider"]
+    "exclude": [
+      "depth_strider"
+    ]
   },
   {
     "id": 10,
     "name": "binding_curse",
     "displayName": "Curse of Binding",
     "maxLevel": 1,
-    "minCost": "25",
-    "maxCost": "50",
+    "minCost": {
+      "a": 0,
+      "b": 25
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
     "treasureOnly": true,
     "curse": true,
     "exclude": []
@@ -106,8 +192,14 @@
     "name": "soul_speed",
     "displayName": "Soul Speed",
     "maxLevel": 3,
-    "minCost": "level * 10",
-    "maxCost": "this.minCost(level) + 15",
+    "minCost": {
+      "a": 10,
+      "b": 0
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 15
+    },
     "treasureOnly": true,
     "tradeable": false,
     "discoverable": false,
@@ -118,35 +210,68 @@
     "name": "sharpness",
     "displayName": "Sharpness",
     "maxLevel": 5,
-    "minCost": "1 + (level - 1) * 11",
-    "maxCost": "this.minCost(level) + 20",
-    "exclude": ["smite", "bane_of_arthropods"]
+    "minCost": {
+      "a": 11,
+      "b": -10
+    },
+    "maxCost": {
+      "a": 11,
+      "b": 10
+    },
+    "exclude": [
+      "smite",
+      "bane_of_arthropods"
+    ]
   },
   {
     "id": 13,
     "name": "smite",
     "displayName": "Smite",
     "maxLevel": 5,
-    "minCost": "5 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 20",
-    "exclude": ["sharpness", "bane_of_arthropods"]
+    "minCost": {
+      "a": 8,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 17
+    },
+    "exclude": [
+      "sharpness",
+      "bane_of_arthropods"
+    ]
   },
   {
     "id": 14,
     "name": "bane_of_arthropods",
     "displayName": "Bane of Arthropods",
     "maxLevel": 5,
-    "minCost": "5 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 20",
-    "exclude": ["smite", "sharpness"]
+    "minCost": {
+      "a": 8,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 17
+    },
+    "exclude": [
+      "smite",
+      "sharpness"
+    ]
   },
   {
     "id": 15,
     "name": "knockback",
     "displayName": "Knockback",
     "maxLevel": 2,
-    "minCost": "5 + 20 * (level - 1)",
-    "maxCost": "super.minCost(level) + 50",
+    "minCost": {
+      "a": 20,
+      "b": -15
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
     "exclude": []
   },
   {
@@ -154,8 +279,14 @@
     "name": "fire_aspect",
     "displayName": "Fire Aspect",
     "maxLevel": 2,
-    "minCost": "10 + 20 * (level - 1)",
-    "maxCost": "super.minCost(level) + 50",
+    "minCost": {
+      "a": 20,
+      "b": -10
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
     "exclude": []
   },
   {
@@ -163,8 +294,14 @@
     "name": "looting",
     "displayName": "Looting",
     "maxLevel": 3,
-    "minCost": "15 + (level - 1) * 9",
-    "maxCost": "super.minCost(level) + 50",
+    "minCost": {
+      "a": 9,
+      "b": 6
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
     "exclude": []
   },
   {
@@ -172,8 +309,14 @@
     "name": "sweeping",
     "displayName": "Sweeping Edge",
     "maxLevel": 3,
-    "minCost": "5 + (level - 1) * 9",
-    "maxCost": "this.minCost(level) + 15",
+    "minCost": {
+      "a": 9,
+      "b": -4
+    },
+    "maxCost": {
+      "a": 9,
+      "b": 11
+    },
     "exclude": []
   },
   {
@@ -181,8 +324,14 @@
     "name": "efficiency",
     "displayName": "Efficiency",
     "maxLevel": 5,
-    "minCost": "1 + 10 * (level - 1)",
-    "maxCost": "super.minCost(level) + 50",
+    "minCost": {
+      "a": 10,
+      "b": -9
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
     "exclude": []
   },
   {
@@ -190,17 +339,31 @@
     "name": "silk_touch",
     "displayName": "Silk Touch",
     "maxLevel": 1,
-    "minCost": "15",
-    "maxCost": "super.minCost(level) + 50",
-    "exclude": ["fortune"]
+    "minCost": {
+      "a": 0,
+      "b": 15
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [
+      "fortune"
+    ]
   },
   {
     "id": 21,
     "name": "unbreaking",
     "displayName": "Unbreaking",
     "maxLevel": 3,
-    "minCost": "5 + (level - 1) * 8",
-    "maxCost": "super.minCost(level) + 50",
+    "minCost": {
+      "a": 8,
+      "b": -3
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
     "exclude": []
   },
   {
@@ -208,17 +371,31 @@
     "name": "fortune",
     "displayName": "Fortune",
     "maxLevel": 3,
-    "minCost": "15 + (level - 1) * 9",
-    "maxCost": "super.minCost(level) + 50",
-    "exclude": ["silk_touch"]
+    "minCost": {
+      "a": 9,
+      "b": 6
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
+    "exclude": [
+      "silk_touch"
+    ]
   },
   {
     "id": 23,
     "name": "power",
     "displayName": "Power",
     "maxLevel": 5,
-    "minCost": "1 + (level - 1) * 10",
-    "maxCost": "this.minCost(level) + 15",
+    "minCost": {
+      "a": 10,
+      "b": -9
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 6
+    },
     "exclude": []
   },
   {
@@ -226,8 +403,14 @@
     "name": "punch",
     "displayName": "Punch",
     "maxLevel": 2,
-    "minCost": "12 + (level - 1) * 20",
-    "maxCost": "this.minCost(level) + 25",
+    "minCost": {
+      "a": 20,
+      "b": -8
+    },
+    "maxCost": {
+      "a": 20,
+      "b": 17
+    },
     "exclude": []
   },
   {
@@ -235,8 +418,14 @@
     "name": "flame",
     "displayName": "Flame",
     "maxLevel": 1,
-    "minCost": "20",
-    "maxCost": "50",
+    "minCost": {
+      "a": 0,
+      "b": 20
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
     "exclude": []
   },
   {
@@ -244,17 +433,31 @@
     "name": "infinity",
     "displayName": "Infinity",
     "maxLevel": 1,
-    "minCost": "20",
-    "maxCost": "50",
-    "exclude": ["mending"]
+    "minCost": {
+      "a": 0,
+      "b": 20
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "mending"
+    ]
   },
   {
     "id": 27,
     "name": "luck_of_the_sea",
     "displayName": "Luck of the Sea",
     "maxLevel": 3,
-    "minCost": "15 + (level - 1) * 9",
-    "maxCost": "super.minCost(level) + 50",
+    "minCost": {
+      "a": 9,
+      "b": 6
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
     "exclude": []
   },
   {
@@ -262,8 +465,14 @@
     "name": "lure",
     "displayName": "Lure",
     "maxLevel": 3,
-    "minCost": "15 + (level - 1) * 9",
-    "maxCost": "super.minCost(level) + 50",
+    "minCost": {
+      "a": 9,
+      "b": 6
+    },
+    "maxCost": {
+      "a": 10,
+      "b": 51
+    },
     "exclude": []
   },
   {
@@ -271,17 +480,31 @@
     "name": "loyalty",
     "displayName": "Loyalty",
     "maxLevel": 3,
-    "minCost": "5 + level * 7",
-    "maxCost": "50",
-    "exclude": ["riptide"]
+    "minCost": {
+      "a": 7,
+      "b": 5
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "riptide"
+    ]
   },
   {
     "id": 30,
     "name": "impaling",
     "displayName": "Impaling",
     "maxLevel": 5,
-    "minCost": "1 + (level - 1) * 8",
-    "maxCost": "this.minCost(level) + 20",
+    "minCost": {
+      "a": 8,
+      "b": -7
+    },
+    "maxCost": {
+      "a": 8,
+      "b": 13
+    },
     "exclude": []
   },
   {
@@ -289,35 +512,66 @@
     "name": "riptide",
     "displayName": "Riptide",
     "maxLevel": 3,
-    "minCost": "10 + level * 7",
-    "maxCost": "50",
-    "exclude": ["loyalty", "channeling"]
+    "minCost": {
+      "a": 7,
+      "b": 10
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "loyalty",
+      "channeling"
+    ]
   },
   {
     "id": 32,
     "name": "channeling",
     "displayName": "Channeling",
     "maxLevel": 1,
-    "minCost": "25",
-    "maxCost": "50",
-    "exclude": ["riptide"]
+    "minCost": {
+      "a": 0,
+      "b": 25
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "riptide"
+    ]
   },
   {
     "id": 33,
     "name": "multishot",
     "displayName": "Multishot",
     "maxLevel": 1,
-    "minCost": "20",
-    "maxCost": "50",
-    "exclude": ["piercing"]
+    "minCost": {
+      "a": 0,
+      "b": 20
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "piercing"
+    ]
   },
   {
     "id": 34,
     "name": "quick_charge",
     "displayName": "Quick Charge",
     "maxLevel": 3,
-    "minCost": "12 + (level - 1) * 20",
-    "maxCost": "50",
+    "minCost": {
+      "a": 20,
+      "b": -8
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
     "exclude": []
   },
   {
@@ -325,27 +579,49 @@
     "name": "piercing",
     "displayName": "Piercing",
     "maxLevel": 4,
-    "minCost": "1 + (level - 1) * 10",
-    "maxCost": "50",
-    "exclude": ["multishot"]
+    "minCost": {
+      "a": 10,
+      "b": -9
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
+    "exclude": [
+      "multishot"
+    ]
   },
   {
     "id": 36,
     "name": "mending",
     "displayName": "Mending",
     "maxLevel": 1,
-    "minCost": "level * 25",
-    "maxCost": "this.minCost(level) + 50",
+    "minCost": {
+      "a": 25,
+      "b": 0
+    },
+    "maxCost": {
+      "a": 25,
+      "b": 50
+    },
     "treasureOnly": true,
-    "exclude": ["infinity"]
+    "exclude": [
+      "infinity"
+    ]
   },
   {
     "id": 37,
     "name": "vanishing_curse",
     "displayName": "Curse of Vanishing",
     "maxLevel": 1,
-    "minCost": "25",
-    "maxCost": "50",
+    "minCost": {
+      "a": 0,
+      "b": 25
+    },
+    "maxCost": {
+      "a": 0,
+      "b": 50
+    },
     "treasureOnly": true,
     "curse": true,
     "exclude": []

--- a/data/pc/1.16.4/enchantments.json
+++ b/data/pc/1.16.4/enchantments.json
@@ -16,7 +16,11 @@
       "blast_protection",
       "fire_protection",
       "projectile_protection"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 1,
@@ -35,7 +39,11 @@
       "blast_protection",
       "protection",
       "projectile_protection"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 2,
@@ -50,7 +58,11 @@
       "a": 6,
       "b": 5
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 3,
@@ -69,7 +81,11 @@
       "fire_protection",
       "protection",
       "projectile_protection"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 4,
@@ -88,7 +104,11 @@
       "protection",
       "blast_protection",
       "fire_protection"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 5,
@@ -103,7 +123,11 @@
       "a": 10,
       "b": 30
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 6,
@@ -118,7 +142,11 @@
       "a": 0,
       "b": 41
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 7,
@@ -133,7 +161,11 @@
       "a": 10,
       "b": 51
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 8,
@@ -150,7 +182,11 @@
     },
     "exclude": [
       "frost_walker"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 9,
@@ -168,7 +204,10 @@
     "treasureOnly": true,
     "exclude": [
       "depth_strider"
-    ]
+    ],
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 10,
@@ -185,7 +224,9 @@
     },
     "treasureOnly": true,
     "curse": true,
-    "exclude": []
+    "exclude": [],
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 11,
@@ -203,7 +244,8 @@
     "treasureOnly": true,
     "tradeable": false,
     "discoverable": false,
-    "exclude": []
+    "exclude": [],
+    "curse": false
   },
   {
     "id": 12,
@@ -221,7 +263,11 @@
     "exclude": [
       "smite",
       "bane_of_arthropods"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 13,
@@ -239,7 +285,11 @@
     "exclude": [
       "sharpness",
       "bane_of_arthropods"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 14,
@@ -257,7 +307,11 @@
     "exclude": [
       "smite",
       "sharpness"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 15,
@@ -272,7 +326,11 @@
       "a": 10,
       "b": 51
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 16,
@@ -287,7 +345,11 @@
       "a": 10,
       "b": 51
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 17,
@@ -302,7 +364,11 @@
       "a": 10,
       "b": 51
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 18,
@@ -317,7 +383,11 @@
       "a": 9,
       "b": 11
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 19,
@@ -332,7 +402,11 @@
       "a": 10,
       "b": 51
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 20,
@@ -349,7 +423,11 @@
     },
     "exclude": [
       "fortune"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 21,
@@ -364,7 +442,11 @@
       "a": 10,
       "b": 51
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 22,
@@ -381,7 +463,11 @@
     },
     "exclude": [
       "silk_touch"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 23,
@@ -396,7 +482,11 @@
       "a": 10,
       "b": 6
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 24,
@@ -411,7 +501,11 @@
       "a": 20,
       "b": 17
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 25,
@@ -426,7 +520,11 @@
       "a": 0,
       "b": 50
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 26,
@@ -443,7 +541,11 @@
     },
     "exclude": [
       "mending"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 27,
@@ -458,7 +560,11 @@
       "a": 10,
       "b": 51
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 28,
@@ -473,7 +579,11 @@
       "a": 10,
       "b": 51
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 29,
@@ -490,7 +600,11 @@
     },
     "exclude": [
       "riptide"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 30,
@@ -505,7 +619,11 @@
       "a": 8,
       "b": 13
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 31,
@@ -523,7 +641,11 @@
     "exclude": [
       "loyalty",
       "channeling"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 32,
@@ -540,7 +662,11 @@
     },
     "exclude": [
       "riptide"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 33,
@@ -557,7 +683,11 @@
     },
     "exclude": [
       "piercing"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 34,
@@ -572,7 +702,11 @@
       "a": 0,
       "b": 50
     },
-    "exclude": []
+    "exclude": [],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 35,
@@ -589,7 +723,11 @@
     },
     "exclude": [
       "multishot"
-    ]
+    ],
+    "treasureOnly": false,
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 36,
@@ -607,7 +745,10 @@
     "treasureOnly": true,
     "exclude": [
       "infinity"
-    ]
+    ],
+    "curse": false,
+    "tradeable": true,
+    "discoverable": true
   },
   {
     "id": 37,
@@ -624,6 +765,8 @@
     },
     "treasureOnly": true,
     "curse": true,
-    "exclude": []
+    "exclude": [],
+    "tradeable": true,
+    "discoverable": true
   }
 ]

--- a/schemas/enchantments_schema.json
+++ b/schemas/enchantments_schema.json
@@ -25,7 +25,6 @@
       "id",
       "name",
       "displayName"
-    ],
-    "additionalProperties": false
+    ]
   }
 }

--- a/schemas/enchantments_schema.json
+++ b/schemas/enchantments_schema.json
@@ -24,7 +24,7 @@
         "description": "The maximum level of an enchantment",
         "type": "integer",
         "minimum": 1,
-        "maximum": 0
+        "maximum": 5
       },
       "minCost": {
         "description": "Min cost equation's coefficients a * level + b",

--- a/schemas/enchantments_schema.json
+++ b/schemas/enchantments_schema.json
@@ -19,6 +19,64 @@
       "displayName": {
         "description": "The display name of an enchantment",
         "type": "string"
+      },
+      "maxLevel": {
+        "description": "The maximum level of an enchantment",
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 0
+      },
+      "minCost": {
+        "description": "Min cost equation's coefficients a * level + b",
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "integer"
+          },
+          "b": {
+            "type": "integer"
+          }
+        }
+      },
+      "maxCost": {
+        "description": "Max cost equation's coefficients a * level + b",
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "integer"
+          },
+          "b": {
+            "type": "integer"
+          }
+        }
+      },
+      "treasureOnly": {
+        "description": "Can only be found in a treasure, not created",
+        "type": "boolean"
+      },
+      "curse": {
+        "description": "Is a curse, not an enchantment",
+        "type": "boolean"
+      },
+      "exclude": {
+        "description": "List of enchantment not compatibles",
+        "type": "array",
+        "uniqueItems": true,
+        "items": {
+          "type": "string"
+        }
+      },
+      "category": {
+        "description": "The category of enchantable items",
+        "type": "string"
+      },
+      "tradeable": {
+        "description": "Can this enchantment be traded",
+        "type": "boolean"
+      },
+      "discoverable": {
+        "description": "Can this enchantment be discovered",
+        "type": "boolean"
       }
     },
     "required": [


### PR DESCRIPTION
The enchants of 1.13 had wrong ids and some bad names according to https://wiki.vg/index.php?title=Protocol&oldid=14889

New enchants were only added in the 1.16.4 version according to https://wiki.vg/index.php?title=Protocol&oldid=16091 and https://wiki.vg/index.php?title=Protocol&oldid=16317

This PR fix both issues