### PR TITLE
Fixed spawn painting

### DIFF
--- a/data/pc/1.7/protocol.json
+++ b/data/pc/1.7/protocol.json
@@ -988,7 +988,7 @@
             },
             {
               "name": "direction",
-              "type": "u8"
+              "type": "i32"
             }
           ]
         ],


### PR DESCRIPTION
https://wiki.vg/index.php?title=Protocol&oldid=6003#Spawn_Painting direction is defined as Int here
but its defined in mcData https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.7/protocol.json#L991 as unsigned byte.