### PR TITLE
Relocate smelting_format and tags to types map

### DIFF
--- a/data/pc/1.14.1/protocol.json
+++ b/data/pc/1.14.1/protocol.json
@@ -269,7 +269,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3797,44 +3835,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.14.3/protocol.json
+++ b/data/pc/1.14.3/protocol.json
@@ -269,7 +269,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3801,44 +3839,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.14.4/protocol.json
+++ b/data/pc/1.14.4/protocol.json
@@ -269,7 +269,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3805,44 +3843,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.14/protocol.json
+++ b/data/pc/1.14/protocol.json
@@ -269,7 +269,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3797,44 +3835,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.15.1/protocol.json
+++ b/data/pc/1.15.1/protocol.json
@@ -269,7 +269,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3825,44 +3863,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.15.2/protocol.json
+++ b/data/pc/1.15.2/protocol.json
@@ -269,7 +269,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3825,44 +3863,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.15/protocol.json
+++ b/data/pc/1.15/protocol.json
@@ -269,7 +269,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3825,44 +3863,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.16-rc1/protocol.json
+++ b/data/pc/1.16-rc1/protocol.json
@@ -270,7 +270,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3873,44 +3911,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.16.1/protocol.json
+++ b/data/pc/1.16.1/protocol.json
@@ -270,7 +270,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3873,44 +3911,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.16.2/protocol.json
+++ b/data/pc/1.16.2/protocol.json
@@ -270,7 +270,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3891,44 +3929,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.16/protocol.json
+++ b/data/pc/1.16/protocol.json
@@ -270,7 +270,45 @@
           ]
         ]
       }
-    ]
+    ],
+    "minecraft_smelting_format": ["container",[
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ingredient",
+        "type": "ingredient"
+      },
+      {
+        "name": "result",
+        "type": "slot"
+      },
+      {
+        "name": "experience",
+        "type": "f32"
+      },
+      {
+        "name": "cookTime",
+        "type": "varint"
+      }
+    ]],
+    "tags":["array",{
+      "countType": "varint",
+      "type": ["container", [
+        {
+          "name": "tagName",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": ["array",{
+            "countType": "varint",
+            "type": "varint"
+          }]
+        }
+      ]]
+    }]
   },
   "handshaking": {
     "toClient": {
@@ -3873,44 +3911,6 @@
             }
           ]
         ],
-        "minecraft_smelting_format": ["container",[
-          {
-            "name": "group",
-            "type": "string"
-          },
-          {
-            "name": "ingredient",
-            "type": "ingredient"
-          },
-          {
-            "name": "result",
-            "type": "slot"
-          },
-          {
-            "name": "experience",
-            "type": "f32"
-          },
-          {
-            "name": "cookTime",
-            "type": "varint"
-          }
-        ]],
-        "tags":["array",{
-          "countType": "varint",
-          "type": ["container", [
-            {
-              "name": "tagName",
-              "type": "string"
-            },
-            {
-              "name": "entries",
-              "type": ["array",{
-                "countType": "varint",
-                "type": "varint"
-              }]
-            }
-          ]]
-        }],
         "packet_tags": [
           "container",
           [

--- a/data/pc/1.17.1/protocol.json
+++ b/data/pc/1.17.1/protocol.json
@@ -340,6 +340,56 @@
           ]
         ]
       }
+    ],
+    "minecraft_smelting_format": [
+      "container",
+      [
+        {
+          "name": "group",
+          "type": "string"
+        },
+        {
+          "name": "ingredient",
+          "type": "ingredient"
+        },
+        {
+          "name": "result",
+          "type": "slot"
+        },
+        {
+          "name": "experience",
+          "type": "f32"
+        },
+        {
+          "name": "cookTime",
+          "type": "varint"
+        }
+      ]
+    ],
+    "tags": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "tagName",
+              "type": "string"
+            },
+            {
+              "name": "entries",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": "varint"
+                }
+              ]
+            }
+          ]
+        ]
+      }
     ]
   },
   "handshaking": {
@@ -3988,56 +4038,6 @@
               ]
             }
           ]
-        ],
-        "minecraft_smelting_format": [
-          "container",
-          [
-            {
-              "name": "group",
-              "type": "string"
-            },
-            {
-              "name": "ingredient",
-              "type": "ingredient"
-            },
-            {
-              "name": "result",
-              "type": "slot"
-            },
-            {
-              "name": "experience",
-              "type": "f32"
-            },
-            {
-              "name": "cookTime",
-              "type": "varint"
-            }
-          ]
-        ],
-        "tags": [
-          "array",
-          {
-            "countType": "varint",
-            "type": [
-              "container",
-              [
-                {
-                  "name": "tagName",
-                  "type": "string"
-                },
-                {
-                  "name": "entries",
-                  "type": [
-                    "array",
-                    {
-                      "countType": "varint",
-                      "type": "varint"
-                    }
-                  ]
-                }
-              ]
-            ]
-          }
         ],
         "packet_tags": [
           "container",

--- a/data/pc/1.17/protocol.json
+++ b/data/pc/1.17/protocol.json
@@ -340,6 +340,56 @@
           ]
         ]
       }
+    ],
+    "minecraft_smelting_format": [
+      "container",
+      [
+        {
+          "name": "group",
+          "type": "string"
+        },
+        {
+          "name": "ingredient",
+          "type": "ingredient"
+        },
+        {
+          "name": "result",
+          "type": "slot"
+        },
+        {
+          "name": "experience",
+          "type": "f32"
+        },
+        {
+          "name": "cookTime",
+          "type": "varint"
+        }
+      ]
+    ],
+    "tags": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "tagName",
+              "type": "string"
+            },
+            {
+              "name": "entries",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": "varint"
+                }
+              ]
+            }
+          ]
+        ]
+      }
     ]
   },
   "handshaking": {
@@ -3970,56 +4020,6 @@
               ]
             }
           ]
-        ],
-        "minecraft_smelting_format": [
-          "container",
-          [
-            {
-              "name": "group",
-              "type": "string"
-            },
-            {
-              "name": "ingredient",
-              "type": "ingredient"
-            },
-            {
-              "name": "result",
-              "type": "slot"
-            },
-            {
-              "name": "experience",
-              "type": "f32"
-            },
-            {
-              "name": "cookTime",
-              "type": "varint"
-            }
-          ]
-        ],
-        "tags": [
-          "array",
-          {
-            "countType": "varint",
-            "type": [
-              "container",
-              [
-                {
-                  "name": "tagName",
-                  "type": "string"
-                },
-                {
-                  "name": "entries",
-                  "type": [
-                    "array",
-                    {
-                      "countType": "varint",
-                      "type": "varint"
-                    }
-                  ]
-                }
-              ]
-            ]
-          }
         ],
         "packet_tags": [
           "container",


### PR DESCRIPTION
Having these types inlined in the protocol:

1. Is frustrating for consumers of protocol.json who expect all custom types in the type map
2. [Breaks the automatically generated docs](https://minecraft-data.prismarine.js.org/?v=1.17.1&d=protocol#toClient_undefined)

So let's move them so that they can play with all the other types, they'll be happier there anyway