### PR TITLE
Correct materials for Podzol & Coarse Dirt

### DIFF
--- a/data/pc/1.13.2/blocks.json
+++ b/data/pc/1.13.2/blocks.json
@@ -280,7 +280,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 11,
     "resistance": 0.5
   },
@@ -307,7 +307,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 13,
     "resistance": 0.5
   },

--- a/data/pc/1.13/blocks.json
+++ b/data/pc/1.13/blocks.json
@@ -270,7 +270,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 11
   },
   {
@@ -296,7 +296,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 13
   },
   {

--- a/data/pc/1.14.4/blocks.json
+++ b/data/pc/1.14.4/blocks.json
@@ -280,7 +280,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 11,
     "resistance": 0.5
   },
@@ -308,7 +308,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 13,
     "resistance": 0.5
   },

--- a/data/pc/1.15.2/blocks.json
+++ b/data/pc/1.15.2/blocks.json
@@ -280,7 +280,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 11,
     "resistance": 0.5
   },
@@ -308,7 +308,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 13,
     "resistance": 0.5
   },

--- a/data/pc/1.16.1/blocks.json
+++ b/data/pc/1.16.1/blocks.json
@@ -287,7 +287,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 11,
     "resistance": 0.5
   },
@@ -315,7 +315,7 @@
     "emitLight": 0,
     "boundingBox": "block",
     "stackSize": 64,
-    "material": "plant",
+    "material": "dirt",
     "defaultState": 13,
     "resistance": 0.5
   },


### PR DESCRIPTION
It seems that some of the materials for podzol and coarse_dirt were wrong. They should be `dirt` instead of `plant`. https://minecraft.fandom.com/wiki/Breaking#Best_tools

Closes https://github.com/PrismarineJS/node-minecraft-data/issues/92