### PR TITLE
Do not rename bitMap in 1.17 to be backward compatible

### DIFF
--- a/data/pc/1.17.1/protocol.json
+++ b/data/pc/1.17.1/protocol.json
@@ -2163,7 +2163,7 @@
               "type": "i32"
             },
             {
-              "name": "primaryBitMask",
+              "name": "bitMap",
               "type": [
                 "array",
                 {

--- a/data/pc/1.17/protocol.json
+++ b/data/pc/1.17/protocol.json
@@ -2151,7 +2151,7 @@
               "type": "i32"
             },
             {
-              "name": "primaryBitMask",
+              "name": "bitMap",
               "type": [
                 "array",
                 {


### PR DESCRIPTION
Fix compatibility issues in chunk-dumper and mineflayer