### PR TITLE
Add support for brigadier:long and minecraft:range

### DIFF
--- a/data/pc/1.13.1/protocol.json
+++ b/data/pc/1.13.1/protocol.json
@@ -1372,7 +1372,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1472,9 +1471,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.13.2-pre1/protocol.json
+++ b/data/pc/1.13.2-pre1/protocol.json
@@ -1377,7 +1377,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1477,9 +1476,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.13.2-pre2/protocol.json
+++ b/data/pc/1.13.2-pre2/protocol.json
@@ -1377,7 +1377,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1477,9 +1476,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.13.2/protocol.json
+++ b/data/pc/1.13.2/protocol.json
@@ -1377,7 +1377,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1477,9 +1476,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.13/protocol.json
+++ b/data/pc/1.13/protocol.json
@@ -1372,7 +1372,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1472,9 +1471,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.14.1/protocol.json
+++ b/data/pc/1.14.1/protocol.json
@@ -1400,7 +1400,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1500,9 +1499,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.14.3/protocol.json
+++ b/data/pc/1.14.3/protocol.json
@@ -1400,7 +1400,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1500,9 +1499,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.14.4/protocol.json
+++ b/data/pc/1.14.4/protocol.json
@@ -1400,7 +1400,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1500,9 +1499,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.14/protocol.json
+++ b/data/pc/1.14/protocol.json
@@ -1400,7 +1400,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1500,9 +1499,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.15.1/protocol.json
+++ b/data/pc/1.15.1/protocol.json
@@ -1392,7 +1392,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1492,9 +1491,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.15.2/protocol.json
+++ b/data/pc/1.15.2/protocol.json
@@ -1392,7 +1392,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1492,9 +1491,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.15/protocol.json
+++ b/data/pc/1.15/protocol.json
@@ -1392,7 +1392,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1492,9 +1491,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.16-rc1/protocol.json
+++ b/data/pc/1.16-rc1/protocol.json
@@ -1368,7 +1368,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1468,9 +1467,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.16.1/protocol.json
+++ b/data/pc/1.16.1/protocol.json
@@ -1368,7 +1368,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1468,9 +1467,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.16.2/protocol.json
+++ b/data/pc/1.16.2/protocol.json
@@ -1368,7 +1368,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1468,9 +1467,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.16/protocol.json
+++ b/data/pc/1.16/protocol.json
@@ -1368,7 +1368,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1468,9 +1467,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/1.17/protocol.json
+++ b/data/pc/1.17/protocol.json
@@ -1424,7 +1424,6 @@
                                       {
                                         "compareTo": "parser",
                                         "fields": {
-                                          "brigadier:bool": "void",
                                           "brigadier:double": [
                                             "container",
                                             [
@@ -1587,9 +1586,64 @@
                                               }
                                             ]
                                           ],
+                                          "brigadier:long": [
+                                            "container",
+                                            [
+                                              {
+                                                "name": "flags",
+                                                "type": [
+                                                  "bitfield",
+                                                  [
+                                                    {
+                                                      "name": "unused",
+                                                      "size": 6,
+                                                      "signed": false
+                                                    },
+                                                    {
+                                                      "name": "max_present",
+                                                      "size": 1,
+                                                      "signed": false
+                                                    },
+                                                    {
+                                                      "name": "min_present",
+                                                      "size": 1,
+                                                      "signed": false
+                                                    }
+                                                  ]
+                                                ]
+                                              },
+                                              {
+                                                "name": "min",
+                                                "type": [
+                                                  "switch",
+                                                  {
+                                                    "compareTo": "flags/min_present",
+                                                    "fields": {
+                                                      "1": "i64"
+                                                    },
+                                                    "default": "void"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "name": "max",
+                                                "type": [
+                                                  "switch",
+                                                  {
+                                                    "compareTo": "flags/max_present",
+                                                    "fields": {
+                                                      "1": "i64"
+                                                    },
+                                                    "default": "void"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ],
                                           "brigadier:string": "varint",
                                           "minecraft:entity": "i8",
-                                          "minecraft:score_holder": "i8"
+                                          "minecraft:score_holder": "i8",
+                                          "minecraft:range": "bool"
                                         },
                                         "default": "void"
                                       }

--- a/data/pc/17w50a/protocol.json
+++ b/data/pc/17w50a/protocol.json
@@ -1240,7 +1240,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1340,9 +1339,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/20w13b/protocol.json
+++ b/data/pc/20w13b/protocol.json
@@ -1392,7 +1392,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1492,9 +1491,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]

--- a/data/pc/21w07a/protocol.json
+++ b/data/pc/21w07a/protocol.json
@@ -1368,7 +1368,6 @@
                               "type": ["switch",{
                                 "compareTo": "parser",
                                 "fields": {
-                                  "brigadier:bool": "void",
                                   "brigadier:double": ["container", [
                                     {
                                       "name": "flags",
@@ -1468,9 +1467,43 @@
                                       }]
                                     }
                                   ]],
+                                  "brigadier:long": ["container", [
+                                    {
+                                      "name": "flags",
+                                      "type": [
+                                        "bitfield",
+                                        [
+                                          { "name": "unused", "size": 6, "signed": false },
+                                          { "name": "max_present", "size": 1, "signed": false },
+                                          { "name": "min_present", "size": 1, "signed": false }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "name": "min",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/min_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    },
+                                    {
+                                      "name": "max",
+                                      "type": ["switch",{
+                                        "compareTo": "flags/max_present",
+                                        "fields": {
+                                          "1": "i64"
+                                        },
+                                        "default": "void"
+                                      }]
+                                    }
+                                  ]],
                                   "brigadier:string": "varint",
                                   "minecraft:entity": "i8",
-                                  "minecraft:score_holder": "i8"
+                                  "minecraft:score_holder": "i8",
+                                  "minecraft:range": "bool"
                                 },
                                 "default": "void"
                               }]


### PR DESCRIPTION
This was a bug that Archengius turned up that applies back to every Minecraft version that supports brigadier, since these types have been around since 1.13 even if vanilla minecraft commands didn't send them.

This also removes "brigadier:bool" from the parser list, since `void` is already the default