### PR TITLE
fix recipe shape (width/height flipped) in 1.16.2 protocol declare_recipes

### DIFF
--- a/data/pc/1.16.2/protocol.json
+++ b/data/pc/1.16.2/protocol.json
@@ -3792,9 +3792,9 @@
                           {
                             "name": "ingredients",
                             "type": ["array",{
-                              "count": "width",
+                              "count": "height",
                               "type": ["array",{
-                                "count": "height",
+                                "count": "width",
                                 "type": "ingredient"
                               }]
                             }]


### PR DESCRIPTION
See also https://wiki.vg/Protocol#Declare_Recipes

With the previous (wrong) protocol definition I received:
```js
		{
			"type": "minecraft:crafting_shaped",
			"recipeId": "minecraft:iron_hoe",
			"data": {
				"width": 2,
				"height": 3,
				"group": "",
				"ingredients": [
					[
						[{ "present": true, "itemId": 579, "itemCount": 1 }],
						[{ "present": true, "itemId": 579, "itemCount": 1 }],
						[]
					],
					[
						[{ "present": true, "itemId": 613, "itemCount": 1 }],
						[],
						[{ "present": true, "itemId": 613, "itemCount": 1 }]
					]
				],
				"result": { /* ... */ }
			}
		}
```
The ingredients look like this
```
56
5.
.6
```
or, alternatively
```
55.
6.6
```
instead of this (correct)
```
55
.6
.6
```

Flipping `width`/`height` in the protocol definition fixes this, and results in a row-then-column indexed 2D array of item ingredients.

I suspect this will also be broken in other versions but I can't test these right now.