### PR TITLE
Bump version number for 1.16.5

### DIFF
--- a/data/dataPaths.json
+++ b/data/dataPaths.json
@@ -867,7 +867,7 @@
       "entities": "pc/1.16.2",
       "protocol": "pc/1.16.2",
       "windows": "pc/1.16.1",
-      "version": "pc/1.16.4",
+      "version": "pc/1.16.5",
       "foods" : "pc/1.16.1",
       "particles": "pc/1.16",
       "blockLoot": "pc/1.16.2",

--- a/data/pc/1.16.5/version.json
+++ b/data/pc/1.16.5/version.json
@@ -1,0 +1,5 @@
+{
+  "minecraftVersion": "1.16.5",
+  "version": 754,
+  "majorVersion": "1.16"
+}


### PR DESCRIPTION
Having these two versions report the same version number is causing collisions in my code.

This bumps the reported version number for 1.16.5 even though it's network compatible with 1.16.4