### PR TITLE
Re-extract all items.json

### DIFF
--- a/data/pc/1.10/items.json
+++ b/data/pc/1.10/items.json
@@ -1192,7 +1192,6 @@
     "displayName": "Iron Shovel",
     "stackSize": 1,
     "name": "iron_shovel",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1208,7 +1207,6 @@
     "displayName": "Iron Pickaxe",
     "stackSize": 1,
     "name": "iron_pickaxe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1224,7 +1222,6 @@
     "displayName": "Iron Axe",
     "stackSize": 1,
     "name": "iron_axe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1240,7 +1237,6 @@
     "displayName": "Flint and Steel",
     "stackSize": 1,
     "name": "flint_and_steel",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -1258,7 +1254,6 @@
     "displayName": "Bow",
     "stackSize": 1,
     "name": "bow",
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -1311,7 +1306,6 @@
     "displayName": "Iron Sword",
     "stackSize": 1,
     "name": "iron_sword",
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1327,7 +1321,6 @@
     "displayName": "Wooden Sword",
     "stackSize": 1,
     "name": "wooden_sword",
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1350,7 +1343,6 @@
     "displayName": "Wooden Shovel",
     "stackSize": 1,
     "name": "wooden_shovel",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1373,7 +1365,6 @@
     "displayName": "Wooden Pickaxe",
     "stackSize": 1,
     "name": "wooden_pickaxe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1396,7 +1387,6 @@
     "displayName": "Wooden Axe",
     "stackSize": 1,
     "name": "wooden_axe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1419,7 +1409,6 @@
     "displayName": "Stone Sword",
     "stackSize": 1,
     "name": "stone_sword",
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1436,7 +1425,6 @@
     "displayName": "Stone Shovel",
     "stackSize": 1,
     "name": "stone_shovel",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1453,7 +1441,6 @@
     "displayName": "Stone Pickaxe",
     "stackSize": 1,
     "name": "stone_pickaxe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1470,7 +1457,6 @@
     "displayName": "Stone Axe",
     "stackSize": 1,
     "name": "stone_axe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1487,7 +1473,6 @@
     "displayName": "Diamond Sword",
     "stackSize": 1,
     "name": "diamond_sword",
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1503,7 +1488,6 @@
     "displayName": "Diamond Shovel",
     "stackSize": 1,
     "name": "diamond_shovel",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1519,7 +1503,6 @@
     "displayName": "Diamond Pickaxe",
     "stackSize": 1,
     "name": "diamond_pickaxe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1535,7 +1518,6 @@
     "displayName": "Diamond Axe",
     "stackSize": 1,
     "name": "diamond_axe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1569,7 +1551,6 @@
     "displayName": "Golden Sword",
     "stackSize": 1,
     "name": "golden_sword",
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1585,7 +1566,6 @@
     "displayName": "Golden Shovel",
     "stackSize": 1,
     "name": "golden_shovel",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1601,7 +1581,6 @@
     "displayName": "Golden Pickaxe",
     "stackSize": 1,
     "name": "golden_pickaxe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1617,7 +1596,6 @@
     "displayName": "Golden Axe",
     "stackSize": 1,
     "name": "golden_axe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1651,7 +1629,6 @@
     "displayName": "Wooden Hoe",
     "stackSize": 1,
     "name": "wooden_hoe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1674,7 +1651,6 @@
     "displayName": "Stone Hoe",
     "stackSize": 1,
     "name": "stone_hoe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1691,7 +1667,6 @@
     "displayName": "Iron Hoe",
     "stackSize": 1,
     "name": "iron_hoe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1707,7 +1682,6 @@
     "displayName": "Diamond Hoe",
     "stackSize": 1,
     "name": "diamond_hoe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1723,7 +1697,6 @@
     "displayName": "Golden Hoe",
     "stackSize": 1,
     "name": "golden_hoe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1757,10 +1730,8 @@
     "displayName": "Leather Cap",
     "stackSize": 1,
     "name": "leather_helmet",
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1776,7 +1747,6 @@
     "displayName": "Leather Tunic",
     "stackSize": 1,
     "name": "leather_chestplate",
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1794,10 +1764,8 @@
     "displayName": "Leather Pants",
     "stackSize": 1,
     "name": "leather_leggings",
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1812,11 +1780,9 @@
     "displayName": "Leather Boots",
     "stackSize": 1,
     "name": "leather_boots",
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1831,10 +1797,8 @@
     "displayName": "Chain Helmet",
     "stackSize": 1,
     "name": "chainmail_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1850,7 +1814,6 @@
     "displayName": "Chain Chestplate",
     "stackSize": 1,
     "name": "chainmail_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1868,10 +1831,8 @@
     "displayName": "Chain Leggings",
     "stackSize": 1,
     "name": "chainmail_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1886,11 +1847,9 @@
     "displayName": "Chain Boots",
     "stackSize": 1,
     "name": "chainmail_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1905,10 +1864,8 @@
     "displayName": "Iron Helmet",
     "stackSize": 1,
     "name": "iron_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1924,7 +1881,6 @@
     "displayName": "Iron Chestplate",
     "stackSize": 1,
     "name": "iron_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1942,10 +1898,8 @@
     "displayName": "Iron Leggings",
     "stackSize": 1,
     "name": "iron_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1960,11 +1914,9 @@
     "displayName": "Iron Boots",
     "stackSize": 1,
     "name": "iron_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1979,10 +1931,8 @@
     "displayName": "Diamond Helmet",
     "stackSize": 1,
     "name": "diamond_helmet",
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1998,7 +1948,6 @@
     "displayName": "Diamond Chestplate",
     "stackSize": 1,
     "name": "diamond_chestplate",
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2016,10 +1965,8 @@
     "displayName": "Diamond Leggings",
     "stackSize": 1,
     "name": "diamond_leggings",
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2034,11 +1981,9 @@
     "displayName": "Diamond Boots",
     "stackSize": 1,
     "name": "diamond_boots",
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2053,10 +1998,8 @@
     "displayName": "Golden Helmet",
     "stackSize": 1,
     "name": "golden_helmet",
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2072,7 +2015,6 @@
     "displayName": "Golden Chestplate",
     "stackSize": 1,
     "name": "golden_chestplate",
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2090,10 +2032,8 @@
     "displayName": "Golden Leggings",
     "stackSize": 1,
     "name": "golden_leggings",
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2108,11 +2048,9 @@
     "displayName": "Golden Boots",
     "stackSize": 1,
     "name": "golden_boots",
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2305,7 +2243,6 @@
     "displayName": "Fishing Rod",
     "stackSize": 1,
     "name": "fishing_rod",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -2474,7 +2411,6 @@
     "displayName": "Shears",
     "stackSize": 1,
     "name": "shears",
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -2794,7 +2730,6 @@
     "displayName": "Carrot on a Stick",
     "stackSize": 1,
     "name": "carrot_on_a_stick",
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3064,7 +2999,6 @@
     "displayName": "Shield",
     "stackSize": 1,
     "name": "shield",
-    "durability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3086,7 +3020,6 @@
     "displayName": "Elytra",
     "stackSize": 1,
     "name": "elytra",
-    "durability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",

--- a/data/pc/1.11/items.json
+++ b/data/pc/1.11/items.json
@@ -1324,7 +1324,6 @@
     "displayName": "Iron Shovel",
     "stackSize": 1,
     "name": "iron_shovel",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1340,7 +1339,6 @@
     "displayName": "Iron Pickaxe",
     "stackSize": 1,
     "name": "iron_pickaxe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1356,7 +1354,6 @@
     "displayName": "Iron Axe",
     "stackSize": 1,
     "name": "iron_axe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1372,7 +1369,6 @@
     "displayName": "Flint and Steel",
     "stackSize": 1,
     "name": "flint_and_steel",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -1390,7 +1386,6 @@
     "displayName": "Bow",
     "stackSize": 1,
     "name": "bow",
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -1443,7 +1438,6 @@
     "displayName": "Iron Sword",
     "stackSize": 1,
     "name": "iron_sword",
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1459,7 +1453,6 @@
     "displayName": "Wooden Sword",
     "stackSize": 1,
     "name": "wooden_sword",
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1482,7 +1475,6 @@
     "displayName": "Wooden Shovel",
     "stackSize": 1,
     "name": "wooden_shovel",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1505,7 +1497,6 @@
     "displayName": "Wooden Pickaxe",
     "stackSize": 1,
     "name": "wooden_pickaxe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1528,7 +1519,6 @@
     "displayName": "Wooden Axe",
     "stackSize": 1,
     "name": "wooden_axe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1551,7 +1541,6 @@
     "displayName": "Stone Sword",
     "stackSize": 1,
     "name": "stone_sword",
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1568,7 +1557,6 @@
     "displayName": "Stone Shovel",
     "stackSize": 1,
     "name": "stone_shovel",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1585,7 +1573,6 @@
     "displayName": "Stone Pickaxe",
     "stackSize": 1,
     "name": "stone_pickaxe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1602,7 +1589,6 @@
     "displayName": "Stone Axe",
     "stackSize": 1,
     "name": "stone_axe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1619,7 +1605,6 @@
     "displayName": "Diamond Sword",
     "stackSize": 1,
     "name": "diamond_sword",
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1635,7 +1620,6 @@
     "displayName": "Diamond Shovel",
     "stackSize": 1,
     "name": "diamond_shovel",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1651,7 +1635,6 @@
     "displayName": "Diamond Pickaxe",
     "stackSize": 1,
     "name": "diamond_pickaxe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1667,7 +1650,6 @@
     "displayName": "Diamond Axe",
     "stackSize": 1,
     "name": "diamond_axe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1701,7 +1683,6 @@
     "displayName": "Golden Sword",
     "stackSize": 1,
     "name": "golden_sword",
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1717,7 +1698,6 @@
     "displayName": "Golden Shovel",
     "stackSize": 1,
     "name": "golden_shovel",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1733,7 +1713,6 @@
     "displayName": "Golden Pickaxe",
     "stackSize": 1,
     "name": "golden_pickaxe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1749,7 +1728,6 @@
     "displayName": "Golden Axe",
     "stackSize": 1,
     "name": "golden_axe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1783,7 +1761,6 @@
     "displayName": "Wooden Hoe",
     "stackSize": 1,
     "name": "wooden_hoe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1806,7 +1783,6 @@
     "displayName": "Stone Hoe",
     "stackSize": 1,
     "name": "stone_hoe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1823,7 +1799,6 @@
     "displayName": "Iron Hoe",
     "stackSize": 1,
     "name": "iron_hoe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1839,7 +1814,6 @@
     "displayName": "Diamond Hoe",
     "stackSize": 1,
     "name": "diamond_hoe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1855,7 +1829,6 @@
     "displayName": "Golden Hoe",
     "stackSize": 1,
     "name": "golden_hoe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1889,10 +1862,8 @@
     "displayName": "Leather Cap",
     "stackSize": 1,
     "name": "leather_helmet",
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1908,7 +1879,6 @@
     "displayName": "Leather Tunic",
     "stackSize": 1,
     "name": "leather_chestplate",
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1926,10 +1896,8 @@
     "displayName": "Leather Pants",
     "stackSize": 1,
     "name": "leather_leggings",
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1944,11 +1912,9 @@
     "displayName": "Leather Boots",
     "stackSize": 1,
     "name": "leather_boots",
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1963,10 +1929,8 @@
     "displayName": "Chain Helmet",
     "stackSize": 1,
     "name": "chainmail_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1982,7 +1946,6 @@
     "displayName": "Chain Chestplate",
     "stackSize": 1,
     "name": "chainmail_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2000,10 +1963,8 @@
     "displayName": "Chain Leggings",
     "stackSize": 1,
     "name": "chainmail_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2018,11 +1979,9 @@
     "displayName": "Chain Boots",
     "stackSize": 1,
     "name": "chainmail_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2037,10 +1996,8 @@
     "displayName": "Iron Helmet",
     "stackSize": 1,
     "name": "iron_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2056,7 +2013,6 @@
     "displayName": "Iron Chestplate",
     "stackSize": 1,
     "name": "iron_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2074,10 +2030,8 @@
     "displayName": "Iron Leggings",
     "stackSize": 1,
     "name": "iron_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2092,11 +2046,9 @@
     "displayName": "Iron Boots",
     "stackSize": 1,
     "name": "iron_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2111,10 +2063,8 @@
     "displayName": "Diamond Helmet",
     "stackSize": 1,
     "name": "diamond_helmet",
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2130,7 +2080,6 @@
     "displayName": "Diamond Chestplate",
     "stackSize": 1,
     "name": "diamond_chestplate",
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2148,10 +2097,8 @@
     "displayName": "Diamond Leggings",
     "stackSize": 1,
     "name": "diamond_leggings",
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2166,11 +2113,9 @@
     "displayName": "Diamond Boots",
     "stackSize": 1,
     "name": "diamond_boots",
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2185,10 +2130,8 @@
     "displayName": "Golden Helmet",
     "stackSize": 1,
     "name": "golden_helmet",
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2204,7 +2147,6 @@
     "displayName": "Golden Chestplate",
     "stackSize": 1,
     "name": "golden_chestplate",
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2222,10 +2164,8 @@
     "displayName": "Golden Leggings",
     "stackSize": 1,
     "name": "golden_leggings",
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2240,11 +2180,9 @@
     "displayName": "Golden Boots",
     "stackSize": 1,
     "name": "golden_boots",
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2437,7 +2375,6 @@
     "displayName": "Fishing Rod",
     "stackSize": 1,
     "name": "fishing_rod",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -2624,7 +2561,6 @@
     "displayName": "Shears",
     "stackSize": 1,
     "name": "shears",
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -2886,7 +2822,6 @@
     "displayName": "Carrot on a Stick",
     "stackSize": 1,
     "name": "carrot_on_a_stick",
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3156,7 +3091,6 @@
     "displayName": "Shield",
     "stackSize": 1,
     "name": "shield",
-    "durability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3178,7 +3112,6 @@
     "displayName": "Elytra",
     "stackSize": 1,
     "name": "elytra",
-    "durability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",

--- a/data/pc/1.12/items.json
+++ b/data/pc/1.12/items.json
@@ -1432,7 +1432,6 @@
     "displayName": "Iron Shovel",
     "stackSize": 1,
     "name": "iron_shovel",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1448,7 +1447,6 @@
     "displayName": "Iron Pickaxe",
     "stackSize": 1,
     "name": "iron_pickaxe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1464,7 +1462,6 @@
     "displayName": "Iron Axe",
     "stackSize": 1,
     "name": "iron_axe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1480,7 +1477,6 @@
     "displayName": "Flint and Steel",
     "stackSize": 1,
     "name": "flint_and_steel",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -1498,7 +1494,6 @@
     "displayName": "Bow",
     "stackSize": 1,
     "name": "bow",
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -1551,7 +1546,6 @@
     "displayName": "Iron Sword",
     "stackSize": 1,
     "name": "iron_sword",
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1567,7 +1561,6 @@
     "displayName": "Wooden Sword",
     "stackSize": 1,
     "name": "wooden_sword",
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1590,7 +1583,6 @@
     "displayName": "Wooden Shovel",
     "stackSize": 1,
     "name": "wooden_shovel",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1613,7 +1605,6 @@
     "displayName": "Wooden Pickaxe",
     "stackSize": 1,
     "name": "wooden_pickaxe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1636,7 +1627,6 @@
     "displayName": "Wooden Axe",
     "stackSize": 1,
     "name": "wooden_axe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1659,7 +1649,6 @@
     "displayName": "Stone Sword",
     "stackSize": 1,
     "name": "stone_sword",
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1676,7 +1665,6 @@
     "displayName": "Stone Shovel",
     "stackSize": 1,
     "name": "stone_shovel",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1693,7 +1681,6 @@
     "displayName": "Stone Pickaxe",
     "stackSize": 1,
     "name": "stone_pickaxe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1710,7 +1697,6 @@
     "displayName": "Stone Axe",
     "stackSize": 1,
     "name": "stone_axe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1727,7 +1713,6 @@
     "displayName": "Diamond Sword",
     "stackSize": 1,
     "name": "diamond_sword",
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1743,7 +1728,6 @@
     "displayName": "Diamond Shovel",
     "stackSize": 1,
     "name": "diamond_shovel",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1759,7 +1743,6 @@
     "displayName": "Diamond Pickaxe",
     "stackSize": 1,
     "name": "diamond_pickaxe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1775,7 +1758,6 @@
     "displayName": "Diamond Axe",
     "stackSize": 1,
     "name": "diamond_axe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1809,7 +1791,6 @@
     "displayName": "Golden Sword",
     "stackSize": 1,
     "name": "golden_sword",
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1825,7 +1806,6 @@
     "displayName": "Golden Shovel",
     "stackSize": 1,
     "name": "golden_shovel",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1841,7 +1821,6 @@
     "displayName": "Golden Pickaxe",
     "stackSize": 1,
     "name": "golden_pickaxe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1857,7 +1836,6 @@
     "displayName": "Golden Axe",
     "stackSize": 1,
     "name": "golden_axe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1891,7 +1869,6 @@
     "displayName": "Wooden Hoe",
     "stackSize": 1,
     "name": "wooden_hoe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1914,7 +1891,6 @@
     "displayName": "Stone Hoe",
     "stackSize": 1,
     "name": "stone_hoe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1931,7 +1907,6 @@
     "displayName": "Iron Hoe",
     "stackSize": 1,
     "name": "iron_hoe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1947,7 +1922,6 @@
     "displayName": "Diamond Hoe",
     "stackSize": 1,
     "name": "diamond_hoe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1963,7 +1937,6 @@
     "displayName": "Golden Hoe",
     "stackSize": 1,
     "name": "golden_hoe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1997,10 +1970,8 @@
     "displayName": "Leather Cap",
     "stackSize": 1,
     "name": "leather_helmet",
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2016,7 +1987,6 @@
     "displayName": "Leather Tunic",
     "stackSize": 1,
     "name": "leather_chestplate",
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2034,10 +2004,8 @@
     "displayName": "Leather Pants",
     "stackSize": 1,
     "name": "leather_leggings",
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2052,11 +2020,9 @@
     "displayName": "Leather Boots",
     "stackSize": 1,
     "name": "leather_boots",
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2071,10 +2037,8 @@
     "displayName": "Chain Helmet",
     "stackSize": 1,
     "name": "chainmail_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2090,7 +2054,6 @@
     "displayName": "Chain Chestplate",
     "stackSize": 1,
     "name": "chainmail_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2108,10 +2071,8 @@
     "displayName": "Chain Leggings",
     "stackSize": 1,
     "name": "chainmail_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2126,11 +2087,9 @@
     "displayName": "Chain Boots",
     "stackSize": 1,
     "name": "chainmail_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2145,10 +2104,8 @@
     "displayName": "Iron Helmet",
     "stackSize": 1,
     "name": "iron_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2164,7 +2121,6 @@
     "displayName": "Iron Chestplate",
     "stackSize": 1,
     "name": "iron_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2182,10 +2138,8 @@
     "displayName": "Iron Leggings",
     "stackSize": 1,
     "name": "iron_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2200,11 +2154,9 @@
     "displayName": "Iron Boots",
     "stackSize": 1,
     "name": "iron_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2219,10 +2171,8 @@
     "displayName": "Diamond Helmet",
     "stackSize": 1,
     "name": "diamond_helmet",
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2238,7 +2188,6 @@
     "displayName": "Diamond Chestplate",
     "stackSize": 1,
     "name": "diamond_chestplate",
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2256,10 +2205,8 @@
     "displayName": "Diamond Leggings",
     "stackSize": 1,
     "name": "diamond_leggings",
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2274,11 +2221,9 @@
     "displayName": "Diamond Boots",
     "stackSize": 1,
     "name": "diamond_boots",
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2293,10 +2238,8 @@
     "displayName": "Golden Helmet",
     "stackSize": 1,
     "name": "golden_helmet",
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2312,7 +2255,6 @@
     "displayName": "Golden Chestplate",
     "stackSize": 1,
     "name": "golden_chestplate",
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2330,10 +2272,8 @@
     "displayName": "Golden Leggings",
     "stackSize": 1,
     "name": "golden_leggings",
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2348,11 +2288,9 @@
     "displayName": "Golden Boots",
     "stackSize": 1,
     "name": "golden_boots",
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2545,7 +2483,6 @@
     "displayName": "Fishing Rod",
     "stackSize": 1,
     "name": "fishing_rod",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -2748,7 +2685,6 @@
     "displayName": "Shears",
     "stackSize": 1,
     "name": "shears",
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3010,7 +2946,6 @@
     "displayName": "Carrot on a Stick",
     "stackSize": 1,
     "name": "carrot_on_a_stick",
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3280,7 +3215,6 @@
     "displayName": "Shield",
     "stackSize": 1,
     "name": "shield",
-    "durability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3302,7 +3236,6 @@
     "displayName": "Elytra",
     "stackSize": 1,
     "name": "elytra",
-    "durability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",

--- a/data/pc/1.13.2/items.json
+++ b/data/pc/1.13.2/items.json
@@ -2828,10 +2828,8 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
-    "durability": 275,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2853,7 +2851,6 @@
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 64,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2869,7 +2866,6 @@
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 64,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2885,7 +2881,6 @@
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 64,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2901,7 +2896,6 @@
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 64,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -2919,7 +2913,6 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 64,
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -2968,7 +2961,6 @@
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 64,
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -2984,7 +2976,6 @@
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 64,
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3007,7 +2998,6 @@
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 64,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3030,7 +3020,6 @@
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 64,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3053,7 +3042,6 @@
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 64,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3076,7 +3064,6 @@
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 64,
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3093,7 +3080,6 @@
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 64,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3110,7 +3096,6 @@
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 64,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3127,7 +3112,6 @@
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 64,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3144,7 +3128,6 @@
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 64,
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3160,7 +3143,6 @@
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 64,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3176,7 +3158,6 @@
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 64,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3192,7 +3173,6 @@
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 64,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3226,7 +3206,6 @@
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 64,
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3242,7 +3221,6 @@
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 64,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3258,7 +3236,6 @@
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 64,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3274,7 +3251,6 @@
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 64,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3308,7 +3284,6 @@
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 64,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3331,7 +3306,6 @@
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 64,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3348,7 +3322,6 @@
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 64,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3364,7 +3337,6 @@
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 64,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3380,7 +3352,6 @@
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 64,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3414,10 +3385,8 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3433,7 +3402,6 @@
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3451,10 +3419,8 @@
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3469,11 +3435,9 @@
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3488,10 +3452,8 @@
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3507,7 +3469,6 @@
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3525,10 +3486,8 @@
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3543,11 +3502,9 @@
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3562,10 +3519,8 @@
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3581,7 +3536,6 @@
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3599,10 +3553,8 @@
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3617,11 +3569,9 @@
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3636,10 +3586,8 @@
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3655,7 +3603,6 @@
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3673,10 +3620,8 @@
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3691,11 +3636,9 @@
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3710,10 +3653,8 @@
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3729,7 +3670,6 @@
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3747,10 +3687,8 @@
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3765,11 +3703,9 @@
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3982,7 +3918,6 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 64,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -4265,7 +4200,6 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 64,
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -4857,7 +4791,6 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 64,
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5181,7 +5114,6 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 64,
-    "durability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5203,7 +5135,6 @@
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 64,
-    "durability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -5351,7 +5282,6 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",

--- a/data/pc/1.13/items.json
+++ b/data/pc/1.13/items.json
@@ -2798,10 +2798,8 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
-    "durability": 275,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2823,7 +2821,6 @@
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2839,7 +2836,6 @@
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2855,7 +2851,6 @@
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2871,7 +2866,6 @@
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -2889,7 +2883,6 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -2938,7 +2931,6 @@
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -2954,7 +2946,6 @@
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -2977,7 +2968,6 @@
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3000,7 +2990,6 @@
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3023,7 +3012,6 @@
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3046,7 +3034,6 @@
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3063,7 +3050,6 @@
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3080,7 +3066,6 @@
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3097,7 +3082,6 @@
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3114,7 +3098,6 @@
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3130,7 +3113,6 @@
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3146,7 +3128,6 @@
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3162,7 +3143,6 @@
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3196,7 +3176,6 @@
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3212,7 +3191,6 @@
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3228,7 +3206,6 @@
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3244,7 +3221,6 @@
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3278,7 +3254,6 @@
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3301,7 +3276,6 @@
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3318,7 +3292,6 @@
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3334,7 +3307,6 @@
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3350,7 +3322,6 @@
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3384,10 +3355,8 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3403,7 +3372,6 @@
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3421,10 +3389,8 @@
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3439,11 +3405,9 @@
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3458,10 +3422,8 @@
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3477,7 +3439,6 @@
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3495,10 +3456,8 @@
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3513,11 +3472,9 @@
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3532,10 +3489,8 @@
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3551,7 +3506,6 @@
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3569,10 +3523,8 @@
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3587,11 +3539,9 @@
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3606,10 +3556,8 @@
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3625,7 +3573,6 @@
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3643,10 +3590,8 @@
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3661,11 +3606,9 @@
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3680,10 +3623,8 @@
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3699,7 +3640,6 @@
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3717,10 +3657,8 @@
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3735,11 +3673,9 @@
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3952,7 +3888,6 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -4235,7 +4170,6 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -4827,7 +4761,6 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5151,7 +5084,6 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
-    "durability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5173,7 +5105,6 @@
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
-    "durability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -5321,7 +5252,6 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",

--- a/data/pc/1.14.4/items.json
+++ b/data/pc/1.14.4/items.json
@@ -3116,10 +3116,8 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
-    "durability": 275,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3141,7 +3139,6 @@
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3157,7 +3154,6 @@
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3173,7 +3169,6 @@
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3189,7 +3184,6 @@
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3207,7 +3201,6 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -3256,7 +3249,6 @@
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3272,7 +3264,6 @@
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3295,7 +3286,6 @@
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3318,7 +3308,6 @@
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3341,7 +3330,6 @@
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3364,7 +3352,6 @@
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3381,7 +3368,6 @@
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3398,7 +3384,6 @@
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3415,7 +3400,6 @@
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3432,7 +3416,6 @@
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3448,7 +3431,6 @@
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3464,7 +3446,6 @@
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3480,7 +3461,6 @@
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3514,7 +3494,6 @@
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3530,7 +3509,6 @@
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3546,7 +3524,6 @@
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3562,7 +3539,6 @@
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3596,7 +3572,6 @@
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3619,7 +3594,6 @@
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3636,7 +3610,6 @@
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3652,7 +3625,6 @@
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3668,7 +3640,6 @@
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3702,10 +3673,8 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3721,7 +3690,6 @@
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3739,10 +3707,8 @@
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3757,11 +3723,9 @@
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3776,10 +3740,8 @@
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3795,7 +3757,6 @@
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3813,10 +3774,8 @@
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3831,11 +3790,9 @@
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3850,10 +3807,8 @@
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3869,7 +3824,6 @@
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3887,10 +3841,8 @@
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3905,11 +3857,9 @@
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3924,10 +3874,8 @@
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3943,7 +3891,6 @@
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3961,10 +3908,8 @@
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3979,11 +3924,9 @@
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3998,10 +3941,8 @@
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4017,7 +3958,6 @@
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4035,10 +3975,8 @@
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4053,11 +3991,9 @@
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4306,7 +4242,6 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -4613,7 +4548,6 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5247,7 +5181,6 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5577,7 +5510,6 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
-    "durability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5599,7 +5531,6 @@
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
-    "durability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -5747,7 +5678,6 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
@@ -5778,7 +5708,6 @@
     "displayName": "Crossbow",
     "name": "crossbow",
     "stackSize": 1,
-    "durability": 326,
     "enchantCategories": [
       "breakable",
       "vanishable",

--- a/data/pc/1.14/items.json
+++ b/data/pc/1.14/items.json
@@ -3,1324 +3,1135 @@
     "id": 0,
     "displayName": "Air",
     "name": "air",
-    "stackSize": 0,
-    "durability": null
+    "stackSize": 0
   },
   {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 2,
     "displayName": "Granite",
     "name": "granite",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 3,
     "displayName": "Polished Granite",
     "name": "polished_granite",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 4,
     "displayName": "Diorite",
     "name": "diorite",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 5,
     "displayName": "Polished Diorite",
     "name": "polished_diorite",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 6,
     "displayName": "Andesite",
     "name": "andesite",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 7,
     "displayName": "Polished Andesite",
     "name": "polished_andesite",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 8,
     "displayName": "Grass Block",
     "name": "grass_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 9,
     "displayName": "Dirt",
     "name": "dirt",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 10,
     "displayName": "Coarse Dirt",
     "name": "coarse_dirt",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 11,
     "displayName": "Podzol",
     "name": "podzol",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 12,
     "displayName": "Cobblestone",
     "name": "cobblestone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 13,
     "displayName": "Oak Planks",
     "name": "oak_planks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 14,
     "displayName": "Spruce Planks",
     "name": "spruce_planks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 15,
     "displayName": "Birch Planks",
     "name": "birch_planks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 16,
     "displayName": "Jungle Planks",
     "name": "jungle_planks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 17,
     "displayName": "Acacia Planks",
     "name": "acacia_planks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 18,
     "displayName": "Dark Oak Planks",
     "name": "dark_oak_planks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 19,
     "displayName": "Oak Sapling",
     "name": "oak_sapling",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 20,
     "displayName": "Spruce Sapling",
     "name": "spruce_sapling",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 21,
     "displayName": "Birch Sapling",
     "name": "birch_sapling",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 22,
     "displayName": "Jungle Sapling",
     "name": "jungle_sapling",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 23,
     "displayName": "Acacia Sapling",
     "name": "acacia_sapling",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 24,
     "displayName": "Dark Oak Sapling",
     "name": "dark_oak_sapling",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 25,
     "displayName": "Bedrock",
     "name": "bedrock",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 26,
     "displayName": "Sand",
     "name": "sand",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 27,
     "displayName": "Red Sand",
     "name": "red_sand",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 28,
     "displayName": "Gravel",
     "name": "gravel",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 29,
     "displayName": "Gold Ore",
     "name": "gold_ore",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 30,
     "displayName": "Iron Ore",
     "name": "iron_ore",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 31,
     "displayName": "Coal Ore",
     "name": "coal_ore",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 32,
     "displayName": "Oak Log",
     "name": "oak_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 33,
     "displayName": "Spruce Log",
     "name": "spruce_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 34,
     "displayName": "Birch Log",
     "name": "birch_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 35,
     "displayName": "Jungle Log",
     "name": "jungle_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 36,
     "displayName": "Acacia Log",
     "name": "acacia_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 37,
     "displayName": "Dark Oak Log",
     "name": "dark_oak_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 38,
     "displayName": "Stripped Oak Log",
     "name": "stripped_oak_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 39,
     "displayName": "Stripped Spruce Log",
     "name": "stripped_spruce_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 40,
     "displayName": "Stripped Birch Log",
     "name": "stripped_birch_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 41,
     "displayName": "Stripped Jungle Log",
     "name": "stripped_jungle_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 42,
     "displayName": "Stripped Acacia Log",
     "name": "stripped_acacia_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 43,
     "displayName": "Stripped Dark Oak Log",
     "name": "stripped_dark_oak_log",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 44,
     "displayName": "Stripped Oak Wood",
     "name": "stripped_oak_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 45,
     "displayName": "Stripped Spruce Wood",
     "name": "stripped_spruce_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 46,
     "displayName": "Stripped Birch Wood",
     "name": "stripped_birch_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 47,
     "displayName": "Stripped Jungle Wood",
     "name": "stripped_jungle_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 48,
     "displayName": "Stripped Acacia Wood",
     "name": "stripped_acacia_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 49,
     "displayName": "Stripped Dark Oak Wood",
     "name": "stripped_dark_oak_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 50,
     "displayName": "Oak Wood",
     "name": "oak_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 51,
     "displayName": "Spruce Wood",
     "name": "spruce_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 52,
     "displayName": "Birch Wood",
     "name": "birch_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 53,
     "displayName": "Jungle Wood",
     "name": "jungle_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 54,
     "displayName": "Acacia Wood",
     "name": "acacia_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 55,
     "displayName": "Dark Oak Wood",
     "name": "dark_oak_wood",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 56,
     "displayName": "Oak Leaves",
     "name": "oak_leaves",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 57,
     "displayName": "Spruce Leaves",
     "name": "spruce_leaves",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 58,
     "displayName": "Birch Leaves",
     "name": "birch_leaves",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 59,
     "displayName": "Jungle Leaves",
     "name": "jungle_leaves",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 60,
     "displayName": "Acacia Leaves",
     "name": "acacia_leaves",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 61,
     "displayName": "Dark Oak Leaves",
     "name": "dark_oak_leaves",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 62,
     "displayName": "Sponge",
     "name": "sponge",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 63,
     "displayName": "Wet Sponge",
     "name": "wet_sponge",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 64,
     "displayName": "Glass",
     "name": "glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 65,
     "displayName": "Lapis Lazuli Ore",
     "name": "lapis_ore",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 66,
     "displayName": "Lapis Lazuli Block",
     "name": "lapis_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 67,
     "displayName": "Dispenser",
     "name": "dispenser",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 68,
     "displayName": "Sandstone",
     "name": "sandstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 69,
     "displayName": "Chiseled Sandstone",
     "name": "chiseled_sandstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 70,
     "displayName": "Cut Sandstone",
     "name": "cut_sandstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 71,
     "displayName": "Note Block",
     "name": "note_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 72,
     "displayName": "Powered Rail",
     "name": "powered_rail",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 73,
     "displayName": "Detector Rail",
     "name": "detector_rail",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 74,
     "displayName": "Sticky Piston",
     "name": "sticky_piston",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 75,
     "displayName": "Cobweb",
     "name": "cobweb",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 76,
     "displayName": "Grass",
     "name": "grass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 77,
     "displayName": "Fern",
     "name": "fern",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 78,
     "displayName": "Dead Bush",
     "name": "dead_bush",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 79,
     "displayName": "Seagrass",
     "name": "seagrass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 80,
     "displayName": "Sea Pickle",
     "name": "sea_pickle",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 81,
     "displayName": "Piston",
     "name": "piston",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 82,
     "displayName": "White Wool",
     "name": "white_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 83,
     "displayName": "Orange Wool",
     "name": "orange_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 84,
     "displayName": "Magenta Wool",
     "name": "magenta_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 85,
     "displayName": "Light Blue Wool",
     "name": "light_blue_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 86,
     "displayName": "Yellow Wool",
     "name": "yellow_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 87,
     "displayName": "Lime Wool",
     "name": "lime_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 88,
     "displayName": "Pink Wool",
     "name": "pink_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 89,
     "displayName": "Gray Wool",
     "name": "gray_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 90,
     "displayName": "Light Gray Wool",
     "name": "light_gray_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 91,
     "displayName": "Cyan Wool",
     "name": "cyan_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 92,
     "displayName": "Purple Wool",
     "name": "purple_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 93,
     "displayName": "Blue Wool",
     "name": "blue_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 94,
     "displayName": "Brown Wool",
     "name": "brown_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 95,
     "displayName": "Green Wool",
     "name": "green_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 96,
     "displayName": "Red Wool",
     "name": "red_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 97,
     "displayName": "Black Wool",
     "name": "black_wool",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 98,
     "displayName": "Dandelion",
     "name": "dandelion",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 99,
     "displayName": "Poppy",
     "name": "poppy",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 100,
     "displayName": "Blue Orchid",
     "name": "blue_orchid",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 101,
     "displayName": "Allium",
     "name": "allium",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 102,
     "displayName": "Azure Bluet",
     "name": "azure_bluet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 103,
     "displayName": "Red Tulip",
     "name": "red_tulip",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 104,
     "displayName": "Orange Tulip",
     "name": "orange_tulip",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 105,
     "displayName": "White Tulip",
     "name": "white_tulip",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 106,
     "displayName": "Pink Tulip",
     "name": "pink_tulip",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 107,
     "displayName": "Oxeye Daisy",
     "name": "oxeye_daisy",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 108,
     "displayName": "Cornflower",
     "name": "cornflower",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 109,
     "displayName": "Lily of the Valley",
     "name": "lily_of_the_valley",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 110,
     "displayName": "Wither Rose",
     "name": "wither_rose",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 111,
     "displayName": "Brown Mushroom",
     "name": "brown_mushroom",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 112,
     "displayName": "Red Mushroom",
     "name": "red_mushroom",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 113,
     "displayName": "Block of Gold",
     "name": "gold_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 114,
     "displayName": "Block of Iron",
     "name": "iron_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 115,
     "displayName": "Oak Slab",
     "name": "oak_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 116,
     "displayName": "Spruce Slab",
     "name": "spruce_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 117,
     "displayName": "Birch Slab",
     "name": "birch_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 118,
     "displayName": "Jungle Slab",
     "name": "jungle_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 119,
     "displayName": "Acacia Slab",
     "name": "acacia_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 120,
     "displayName": "Dark Oak Slab",
     "name": "dark_oak_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 121,
     "displayName": "Stone Slab",
     "name": "stone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 122,
     "displayName": "Smooth Stone Slab",
     "name": "smooth_stone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 123,
     "displayName": "Sandstone Slab",
     "name": "sandstone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 124,
     "displayName": "Cut Sandstone Slab",
     "name": "cut_sandstone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 125,
     "displayName": "Petrified Oak Slab",
     "name": "petrified_oak_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 126,
     "displayName": "Cobblestone Slab",
     "name": "cobblestone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 127,
     "displayName": "Brick Slab",
     "name": "brick_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 128,
     "displayName": "Stone Brick Slab",
     "name": "stone_brick_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 129,
     "displayName": "Nether Brick Slab",
     "name": "nether_brick_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 130,
     "displayName": "Quartz Slab",
     "name": "quartz_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 131,
     "displayName": "Red Sandstone Slab",
     "name": "red_sandstone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 132,
     "displayName": "Cut Red Sandstone Slab",
     "name": "cut_red_sandstone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 133,
     "displayName": "Purpur Slab",
     "name": "purpur_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 134,
     "displayName": "Prismarine Slab",
     "name": "prismarine_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 135,
     "displayName": "Prismarine Brick Slab",
     "name": "prismarine_brick_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 136,
     "displayName": "Dark Prismarine Slab",
     "name": "dark_prismarine_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 137,
     "displayName": "Smooth Quartz",
     "name": "smooth_quartz",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 138,
     "displayName": "Smooth Red Sandstone",
     "name": "smooth_red_sandstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 139,
     "displayName": "Smooth Sandstone",
     "name": "smooth_sandstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 140,
     "displayName": "Smooth Stone",
     "name": "smooth_stone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 141,
     "displayName": "Bricks",
     "name": "bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 142,
     "displayName": "TNT",
     "name": "tnt",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 143,
     "displayName": "Bookshelf",
     "name": "bookshelf",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 144,
     "displayName": "Mossy Cobblestone",
     "name": "mossy_cobblestone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 145,
     "displayName": "Obsidian",
     "name": "obsidian",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 146,
     "displayName": "Torch",
     "name": "torch",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 147,
     "displayName": "End Rod",
     "name": "end_rod",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 148,
     "displayName": "Chorus Plant",
     "name": "chorus_plant",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 149,
     "displayName": "Chorus Flower",
     "name": "chorus_flower",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 150,
     "displayName": "Purpur Block",
     "name": "purpur_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 151,
     "displayName": "Purpur Pillar",
     "name": "purpur_pillar",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 152,
     "displayName": "Purpur Stairs",
     "name": "purpur_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 153,
     "displayName": "Spawner",
     "name": "spawner",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 154,
     "displayName": "Oak Stairs",
     "name": "oak_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 155,
     "displayName": "Chest",
     "name": "chest",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 156,
     "displayName": "Diamond Ore",
     "name": "diamond_ore",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 157,
     "displayName": "Block of Diamond",
     "name": "diamond_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 158,
     "displayName": "Crafting Table",
     "name": "crafting_table",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 159,
     "displayName": "Farmland",
     "name": "farmland",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 160,
     "displayName": "Furnace",
     "name": "furnace",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 161,
     "displayName": "Ladder",
     "name": "ladder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 162,
     "displayName": "Rail",
     "name": "rail",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 163,
     "displayName": "Cobblestone Stairs",
     "name": "cobblestone_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 164,
     "displayName": "Lever",
     "name": "lever",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 165,
     "displayName": "Stone Pressure Plate",
     "name": "stone_pressure_plate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 166,
     "displayName": "Oak Pressure Plate",
     "name": "oak_pressure_plate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 167,
     "displayName": "Spruce Pressure Plate",
     "name": "spruce_pressure_plate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 168,
     "displayName": "Birch Pressure Plate",
     "name": "birch_pressure_plate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 169,
     "displayName": "Jungle Pressure Plate",
     "name": "jungle_pressure_plate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 170,
     "displayName": "Acacia Pressure Plate",
     "name": "acacia_pressure_plate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 171,
     "displayName": "Dark Oak Pressure Plate",
     "name": "dark_oak_pressure_plate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 172,
     "displayName": "Redstone Ore",
     "name": "redstone_ore",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 173,
     "displayName": "Redstone Torch",
     "name": "redstone_torch",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 174,
     "displayName": "Stone Button",
     "name": "stone_button",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 175,
     "displayName": "Snow",
     "name": "snow",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 176,
     "displayName": "Ice",
     "name": "ice",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 177,
     "displayName": "Snow Block",
     "name": "snow_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 178,
     "displayName": "Cactus",
     "name": "cactus",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 179,
     "displayName": "Clay",
     "name": "clay",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 180,
     "displayName": "Jukebox",
     "name": "jukebox",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 181,
     "displayName": "Oak Fence",
     "name": "oak_fence",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 182,
     "displayName": "Spruce Fence",
     "name": "spruce_fence",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 183,
     "displayName": "Birch Fence",
     "name": "birch_fence",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 184,
     "displayName": "Jungle Fence",
     "name": "jungle_fence",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 185,
     "displayName": "Acacia Fence",
     "name": "acacia_fence",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 186,
     "displayName": "Dark Oak Fence",
     "name": "dark_oak_fence",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 187,
     "displayName": "Pumpkin",
     "name": "pumpkin",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 188,
     "displayName": "Carved Pumpkin",
     "name": "carved_pumpkin",
     "stackSize": 64,
-    "durability": null,
     "enchantCategories": [
       "wearable",
       "vanishable"
@@ -1330,2314 +1141,1984 @@
     "id": 189,
     "displayName": "Netherrack",
     "name": "netherrack",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 190,
     "displayName": "Soul Sand",
     "name": "soul_sand",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 191,
     "displayName": "Glowstone",
     "name": "glowstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 192,
     "displayName": "Jack o'Lantern",
     "name": "jack_o_lantern",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 193,
     "displayName": "Oak Trapdoor",
     "name": "oak_trapdoor",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 194,
     "displayName": "Spruce Trapdoor",
     "name": "spruce_trapdoor",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 195,
     "displayName": "Birch Trapdoor",
     "name": "birch_trapdoor",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 196,
     "displayName": "Jungle Trapdoor",
     "name": "jungle_trapdoor",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 197,
     "displayName": "Acacia Trapdoor",
     "name": "acacia_trapdoor",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 198,
     "displayName": "Dark Oak Trapdoor",
     "name": "dark_oak_trapdoor",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 199,
     "displayName": "Infested Stone",
     "name": "infested_stone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 200,
     "displayName": "Infested Cobblestone",
     "name": "infested_cobblestone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 201,
     "displayName": "Infested Stone Bricks",
     "name": "infested_stone_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 202,
     "displayName": "Infested Mossy Stone Bricks",
     "name": "infested_mossy_stone_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 203,
     "displayName": "Infested Cracked Stone Bricks",
     "name": "infested_cracked_stone_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 204,
     "displayName": "Infested Chiseled Stone Bricks",
     "name": "infested_chiseled_stone_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 205,
     "displayName": "Stone Bricks",
     "name": "stone_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 206,
     "displayName": "Mossy Stone Bricks",
     "name": "mossy_stone_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 207,
     "displayName": "Cracked Stone Bricks",
     "name": "cracked_stone_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 208,
     "displayName": "Chiseled Stone Bricks",
     "name": "chiseled_stone_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 209,
     "displayName": "Brown Mushroom Block",
     "name": "brown_mushroom_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 210,
     "displayName": "Red Mushroom Block",
     "name": "red_mushroom_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 211,
     "displayName": "Mushroom Stem",
     "name": "mushroom_stem",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 212,
     "displayName": "Iron Bars",
     "name": "iron_bars",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 213,
     "displayName": "Glass Pane",
     "name": "glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 214,
     "displayName": "Melon",
     "name": "melon",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 215,
     "displayName": "Vines",
     "name": "vine",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 216,
     "displayName": "Oak Fence Gate",
     "name": "oak_fence_gate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 217,
     "displayName": "Spruce Fence Gate",
     "name": "spruce_fence_gate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 218,
     "displayName": "Birch Fence Gate",
     "name": "birch_fence_gate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 219,
     "displayName": "Jungle Fence Gate",
     "name": "jungle_fence_gate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 220,
     "displayName": "Acacia Fence Gate",
     "name": "acacia_fence_gate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 221,
     "displayName": "Dark Oak Fence Gate",
     "name": "dark_oak_fence_gate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 222,
     "displayName": "Brick Stairs",
     "name": "brick_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 223,
     "displayName": "Stone Brick Stairs",
     "name": "stone_brick_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 224,
     "displayName": "Mycelium",
     "name": "mycelium",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 225,
     "displayName": "Lily Pad",
     "name": "lily_pad",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 226,
     "displayName": "Nether Bricks",
     "name": "nether_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 227,
     "displayName": "Nether Brick Fence",
     "name": "nether_brick_fence",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 228,
     "displayName": "Nether Brick Stairs",
     "name": "nether_brick_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 229,
     "displayName": "Enchanting Table",
     "name": "enchanting_table",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 230,
     "displayName": "End Portal Frame",
     "name": "end_portal_frame",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 231,
     "displayName": "End Stone",
     "name": "end_stone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 232,
     "displayName": "End Stone Bricks",
     "name": "end_stone_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 233,
     "displayName": "Dragon Egg",
     "name": "dragon_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 234,
     "displayName": "Redstone Lamp",
     "name": "redstone_lamp",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 235,
     "displayName": "Sandstone Stairs",
     "name": "sandstone_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 236,
     "displayName": "Emerald Ore",
     "name": "emerald_ore",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 237,
     "displayName": "Ender Chest",
     "name": "ender_chest",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 238,
     "displayName": "Tripwire Hook",
     "name": "tripwire_hook",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 239,
     "displayName": "Block of Emerald",
     "name": "emerald_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 240,
     "displayName": "Spruce Stairs",
     "name": "spruce_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 241,
     "displayName": "Birch Stairs",
     "name": "birch_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 242,
     "displayName": "Jungle Stairs",
     "name": "jungle_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 243,
     "displayName": "Command Block",
     "name": "command_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 244,
     "displayName": "Beacon",
     "name": "beacon",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 245,
     "displayName": "Cobblestone Wall",
     "name": "cobblestone_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 246,
     "displayName": "Mossy Cobblestone Wall",
     "name": "mossy_cobblestone_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 247,
     "displayName": "Brick Wall",
     "name": "brick_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 248,
     "displayName": "Prismarine Wall",
     "name": "prismarine_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 249,
     "displayName": "Red Sandstone Wall",
     "name": "red_sandstone_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 250,
     "displayName": "Mossy Stone Brick Wall",
     "name": "mossy_stone_brick_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 251,
     "displayName": "Granite Wall",
     "name": "granite_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 252,
     "displayName": "Stone Brick Wall",
     "name": "stone_brick_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 253,
     "displayName": "Nether Brick Wall",
     "name": "nether_brick_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 254,
     "displayName": "Andesite Wall",
     "name": "andesite_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 255,
     "displayName": "Red Nether Brick Wall",
     "name": "red_nether_brick_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 256,
     "displayName": "Sandstone Wall",
     "name": "sandstone_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 257,
     "displayName": "End Stone Brick Wall",
     "name": "end_stone_brick_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 258,
     "displayName": "Diorite Wall",
     "name": "diorite_wall",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 259,
     "displayName": "Oak Button",
     "name": "oak_button",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 260,
     "displayName": "Spruce Button",
     "name": "spruce_button",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 261,
     "displayName": "Birch Button",
     "name": "birch_button",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 262,
     "displayName": "Jungle Button",
     "name": "jungle_button",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 263,
     "displayName": "Acacia Button",
     "name": "acacia_button",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 264,
     "displayName": "Dark Oak Button",
     "name": "dark_oak_button",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 265,
     "displayName": "Anvil",
     "name": "anvil",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 266,
     "displayName": "Chipped Anvil",
     "name": "chipped_anvil",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 267,
     "displayName": "Damaged Anvil",
     "name": "damaged_anvil",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 268,
     "displayName": "Trapped Chest",
     "name": "trapped_chest",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 269,
     "displayName": "Light Weighted Pressure Plate",
     "name": "light_weighted_pressure_plate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 270,
     "displayName": "Heavy Weighted Pressure Plate",
     "name": "heavy_weighted_pressure_plate",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 271,
     "displayName": "Daylight Detector",
     "name": "daylight_detector",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 272,
     "displayName": "Block of Redstone",
     "name": "redstone_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 273,
     "displayName": "Nether Quartz Ore",
     "name": "nether_quartz_ore",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 274,
     "displayName": "Hopper",
     "name": "hopper",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 275,
     "displayName": "Chiseled Quartz Block",
     "name": "chiseled_quartz_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 276,
     "displayName": "Block of Quartz",
     "name": "quartz_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 277,
     "displayName": "Quartz Pillar",
     "name": "quartz_pillar",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 278,
     "displayName": "Quartz Stairs",
     "name": "quartz_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 279,
     "displayName": "Activator Rail",
     "name": "activator_rail",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 280,
     "displayName": "Dropper",
     "name": "dropper",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 281,
     "displayName": "White Terracotta",
     "name": "white_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 282,
     "displayName": "Orange Terracotta",
     "name": "orange_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 283,
     "displayName": "Magenta Terracotta",
     "name": "magenta_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 284,
     "displayName": "Light Blue Terracotta",
     "name": "light_blue_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 285,
     "displayName": "Yellow Terracotta",
     "name": "yellow_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 286,
     "displayName": "Lime Terracotta",
     "name": "lime_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 287,
     "displayName": "Pink Terracotta",
     "name": "pink_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 288,
     "displayName": "Gray Terracotta",
     "name": "gray_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 289,
     "displayName": "Light Gray Terracotta",
     "name": "light_gray_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 290,
     "displayName": "Cyan Terracotta",
     "name": "cyan_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 291,
     "displayName": "Purple Terracotta",
     "name": "purple_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 292,
     "displayName": "Blue Terracotta",
     "name": "blue_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 293,
     "displayName": "Brown Terracotta",
     "name": "brown_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 294,
     "displayName": "Green Terracotta",
     "name": "green_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 295,
     "displayName": "Red Terracotta",
     "name": "red_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 296,
     "displayName": "Black Terracotta",
     "name": "black_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 297,
     "displayName": "Barrier",
     "name": "barrier",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 298,
     "displayName": "Iron Trapdoor",
     "name": "iron_trapdoor",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 299,
     "displayName": "Hay Bale",
     "name": "hay_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 300,
     "displayName": "White Carpet",
     "name": "white_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 301,
     "displayName": "Orange Carpet",
     "name": "orange_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 302,
     "displayName": "Magenta Carpet",
     "name": "magenta_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 303,
     "displayName": "Light Blue Carpet",
     "name": "light_blue_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 304,
     "displayName": "Yellow Carpet",
     "name": "yellow_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 305,
     "displayName": "Lime Carpet",
     "name": "lime_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 306,
     "displayName": "Pink Carpet",
     "name": "pink_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 307,
     "displayName": "Gray Carpet",
     "name": "gray_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 308,
     "displayName": "Light Gray Carpet",
     "name": "light_gray_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 309,
     "displayName": "Cyan Carpet",
     "name": "cyan_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 310,
     "displayName": "Purple Carpet",
     "name": "purple_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 311,
     "displayName": "Blue Carpet",
     "name": "blue_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 312,
     "displayName": "Brown Carpet",
     "name": "brown_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 313,
     "displayName": "Green Carpet",
     "name": "green_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 314,
     "displayName": "Red Carpet",
     "name": "red_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 315,
     "displayName": "Black Carpet",
     "name": "black_carpet",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 316,
     "displayName": "Terracotta",
     "name": "terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 317,
     "displayName": "Block of Coal",
     "name": "coal_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 318,
     "displayName": "Packed Ice",
     "name": "packed_ice",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 319,
     "displayName": "Acacia Stairs",
     "name": "acacia_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 320,
     "displayName": "Dark Oak Stairs",
     "name": "dark_oak_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 321,
     "displayName": "Slime Block",
     "name": "slime_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 322,
     "displayName": "Grass Path",
     "name": "grass_path",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 323,
     "displayName": "Sunflower",
     "name": "sunflower",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 324,
     "displayName": "Lilac",
     "name": "lilac",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 325,
     "displayName": "Rose Bush",
     "name": "rose_bush",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 326,
     "displayName": "Peony",
     "name": "peony",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 327,
     "displayName": "Tall Grass",
     "name": "tall_grass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 328,
     "displayName": "Large Fern",
     "name": "large_fern",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 329,
     "displayName": "White Stained Glass",
     "name": "white_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 330,
     "displayName": "Orange Stained Glass",
     "name": "orange_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 331,
     "displayName": "Magenta Stained Glass",
     "name": "magenta_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 332,
     "displayName": "Light Blue Stained Glass",
     "name": "light_blue_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 333,
     "displayName": "Yellow Stained Glass",
     "name": "yellow_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 334,
     "displayName": "Lime Stained Glass",
     "name": "lime_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 335,
     "displayName": "Pink Stained Glass",
     "name": "pink_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 336,
     "displayName": "Gray Stained Glass",
     "name": "gray_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 337,
     "displayName": "Light Gray Stained Glass",
     "name": "light_gray_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 338,
     "displayName": "Cyan Stained Glass",
     "name": "cyan_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 339,
     "displayName": "Purple Stained Glass",
     "name": "purple_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 340,
     "displayName": "Blue Stained Glass",
     "name": "blue_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 341,
     "displayName": "Brown Stained Glass",
     "name": "brown_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 342,
     "displayName": "Green Stained Glass",
     "name": "green_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 343,
     "displayName": "Red Stained Glass",
     "name": "red_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 344,
     "displayName": "Black Stained Glass",
     "name": "black_stained_glass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 345,
     "displayName": "White Stained Glass Pane",
     "name": "white_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 346,
     "displayName": "Orange Stained Glass Pane",
     "name": "orange_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 347,
     "displayName": "Magenta Stained Glass Pane",
     "name": "magenta_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 348,
     "displayName": "Light Blue Stained Glass Pane",
     "name": "light_blue_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 349,
     "displayName": "Yellow Stained Glass Pane",
     "name": "yellow_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 350,
     "displayName": "Lime Stained Glass Pane",
     "name": "lime_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 351,
     "displayName": "Pink Stained Glass Pane",
     "name": "pink_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 352,
     "displayName": "Gray Stained Glass Pane",
     "name": "gray_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 353,
     "displayName": "Light Gray Stained Glass Pane",
     "name": "light_gray_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 354,
     "displayName": "Cyan Stained Glass Pane",
     "name": "cyan_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 355,
     "displayName": "Purple Stained Glass Pane",
     "name": "purple_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 356,
     "displayName": "Blue Stained Glass Pane",
     "name": "blue_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 357,
     "displayName": "Brown Stained Glass Pane",
     "name": "brown_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 358,
     "displayName": "Green Stained Glass Pane",
     "name": "green_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 359,
     "displayName": "Red Stained Glass Pane",
     "name": "red_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 360,
     "displayName": "Black Stained Glass Pane",
     "name": "black_stained_glass_pane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 361,
     "displayName": "Prismarine",
     "name": "prismarine",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 362,
     "displayName": "Prismarine Bricks",
     "name": "prismarine_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 363,
     "displayName": "Dark Prismarine",
     "name": "dark_prismarine",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 364,
     "displayName": "Prismarine Stairs",
     "name": "prismarine_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 365,
     "displayName": "Prismarine Brick Stairs",
     "name": "prismarine_brick_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 366,
     "displayName": "Dark Prismarine Stairs",
     "name": "dark_prismarine_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 367,
     "displayName": "Sea Lantern",
     "name": "sea_lantern",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 368,
     "displayName": "Red Sandstone",
     "name": "red_sandstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 369,
     "displayName": "Chiseled Red Sandstone",
     "name": "chiseled_red_sandstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 370,
     "displayName": "Cut Red Sandstone",
     "name": "cut_red_sandstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 371,
     "displayName": "Red Sandstone Stairs",
     "name": "red_sandstone_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 372,
     "displayName": "Repeating Command Block",
     "name": "repeating_command_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 373,
     "displayName": "Chain Command Block",
     "name": "chain_command_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 374,
     "displayName": "Magma Block",
     "name": "magma_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 375,
     "displayName": "Nether Wart Block",
     "name": "nether_wart_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 376,
     "displayName": "Red Nether Bricks",
     "name": "red_nether_bricks",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 377,
     "displayName": "Bone Block",
     "name": "bone_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 378,
     "displayName": "Structure Void",
     "name": "structure_void",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 379,
     "displayName": "Observer",
     "name": "observer",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 380,
     "displayName": "Shulker Box",
     "name": "shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 381,
     "displayName": "White Shulker Box",
     "name": "white_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 382,
     "displayName": "Orange Shulker Box",
     "name": "orange_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 383,
     "displayName": "Magenta Shulker Box",
     "name": "magenta_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 384,
     "displayName": "Light Blue Shulker Box",
     "name": "light_blue_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 385,
     "displayName": "Yellow Shulker Box",
     "name": "yellow_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 386,
     "displayName": "Lime Shulker Box",
     "name": "lime_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 387,
     "displayName": "Pink Shulker Box",
     "name": "pink_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 388,
     "displayName": "Gray Shulker Box",
     "name": "gray_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 389,
     "displayName": "Light Gray Shulker Box",
     "name": "light_gray_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 390,
     "displayName": "Cyan Shulker Box",
     "name": "cyan_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 391,
     "displayName": "Purple Shulker Box",
     "name": "purple_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 392,
     "displayName": "Blue Shulker Box",
     "name": "blue_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 393,
     "displayName": "Brown Shulker Box",
     "name": "brown_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 394,
     "displayName": "Green Shulker Box",
     "name": "green_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 395,
     "displayName": "Red Shulker Box",
     "name": "red_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 396,
     "displayName": "Black Shulker Box",
     "name": "black_shulker_box",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 397,
     "displayName": "White Glazed Terracotta",
     "name": "white_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 398,
     "displayName": "Orange Glazed Terracotta",
     "name": "orange_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 399,
     "displayName": "Magenta Glazed Terracotta",
     "name": "magenta_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 400,
     "displayName": "Light Blue Glazed Terracotta",
     "name": "light_blue_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 401,
     "displayName": "Yellow Glazed Terracotta",
     "name": "yellow_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 402,
     "displayName": "Lime Glazed Terracotta",
     "name": "lime_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 403,
     "displayName": "Pink Glazed Terracotta",
     "name": "pink_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 404,
     "displayName": "Gray Glazed Terracotta",
     "name": "gray_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 405,
     "displayName": "Light Gray Glazed Terracotta",
     "name": "light_gray_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 406,
     "displayName": "Cyan Glazed Terracotta",
     "name": "cyan_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 407,
     "displayName": "Purple Glazed Terracotta",
     "name": "purple_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 408,
     "displayName": "Blue Glazed Terracotta",
     "name": "blue_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 409,
     "displayName": "Brown Glazed Terracotta",
     "name": "brown_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 410,
     "displayName": "Green Glazed Terracotta",
     "name": "green_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 411,
     "displayName": "Red Glazed Terracotta",
     "name": "red_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 412,
     "displayName": "Black Glazed Terracotta",
     "name": "black_glazed_terracotta",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 413,
     "displayName": "White Concrete",
     "name": "white_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 414,
     "displayName": "Orange Concrete",
     "name": "orange_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 415,
     "displayName": "Magenta Concrete",
     "name": "magenta_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 416,
     "displayName": "Light Blue Concrete",
     "name": "light_blue_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 417,
     "displayName": "Yellow Concrete",
     "name": "yellow_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 418,
     "displayName": "Lime Concrete",
     "name": "lime_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 419,
     "displayName": "Pink Concrete",
     "name": "pink_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 420,
     "displayName": "Gray Concrete",
     "name": "gray_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 421,
     "displayName": "Light Gray Concrete",
     "name": "light_gray_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 422,
     "displayName": "Cyan Concrete",
     "name": "cyan_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 423,
     "displayName": "Purple Concrete",
     "name": "purple_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 424,
     "displayName": "Blue Concrete",
     "name": "blue_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 425,
     "displayName": "Brown Concrete",
     "name": "brown_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 426,
     "displayName": "Green Concrete",
     "name": "green_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 427,
     "displayName": "Red Concrete",
     "name": "red_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 428,
     "displayName": "Black Concrete",
     "name": "black_concrete",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 429,
     "displayName": "White Concrete Powder",
     "name": "white_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 430,
     "displayName": "Orange Concrete Powder",
     "name": "orange_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 431,
     "displayName": "Magenta Concrete Powder",
     "name": "magenta_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 432,
     "displayName": "Light Blue Concrete Powder",
     "name": "light_blue_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 433,
     "displayName": "Yellow Concrete Powder",
     "name": "yellow_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 434,
     "displayName": "Lime Concrete Powder",
     "name": "lime_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 435,
     "displayName": "Pink Concrete Powder",
     "name": "pink_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 436,
     "displayName": "Gray Concrete Powder",
     "name": "gray_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 437,
     "displayName": "Light Gray Concrete Powder",
     "name": "light_gray_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 438,
     "displayName": "Cyan Concrete Powder",
     "name": "cyan_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 439,
     "displayName": "Purple Concrete Powder",
     "name": "purple_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 440,
     "displayName": "Blue Concrete Powder",
     "name": "blue_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 441,
     "displayName": "Brown Concrete Powder",
     "name": "brown_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 442,
     "displayName": "Green Concrete Powder",
     "name": "green_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 443,
     "displayName": "Red Concrete Powder",
     "name": "red_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 444,
     "displayName": "Black Concrete Powder",
     "name": "black_concrete_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 445,
     "displayName": "Turtle Egg",
     "name": "turtle_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 446,
     "displayName": "Dead Tube Coral Block",
     "name": "dead_tube_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 447,
     "displayName": "Dead Brain Coral Block",
     "name": "dead_brain_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 448,
     "displayName": "Dead Bubble Coral Block",
     "name": "dead_bubble_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 449,
     "displayName": "Dead Fire Coral Block",
     "name": "dead_fire_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 450,
     "displayName": "Dead Horn Coral Block",
     "name": "dead_horn_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 451,
     "displayName": "Tube Coral Block",
     "name": "tube_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 452,
     "displayName": "Brain Coral Block",
     "name": "brain_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 453,
     "displayName": "Bubble Coral Block",
     "name": "bubble_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 454,
     "displayName": "Fire Coral Block",
     "name": "fire_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 455,
     "displayName": "Horn Coral Block",
     "name": "horn_coral_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 456,
     "displayName": "Tube Coral",
     "name": "tube_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 457,
     "displayName": "Brain Coral",
     "name": "brain_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 458,
     "displayName": "Bubble Coral",
     "name": "bubble_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 459,
     "displayName": "Fire Coral",
     "name": "fire_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 460,
     "displayName": "Horn Coral",
     "name": "horn_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 461,
     "displayName": "Dead Brain Coral",
     "name": "dead_brain_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 462,
     "displayName": "Dead Bubble Coral",
     "name": "dead_bubble_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 463,
     "displayName": "Dead Fire Coral",
     "name": "dead_fire_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 464,
     "displayName": "Dead Horn Coral",
     "name": "dead_horn_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 465,
     "displayName": "Dead Tube Coral",
     "name": "dead_tube_coral",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 466,
     "displayName": "Tube Coral Fan",
     "name": "tube_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 467,
     "displayName": "Brain Coral Fan",
     "name": "brain_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 468,
     "displayName": "Bubble Coral Fan",
     "name": "bubble_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 469,
     "displayName": "Fire Coral Fan",
     "name": "fire_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 470,
     "displayName": "Horn Coral Fan",
     "name": "horn_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 471,
     "displayName": "Dead Tube Coral Fan",
     "name": "dead_tube_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 472,
     "displayName": "Dead Brain Coral Fan",
     "name": "dead_brain_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 473,
     "displayName": "Dead Bubble Coral Fan",
     "name": "dead_bubble_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 474,
     "displayName": "Dead Fire Coral Fan",
     "name": "dead_fire_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 475,
     "displayName": "Dead Horn Coral Fan",
     "name": "dead_horn_coral_fan",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 476,
     "displayName": "Blue Ice",
     "name": "blue_ice",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 477,
     "displayName": "Conduit",
     "name": "conduit",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 478,
     "displayName": "Polished Granite Stairs",
     "name": "polished_granite_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 479,
     "displayName": "Smooth Red Sandstone Stairs",
     "name": "smooth_red_sandstone_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 480,
     "displayName": "Mossy Stone Brick Stairs",
     "name": "mossy_stone_brick_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 481,
     "displayName": "Polished Diorite Stairs",
     "name": "polished_diorite_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 482,
     "displayName": "Mossy Cobblestone Stairs",
     "name": "mossy_cobblestone_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 483,
     "displayName": "End Stone Brick Stairs",
     "name": "end_stone_brick_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 484,
     "displayName": "Stone Stairs",
     "name": "stone_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 485,
     "displayName": "Smooth Sandstone Stairs",
     "name": "smooth_sandstone_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 486,
     "displayName": "Smooth Quartz Stairs",
     "name": "smooth_quartz_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 487,
     "displayName": "Granite Stairs",
     "name": "granite_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 488,
     "displayName": "Andesite Stairs",
     "name": "andesite_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 489,
     "displayName": "Red Nether Brick Stairs",
     "name": "red_nether_brick_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 490,
     "displayName": "Polished Andesite Stairs",
     "name": "polished_andesite_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 491,
     "displayName": "Diorite Stairs",
     "name": "diorite_stairs",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 492,
     "displayName": "Polished Granite Slab",
     "name": "polished_granite_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 493,
     "displayName": "Smooth Red Sandstone Slab",
     "name": "smooth_red_sandstone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 494,
     "displayName": "Mossy Stone Brick Slab",
     "name": "mossy_stone_brick_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 495,
     "displayName": "Polished Diorite Slab",
     "name": "polished_diorite_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 496,
     "displayName": "Mossy Cobblestone Slab",
     "name": "mossy_cobblestone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 497,
     "displayName": "End Stone Brick Slab",
     "name": "end_stone_brick_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 498,
     "displayName": "Smooth Sandstone Slab",
     "name": "smooth_sandstone_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 499,
     "displayName": "Smooth Quartz Slab",
     "name": "smooth_quartz_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 500,
     "displayName": "Granite Slab",
     "name": "granite_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 501,
     "displayName": "Andesite Slab",
     "name": "andesite_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 502,
     "displayName": "Red Nether Brick Slab",
     "name": "red_nether_brick_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 503,
     "displayName": "Polished Andesite Slab",
     "name": "polished_andesite_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 504,
     "displayName": "Diorite Slab",
     "name": "diorite_slab",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 505,
     "displayName": "Scaffolding",
     "name": "scaffolding",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 506,
     "displayName": "Iron Door",
     "name": "iron_door",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 507,
     "displayName": "Oak Door",
     "name": "oak_door",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 508,
     "displayName": "Spruce Door",
     "name": "spruce_door",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 509,
     "displayName": "Birch Door",
     "name": "birch_door",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 510,
     "displayName": "Jungle Door",
     "name": "jungle_door",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 511,
     "displayName": "Acacia Door",
     "name": "acacia_door",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 512,
     "displayName": "Dark Oak Door",
     "name": "dark_oak_door",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 513,
     "displayName": "Redstone Repeater",
     "name": "repeater",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 514,
     "displayName": "Redstone Comparator",
     "name": "comparator",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 515,
     "displayName": "Structure Block",
     "name": "structure_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 516,
     "displayName": "Jigsaw Block",
     "name": "jigsaw",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 517,
     "displayName": "Composter",
     "name": "composter",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 518,
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
-    "durability": 275,
+    "maxDurability": 275,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3645,22 +3126,20 @@
     ],
     "repairWith": [
       "scute"
-    ],
-    "maxDurability": 275
+    ]
   },
   {
     "id": 519,
     "displayName": "Scute",
     "name": "scute",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 520,
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3668,15 +3147,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 521,
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3684,15 +3162,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 522,
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3700,89 +3177,79 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 523,
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
-    "durability": 64,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 524,
     "displayName": "Apple",
     "name": "apple",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 525,
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
-    "durability": 384,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 526,
     "displayName": "Arrow",
     "name": "arrow",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 527,
     "displayName": "Coal",
     "name": "coal",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 528,
     "displayName": "Charcoal",
     "name": "charcoal",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 529,
     "displayName": "Diamond",
     "name": "diamond",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 530,
     "displayName": "Iron Ingot",
     "name": "iron_ingot",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 531,
     "displayName": "Gold Ingot",
     "name": "gold_ingot",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 532,
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3790,15 +3257,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 533,
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3813,15 +3279,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 534,
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3836,15 +3301,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 535,
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3859,15 +3323,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 536,
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3882,15 +3345,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 537,
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3899,15 +3361,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 538,
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3916,15 +3377,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 539,
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3933,15 +3393,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 540,
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3950,15 +3409,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 541,
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3966,15 +3424,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 542,
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3982,15 +3439,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 543,
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3998,15 +3454,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 544,
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4014,36 +3469,32 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 545,
     "displayName": "Stick",
     "name": "stick",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 546,
     "displayName": "Bowl",
     "name": "bowl",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 547,
     "displayName": "Mushroom Stew",
     "name": "mushroom_stew",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 548,
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -4051,15 +3502,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 549,
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4067,15 +3517,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 550,
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4083,15 +3532,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 551,
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4099,36 +3547,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 552,
     "displayName": "String",
     "name": "string",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 553,
     "displayName": "Feather",
     "name": "feather",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 554,
     "displayName": "Gunpowder",
     "name": "gunpowder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 555,
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4143,15 +3587,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 556,
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4160,15 +3603,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 557,
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4176,15 +3618,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 558,
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4192,15 +3633,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 559,
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4208,39 +3648,34 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 560,
     "displayName": "Wheat Seeds",
     "name": "wheat_seeds",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 561,
     "displayName": "Wheat",
     "name": "wheat",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 562,
     "displayName": "Bread",
     "name": "bread",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 563,
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
-    "durability": 55,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4248,15 +3683,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 564,
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
-    "durability": 80,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4266,55 +3700,49 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 565,
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
-    "durability": 75,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 566,
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
-    "durability": 65,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 567,
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
-    "durability": 165,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4322,15 +3750,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 568,
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
-    "durability": 240,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4340,55 +3767,49 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 569,
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
-    "durability": 225,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 570,
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
-    "durability": 195,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 571,
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
-    "durability": 165,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4396,15 +3817,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 572,
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
-    "durability": 240,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4414,55 +3834,49 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 573,
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
-    "durability": 225,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 574,
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
-    "durability": 195,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 575,
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
-    "durability": 363,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4470,15 +3884,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 576,
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
-    "durability": 528,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4488,55 +3901,49 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 577,
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
-    "durability": 495,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 578,
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
-    "durability": 429,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 579,
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
-    "durability": 77,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4544,15 +3951,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 580,
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
-    "durability": 112,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4562,1372 +3968,1179 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 581,
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
-    "durability": 105,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 582,
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
-    "durability": 91,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 583,
     "displayName": "Flint",
     "name": "flint",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 584,
     "displayName": "Raw Porkchop",
     "name": "porkchop",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 585,
     "displayName": "Cooked Porkchop",
     "name": "cooked_porkchop",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 586,
     "displayName": "Painting",
     "name": "painting",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 587,
     "displayName": "Golden Apple",
     "name": "golden_apple",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 588,
     "displayName": "Enchanted Golden Apple",
     "name": "enchanted_golden_apple",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 589,
     "displayName": "Oak Sign",
     "name": "oak_sign",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 590,
     "displayName": "Spruce Sign",
     "name": "spruce_sign",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 591,
     "displayName": "Birch Sign",
     "name": "birch_sign",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 592,
     "displayName": "Jungle Sign",
     "name": "jungle_sign",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 593,
     "displayName": "Acacia Sign",
     "name": "acacia_sign",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 594,
     "displayName": "Dark Oak Sign",
     "name": "dark_oak_sign",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 595,
     "displayName": "Bucket",
     "name": "bucket",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 596,
     "displayName": "Water Bucket",
     "name": "water_bucket",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 597,
     "displayName": "Lava Bucket",
     "name": "lava_bucket",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 598,
     "displayName": "Minecart",
     "name": "minecart",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 599,
     "displayName": "Saddle",
     "name": "saddle",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 600,
     "displayName": "Redstone Dust",
     "name": "redstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 601,
     "displayName": "Snowball",
     "name": "snowball",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 602,
     "displayName": "Oak Boat",
     "name": "oak_boat",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 603,
     "displayName": "Leather",
     "name": "leather",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 604,
     "displayName": "Milk Bucket",
     "name": "milk_bucket",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 605,
     "displayName": "Bucket of Pufferfish",
     "name": "pufferfish_bucket",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 606,
     "displayName": "Bucket of Salmon",
     "name": "salmon_bucket",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 607,
     "displayName": "Bucket of Cod",
     "name": "cod_bucket",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 608,
     "displayName": "Bucket of Tropical Fish",
     "name": "tropical_fish_bucket",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 609,
     "displayName": "Brick",
     "name": "brick",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 610,
     "displayName": "Clay",
     "name": "clay_ball",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 611,
     "displayName": "Sugar Cane",
     "name": "sugar_cane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 612,
     "displayName": "Kelp",
     "name": "kelp",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 613,
     "displayName": "Dried Kelp Block",
     "name": "dried_kelp_block",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 614,
     "displayName": "Bamboo",
     "name": "bamboo",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 615,
     "displayName": "Paper",
     "name": "paper",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 616,
     "displayName": "Book",
     "name": "book",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 617,
     "displayName": "Slimeball",
     "name": "slime_ball",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 618,
     "displayName": "Minecart with Chest",
     "name": "chest_minecart",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 619,
     "displayName": "Minecart with Furnace",
     "name": "furnace_minecart",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 620,
     "displayName": "Egg",
     "name": "egg",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 621,
     "displayName": "Compass",
     "name": "compass",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 622,
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
-    "durability": 64,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 623,
     "displayName": "Clock",
     "name": "clock",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 624,
     "displayName": "Glowstone Dust",
     "name": "glowstone_dust",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 625,
     "displayName": "Raw Cod",
     "name": "cod",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 626,
     "displayName": "Raw Salmon",
     "name": "salmon",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 627,
     "displayName": "Tropical Fish",
     "name": "tropical_fish",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 628,
     "displayName": "Pufferfish",
     "name": "pufferfish",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 629,
     "displayName": "Cooked Cod",
     "name": "cooked_cod",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 630,
     "displayName": "Cooked Salmon",
     "name": "cooked_salmon",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 631,
     "displayName": "Ink Sac",
     "name": "ink_sac",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 632,
     "displayName": "Red Dye",
     "name": "red_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 633,
     "displayName": "Green Dye",
     "name": "green_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 634,
     "displayName": "Cocoa Beans",
     "name": "cocoa_beans",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 635,
     "displayName": "Lapis Lazuli",
     "name": "lapis_lazuli",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 636,
     "displayName": "Purple Dye",
     "name": "purple_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 637,
     "displayName": "Cyan Dye",
     "name": "cyan_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 638,
     "displayName": "Light Gray Dye",
     "name": "light_gray_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 639,
     "displayName": "Gray Dye",
     "name": "gray_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 640,
     "displayName": "Pink Dye",
     "name": "pink_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 641,
     "displayName": "Lime Dye",
     "name": "lime_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 642,
     "displayName": "Yellow Dye",
     "name": "yellow_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 643,
     "displayName": "Light Blue Dye",
     "name": "light_blue_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 644,
     "displayName": "Magenta Dye",
     "name": "magenta_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 645,
     "displayName": "Orange Dye",
     "name": "orange_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 646,
     "displayName": "Bone Meal",
     "name": "bone_meal",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 647,
     "displayName": "Blue Dye",
     "name": "blue_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 648,
     "displayName": "Brown Dye",
     "name": "brown_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 649,
     "displayName": "Black Dye",
     "name": "black_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 650,
     "displayName": "White Dye",
     "name": "white_dye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 651,
     "displayName": "Bone",
     "name": "bone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 652,
     "displayName": "Sugar",
     "name": "sugar",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 653,
     "displayName": "Cake",
     "name": "cake",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 654,
     "displayName": "White Bed",
     "name": "white_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 655,
     "displayName": "Orange Bed",
     "name": "orange_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 656,
     "displayName": "Magenta Bed",
     "name": "magenta_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 657,
     "displayName": "Light Blue Bed",
     "name": "light_blue_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 658,
     "displayName": "Yellow Bed",
     "name": "yellow_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 659,
     "displayName": "Lime Bed",
     "name": "lime_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 660,
     "displayName": "Pink Bed",
     "name": "pink_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 661,
     "displayName": "Gray Bed",
     "name": "gray_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 662,
     "displayName": "Light Gray Bed",
     "name": "light_gray_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 663,
     "displayName": "Cyan Bed",
     "name": "cyan_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 664,
     "displayName": "Purple Bed",
     "name": "purple_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 665,
     "displayName": "Blue Bed",
     "name": "blue_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 666,
     "displayName": "Brown Bed",
     "name": "brown_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 667,
     "displayName": "Green Bed",
     "name": "green_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 668,
     "displayName": "Red Bed",
     "name": "red_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 669,
     "displayName": "Black Bed",
     "name": "black_bed",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 670,
     "displayName": "Cookie",
     "name": "cookie",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 671,
     "displayName": "Map",
     "name": "filled_map",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 672,
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
-    "durability": 238,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 673,
     "displayName": "Melon Slice",
     "name": "melon_slice",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 674,
     "displayName": "Dried Kelp",
     "name": "dried_kelp",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 675,
     "displayName": "Pumpkin Seeds",
     "name": "pumpkin_seeds",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 676,
     "displayName": "Melon Seeds",
     "name": "melon_seeds",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 677,
     "displayName": "Raw Beef",
     "name": "beef",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 678,
     "displayName": "Steak",
     "name": "cooked_beef",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 679,
     "displayName": "Raw Chicken",
     "name": "chicken",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 680,
     "displayName": "Cooked Chicken",
     "name": "cooked_chicken",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 681,
     "displayName": "Rotten Flesh",
     "name": "rotten_flesh",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 682,
     "displayName": "Ender Pearl",
     "name": "ender_pearl",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 683,
     "displayName": "Blaze Rod",
     "name": "blaze_rod",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 684,
     "displayName": "Ghast Tear",
     "name": "ghast_tear",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 685,
     "displayName": "Gold Nugget",
     "name": "gold_nugget",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 686,
     "displayName": "Nether Wart",
     "name": "nether_wart",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 687,
     "displayName": "Potion",
     "name": "potion",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 688,
     "displayName": "Glass Bottle",
     "name": "glass_bottle",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 689,
     "displayName": "Spider Eye",
     "name": "spider_eye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 690,
     "displayName": "Fermented Spider Eye",
     "name": "fermented_spider_eye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 691,
     "displayName": "Blaze Powder",
     "name": "blaze_powder",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 692,
     "displayName": "Magma Cream",
     "name": "magma_cream",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 693,
     "displayName": "Brewing Stand",
     "name": "brewing_stand",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 694,
     "displayName": "Cauldron",
     "name": "cauldron",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 695,
     "displayName": "Eye of Ender",
     "name": "ender_eye",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 696,
     "displayName": "Glistering Melon Slice",
     "name": "glistering_melon_slice",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 697,
     "displayName": "Bat Spawn Egg",
     "name": "bat_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 698,
     "displayName": "Blaze Spawn Egg",
     "name": "blaze_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 699,
     "displayName": "Cat Spawn Egg",
     "name": "cat_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 700,
     "displayName": "Cave Spider Spawn Egg",
     "name": "cave_spider_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 701,
     "displayName": "Chicken Spawn Egg",
     "name": "chicken_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 702,
     "displayName": "Cod Spawn Egg",
     "name": "cod_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 703,
     "displayName": "Cow Spawn Egg",
     "name": "cow_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 704,
     "displayName": "Creeper Spawn Egg",
     "name": "creeper_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 705,
     "displayName": "Dolphin Spawn Egg",
     "name": "dolphin_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 706,
     "displayName": "Donkey Spawn Egg",
     "name": "donkey_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 707,
     "displayName": "Drowned Spawn Egg",
     "name": "drowned_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 708,
     "displayName": "Elder Guardian Spawn Egg",
     "name": "elder_guardian_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 709,
     "displayName": "Enderman Spawn Egg",
     "name": "enderman_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 710,
     "displayName": "Endermite Spawn Egg",
     "name": "endermite_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 711,
     "displayName": "Evoker Spawn Egg",
     "name": "evoker_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 712,
     "displayName": "Fox Spawn Egg",
     "name": "fox_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 713,
     "displayName": "Ghast Spawn Egg",
     "name": "ghast_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 714,
     "displayName": "Guardian Spawn Egg",
     "name": "guardian_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 715,
     "displayName": "Horse Spawn Egg",
     "name": "horse_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 716,
     "displayName": "Husk Spawn Egg",
     "name": "husk_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 717,
     "displayName": "Llama Spawn Egg",
     "name": "llama_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 718,
     "displayName": "Magma Cube Spawn Egg",
     "name": "magma_cube_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 719,
     "displayName": "Mooshroom Spawn Egg",
     "name": "mooshroom_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 720,
     "displayName": "Mule Spawn Egg",
     "name": "mule_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 721,
     "displayName": "Ocelot Spawn Egg",
     "name": "ocelot_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 722,
     "displayName": "Panda Spawn Egg",
     "name": "panda_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 723,
     "displayName": "Parrot Spawn Egg",
     "name": "parrot_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 724,
     "displayName": "Phantom Spawn Egg",
     "name": "phantom_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 725,
     "displayName": "Pig Spawn Egg",
     "name": "pig_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 726,
     "displayName": "Pillager Spawn Egg",
     "name": "pillager_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 727,
     "displayName": "Polar Bear Spawn Egg",
     "name": "polar_bear_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 728,
     "displayName": "Pufferfish Spawn Egg",
     "name": "pufferfish_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 729,
     "displayName": "Rabbit Spawn Egg",
     "name": "rabbit_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 730,
     "displayName": "Ravager Spawn Egg",
     "name": "ravager_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 731,
     "displayName": "Salmon Spawn Egg",
     "name": "salmon_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 732,
     "displayName": "Sheep Spawn Egg",
     "name": "sheep_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 733,
     "displayName": "Shulker Spawn Egg",
     "name": "shulker_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 734,
     "displayName": "Silverfish Spawn Egg",
     "name": "silverfish_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 735,
     "displayName": "Skeleton Spawn Egg",
     "name": "skeleton_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 736,
     "displayName": "Skeleton Horse Spawn Egg",
     "name": "skeleton_horse_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 737,
     "displayName": "Slime Spawn Egg",
     "name": "slime_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 738,
     "displayName": "Spider Spawn Egg",
     "name": "spider_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 739,
     "displayName": "Squid Spawn Egg",
     "name": "squid_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 740,
     "displayName": "Stray Spawn Egg",
     "name": "stray_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 741,
     "displayName": "Trader Llama Spawn Egg",
     "name": "trader_llama_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 742,
     "displayName": "Tropical Fish Spawn Egg",
     "name": "tropical_fish_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 743,
     "displayName": "Turtle Spawn Egg",
     "name": "turtle_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 744,
     "displayName": "Vex Spawn Egg",
     "name": "vex_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 745,
     "displayName": "Villager Spawn Egg",
     "name": "villager_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 746,
     "displayName": "Vindicator Spawn Egg",
     "name": "vindicator_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 747,
     "displayName": "Wandering Trader Spawn Egg",
     "name": "wandering_trader_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 748,
     "displayName": "Witch Spawn Egg",
     "name": "witch_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 749,
     "displayName": "Wither Skeleton Spawn Egg",
     "name": "wither_skeleton_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 750,
     "displayName": "Wolf Spawn Egg",
     "name": "wolf_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 751,
     "displayName": "Zombie Spawn Egg",
     "name": "zombie_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 752,
     "displayName": "Zombie Horse Spawn Egg",
     "name": "zombie_horse_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 753,
     "displayName": "Zombie Pigman Spawn Egg",
     "name": "zombie_pigman_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 754,
     "displayName": "Zombie Villager Spawn Egg",
     "name": "zombie_villager_spawn_egg",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 755,
     "displayName": "Bottle o' Enchanting",
     "name": "experience_bottle",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 756,
     "displayName": "Fire Charge",
     "name": "fire_charge",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 757,
     "displayName": "Book and Quill",
     "name": "writable_book",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 758,
     "displayName": "Written Book",
     "name": "written_book",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 759,
     "displayName": "Emerald",
     "name": "emerald",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 760,
     "displayName": "Item Frame",
     "name": "item_frame",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 761,
     "displayName": "Flower Pot",
     "name": "flower_pot",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 762,
     "displayName": "Carrot",
     "name": "carrot",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 763,
     "displayName": "Potato",
     "name": "potato",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 764,
     "displayName": "Baked Potato",
     "name": "baked_potato",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 765,
     "displayName": "Poisonous Potato",
     "name": "poisonous_potato",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 766,
     "displayName": "Empty Map",
     "name": "map",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 767,
     "displayName": "Golden Carrot",
     "name": "golden_carrot",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 768,
     "displayName": "Skeleton Skull",
     "name": "skeleton_skull",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 769,
     "displayName": "Wither Skeleton Skull",
     "name": "wither_skeleton_skull",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 770,
     "displayName": "Player Head",
     "name": "player_head",
     "stackSize": 64,
-    "durability": null,
     "enchantCategories": [
       "wearable",
       "vanishable"
@@ -5938,7 +5151,6 @@
     "displayName": "Zombie Head",
     "name": "zombie_head",
     "stackSize": 64,
-    "durability": null,
     "enchantCategories": [
       "wearable",
       "vanishable"
@@ -5949,7 +5161,6 @@
     "displayName": "Creeper Head",
     "name": "creeper_head",
     "stackSize": 64,
-    "durability": null,
     "enchantCategories": [
       "wearable",
       "vanishable"
@@ -5960,7 +5171,6 @@
     "displayName": "Dragon Head",
     "name": "dragon_head",
     "stackSize": 64,
-    "durability": null,
     "enchantCategories": [
       "wearable",
       "vanishable"
@@ -5971,390 +5181,336 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
-    "durability": 25,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 775,
     "displayName": "Nether Star",
     "name": "nether_star",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 776,
     "displayName": "Pumpkin Pie",
     "name": "pumpkin_pie",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 777,
     "displayName": "Firework Rocket",
     "name": "firework_rocket",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 778,
     "displayName": "Firework Star",
     "name": "firework_star",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 779,
     "displayName": "Enchanted Book",
     "name": "enchanted_book",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 780,
     "displayName": "Nether Brick",
     "name": "nether_brick",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 781,
     "displayName": "Nether Quartz",
     "name": "quartz",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 782,
     "displayName": "Minecart with TNT",
     "name": "tnt_minecart",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 783,
     "displayName": "Minecart with Hopper",
     "name": "hopper_minecart",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 784,
     "displayName": "Prismarine Shard",
     "name": "prismarine_shard",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 785,
     "displayName": "Prismarine Crystals",
     "name": "prismarine_crystals",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 786,
     "displayName": "Raw Rabbit",
     "name": "rabbit",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 787,
     "displayName": "Cooked Rabbit",
     "name": "cooked_rabbit",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 788,
     "displayName": "Rabbit Stew",
     "name": "rabbit_stew",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 789,
     "displayName": "Rabbit's Foot",
     "name": "rabbit_foot",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 790,
     "displayName": "Rabbit Hide",
     "name": "rabbit_hide",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 791,
     "displayName": "Armor Stand",
     "name": "armor_stand",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 792,
     "displayName": "Iron Horse Armor",
     "name": "iron_horse_armor",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 793,
     "displayName": "Golden Horse Armor",
     "name": "golden_horse_armor",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 794,
     "displayName": "Diamond Horse Armor",
     "name": "diamond_horse_armor",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 795,
     "displayName": "Leather Horse Armor",
     "name": "leather_horse_armor",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 796,
     "displayName": "Lead",
     "name": "lead",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 797,
     "displayName": "Name Tag",
     "name": "name_tag",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 798,
     "displayName": "Minecart with Command Block",
     "name": "command_block_minecart",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 799,
     "displayName": "Raw Mutton",
     "name": "mutton",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 800,
     "displayName": "Cooked Mutton",
     "name": "cooked_mutton",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 801,
     "displayName": "White Banner",
     "name": "white_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 802,
     "displayName": "Orange Banner",
     "name": "orange_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 803,
     "displayName": "Magenta Banner",
     "name": "magenta_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 804,
     "displayName": "Light Blue Banner",
     "name": "light_blue_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 805,
     "displayName": "Yellow Banner",
     "name": "yellow_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 806,
     "displayName": "Lime Banner",
     "name": "lime_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 807,
     "displayName": "Pink Banner",
     "name": "pink_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 808,
     "displayName": "Gray Banner",
     "name": "gray_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 809,
     "displayName": "Light Gray Banner",
     "name": "light_gray_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 810,
     "displayName": "Cyan Banner",
     "name": "cyan_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 811,
     "displayName": "Purple Banner",
     "name": "purple_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 812,
     "displayName": "Blue Banner",
     "name": "blue_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 813,
     "displayName": "Brown Banner",
     "name": "brown_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 814,
     "displayName": "Green Banner",
     "name": "green_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 815,
     "displayName": "Red Banner",
     "name": "red_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 816,
     "displayName": "Black Banner",
     "name": "black_banner",
-    "stackSize": 16,
-    "durability": null
+    "stackSize": 16
   },
   {
     "id": 817,
     "displayName": "End Crystal",
     "name": "end_crystal",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 818,
     "displayName": "Chorus Fruit",
     "name": "chorus_fruit",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 819,
     "displayName": "Popped Chorus Fruit",
     "name": "popped_chorus_fruit",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 820,
     "displayName": "Beetroot",
     "name": "beetroot",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 821,
     "displayName": "Beetroot Seeds",
     "name": "beetroot_seeds",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 822,
     "displayName": "Beetroot Soup",
     "name": "beetroot_soup",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 823,
     "displayName": "Dragon's Breath",
     "name": "dragon_breath",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 824,
     "displayName": "Splash Potion",
     "name": "splash_potion",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 825,
     "displayName": "Spectral Arrow",
     "name": "spectral_arrow",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 826,
     "displayName": "Tipped Arrow",
     "name": "tipped_arrow",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 827,
     "displayName": "Lingering Potion",
     "name": "lingering_potion",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 828,
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
-    "durability": 336,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -6368,15 +5524,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 829,
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
-    "durability": 432,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -6384,348 +5539,300 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 830,
     "displayName": "Spruce Boat",
     "name": "spruce_boat",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 831,
     "displayName": "Birch Boat",
     "name": "birch_boat",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 832,
     "displayName": "Jungle Boat",
     "name": "jungle_boat",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 833,
     "displayName": "Acacia Boat",
     "name": "acacia_boat",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 834,
     "displayName": "Dark Oak Boat",
     "name": "dark_oak_boat",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 835,
     "displayName": "Totem of Undying",
     "name": "totem_of_undying",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 836,
     "displayName": "Shulker Shell",
     "name": "shulker_shell",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 837,
     "displayName": "Iron Nugget",
     "name": "iron_nugget",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 838,
     "displayName": "Knowledge Book",
     "name": "knowledge_book",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 839,
     "displayName": "Debug Stick",
     "name": "debug_stick",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 840,
     "displayName": "13 Disc",
     "name": "music_disc_13",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 841,
     "displayName": "Cat Disc",
     "name": "music_disc_cat",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 842,
     "displayName": "Blocks Disc",
     "name": "music_disc_blocks",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 843,
     "displayName": "Chirp Disc",
     "name": "music_disc_chirp",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 844,
     "displayName": "Far Disc",
     "name": "music_disc_far",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 845,
     "displayName": "Mall Disc",
     "name": "music_disc_mall",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 846,
     "displayName": "Mellohi Disc",
     "name": "music_disc_mellohi",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 847,
     "displayName": "Stal Disc",
     "name": "music_disc_stal",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 848,
     "displayName": "Strad Disc",
     "name": "music_disc_strad",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 849,
     "displayName": "Ward Disc",
     "name": "music_disc_ward",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 850,
     "displayName": "11 Disc",
     "name": "music_disc_11",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 851,
     "displayName": "Wait Disc",
     "name": "music_disc_wait",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 852,
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "trident"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 853,
     "displayName": "Phantom Membrane",
     "name": "phantom_membrane",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 854,
     "displayName": "Nautilus Shell",
     "name": "nautilus_shell",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 855,
     "displayName": "Heart of the Sea",
     "name": "heart_of_the_sea",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 856,
     "displayName": "Crossbow",
     "name": "crossbow",
     "stackSize": 1,
-    "durability": 326,
+    "maxDurability": 326,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "crossbow"
-    ],
-    "maxDurability": 326
+    ]
   },
   {
     "id": 857,
     "displayName": "Suspicious Stew",
     "name": "suspicious_stew",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 858,
     "displayName": "Loom",
     "name": "loom",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 859,
     "displayName": "Banner Pattern",
     "name": "flower_banner_pattern",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 860,
     "displayName": "Banner Pattern",
     "name": "creeper_banner_pattern",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 861,
     "displayName": "Banner Pattern",
     "name": "skull_banner_pattern",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 862,
     "displayName": "Banner Pattern",
     "name": "mojang_banner_pattern",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 863,
     "displayName": "Banner Pattern",
     "name": "globe_banner_pattern",
-    "stackSize": 1,
-    "durability": null
+    "stackSize": 1
   },
   {
     "id": 864,
     "displayName": "Barrel",
     "name": "barrel",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 865,
     "displayName": "Smoker",
     "name": "smoker",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 866,
     "displayName": "Blast Furnace",
     "name": "blast_furnace",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 867,
     "displayName": "Cartography Table",
     "name": "cartography_table",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 868,
     "displayName": "Fletching Table",
     "name": "fletching_table",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 869,
     "displayName": "Grindstone",
     "name": "grindstone",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 870,
     "displayName": "Lectern",
     "name": "lectern",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 871,
     "displayName": "Smithing Table",
     "name": "smithing_table",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 872,
     "displayName": "Stonecutter",
     "name": "stonecutter",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 873,
     "displayName": "Bell",
     "name": "bell",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 874,
     "displayName": "Lantern",
     "name": "lantern",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 875,
     "displayName": "Sweet Berries",
     "name": "sweet_berries",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   },
   {
     "id": 876,
     "displayName": "Campfire",
     "name": "campfire",
-    "stackSize": 64,
-    "durability": null
+    "stackSize": 64
   }
 ]

--- a/data/pc/1.15.2/items.json
+++ b/data/pc/1.15.2/items.json
@@ -3116,10 +3116,8 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
-    "durability": 275,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3141,7 +3139,6 @@
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3157,7 +3154,6 @@
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3173,7 +3169,6 @@
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3189,7 +3184,6 @@
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3207,7 +3201,6 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -3256,7 +3249,6 @@
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3272,7 +3264,6 @@
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3295,7 +3286,6 @@
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3318,7 +3308,6 @@
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3341,7 +3330,6 @@
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3364,7 +3352,6 @@
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3381,7 +3368,6 @@
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3398,7 +3384,6 @@
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3415,7 +3400,6 @@
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3432,7 +3416,6 @@
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3448,7 +3431,6 @@
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3464,7 +3446,6 @@
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3480,7 +3461,6 @@
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3514,7 +3494,6 @@
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3530,7 +3509,6 @@
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3546,7 +3524,6 @@
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3562,7 +3539,6 @@
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3596,7 +3572,6 @@
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3619,7 +3594,6 @@
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3636,7 +3610,6 @@
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3652,7 +3625,6 @@
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3668,7 +3640,6 @@
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3702,10 +3673,8 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3721,7 +3690,6 @@
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3739,10 +3707,8 @@
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3757,11 +3723,9 @@
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3776,10 +3740,8 @@
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3795,7 +3757,6 @@
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3813,10 +3774,8 @@
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3831,11 +3790,9 @@
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3850,10 +3807,8 @@
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3869,7 +3824,6 @@
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3887,10 +3841,8 @@
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3905,11 +3857,9 @@
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3924,10 +3874,8 @@
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3943,7 +3891,6 @@
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3961,10 +3908,8 @@
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3979,11 +3924,9 @@
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -3998,10 +3941,8 @@
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4017,7 +3958,6 @@
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4035,10 +3975,8 @@
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4053,11 +3991,9 @@
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4306,7 +4242,6 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -4613,7 +4548,6 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5253,7 +5187,6 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5583,7 +5516,6 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
-    "durability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5605,7 +5537,6 @@
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
-    "durability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -5753,7 +5684,6 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
@@ -5784,7 +5714,6 @@
     "displayName": "Crossbow",
     "name": "crossbow",
     "stackSize": 1,
-    "durability": 326,
     "enchantCategories": [
       "breakable",
       "vanishable",

--- a/data/pc/1.16.1/items.json
+++ b/data/pc/1.16.1/items.json
@@ -3428,10 +3428,8 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
-    "durability": 275,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3453,7 +3451,6 @@
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3469,7 +3466,6 @@
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3485,7 +3481,6 @@
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3501,7 +3496,6 @@
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3519,7 +3513,6 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -3580,7 +3573,6 @@
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3596,7 +3588,6 @@
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3619,7 +3610,6 @@
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3642,7 +3632,6 @@
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3665,7 +3654,6 @@
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3688,7 +3676,6 @@
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3705,7 +3692,6 @@
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3722,7 +3708,6 @@
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3739,7 +3724,6 @@
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3756,7 +3740,6 @@
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3772,7 +3755,6 @@
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3788,7 +3770,6 @@
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3804,7 +3785,6 @@
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3838,7 +3818,6 @@
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3854,7 +3833,6 @@
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3870,7 +3848,6 @@
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3886,7 +3863,6 @@
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3902,7 +3878,6 @@
     "displayName": "Netherite Sword",
     "name": "netherite_sword",
     "stackSize": 1,
-    "durability": 2031,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3918,7 +3893,6 @@
     "displayName": "Netherite Shovel",
     "name": "netherite_shovel",
     "stackSize": 1,
-    "durability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3934,7 +3908,6 @@
     "displayName": "Netherite Pickaxe",
     "name": "netherite_pickaxe",
     "stackSize": 1,
-    "durability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3950,7 +3923,6 @@
     "displayName": "Netherite Axe",
     "name": "netherite_axe",
     "stackSize": 1,
-    "durability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3984,7 +3956,6 @@
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4007,7 +3978,6 @@
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4024,7 +3994,6 @@
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4040,7 +4009,6 @@
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4056,7 +4024,6 @@
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4072,7 +4039,6 @@
     "displayName": "Netherite Hoe",
     "name": "netherite_hoe",
     "stackSize": 1,
-    "durability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4106,10 +4072,8 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4125,7 +4089,6 @@
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4143,10 +4106,8 @@
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4161,11 +4122,9 @@
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4180,10 +4139,8 @@
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4199,7 +4156,6 @@
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4217,10 +4173,8 @@
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4235,11 +4189,9 @@
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4254,10 +4206,8 @@
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4273,7 +4223,6 @@
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4291,10 +4240,8 @@
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4309,11 +4256,9 @@
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4328,10 +4273,8 @@
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4347,7 +4290,6 @@
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4365,10 +4307,8 @@
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4383,11 +4323,9 @@
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4402,10 +4340,8 @@
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4421,7 +4357,6 @@
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4439,10 +4374,8 @@
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4457,11 +4390,9 @@
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4476,10 +4407,8 @@
     "displayName": "Netherite Helmet",
     "name": "netherite_helmet",
     "stackSize": 1,
-    "durability": 407,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4495,7 +4424,6 @@
     "displayName": "Netherite Chestplate",
     "name": "netherite_chestplate",
     "stackSize": 1,
-    "durability": 592,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4513,10 +4441,8 @@
     "displayName": "Netherite Leggings",
     "name": "netherite_leggings",
     "stackSize": 1,
-    "durability": 555,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4531,11 +4457,9 @@
     "displayName": "Netherite Boots",
     "name": "netherite_boots",
     "stackSize": 1,
-    "durability": 481,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -4778,7 +4702,6 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -5085,7 +5008,6 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5749,7 +5671,6 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5761,7 +5682,6 @@
     "displayName": "Warped Fungus on a Stick",
     "name": "warped_fungus_on_a_stick",
     "stackSize": 64,
-    "durability": 100,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -6091,7 +6011,6 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
-    "durability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -6113,7 +6032,6 @@
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
-    "durability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -6267,7 +6185,6 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
-    "durability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
@@ -6298,7 +6215,6 @@
     "displayName": "Crossbow",
     "name": "crossbow",
     "stackSize": 1,
-    "durability": 326,
     "enchantCategories": [
       "breakable",
       "vanishable",

--- a/data/pc/1.16.2/items.json
+++ b/data/pc/1.16.2/items.json
@@ -3428,10 +3428,9 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
-    "durability": 275,
+    "maxDurability": 275,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -3439,8 +3438,7 @@
     ],
     "repairWith": [
       "scute"
-    ],
-    "maxDurability": 275
+    ]
   },
   {
     "id": 571,
@@ -3453,12 +3451,11 @@
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
-    "durability": 64,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 573,
@@ -3471,13 +3468,12 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
-    "durability": 384,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 575,
@@ -3532,7 +3528,7 @@
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3547,15 +3543,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 584,
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3570,15 +3565,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 585,
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3593,15 +3587,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 586,
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3616,15 +3609,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 587,
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
-    "durability": 59,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3639,15 +3631,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 588,
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3656,15 +3647,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 589,
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3673,15 +3663,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 590,
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3690,15 +3679,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 591,
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3707,15 +3695,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 592,
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
-    "durability": 131,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3724,15 +3711,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 593,
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3740,15 +3726,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 594,
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3756,15 +3741,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 595,
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3772,15 +3756,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 596,
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3788,15 +3771,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 597,
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
-    "durability": 32,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3804,15 +3786,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 598,
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3820,15 +3801,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 599,
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3836,15 +3816,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 600,
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3852,15 +3831,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 601,
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3868,15 +3846,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 602,
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3884,15 +3861,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 603,
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3900,15 +3876,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 604,
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3916,15 +3891,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 605,
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3932,15 +3906,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 606,
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3948,15 +3921,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 607,
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
-    "durability": 1561,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3964,15 +3936,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 608,
     "displayName": "Netherite Sword",
     "name": "netherite_sword",
     "stackSize": 1,
-    "durability": 2031,
+    "maxDurability": 2031,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3980,15 +3951,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 609,
     "displayName": "Netherite Shovel",
     "name": "netherite_shovel",
     "stackSize": 1,
-    "durability": 2031,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3996,15 +3966,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 610,
     "displayName": "Netherite Pickaxe",
     "name": "netherite_pickaxe",
     "stackSize": 1,
-    "durability": 2031,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4012,15 +3981,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 611,
     "displayName": "Netherite Axe",
     "name": "netherite_axe",
     "stackSize": 1,
-    "durability": 2031,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4028,15 +3996,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 612,
     "displayName": "Netherite Hoe",
     "name": "netherite_hoe",
     "stackSize": 1,
-    "durability": 2031,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4044,8 +4011,7 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 613,
@@ -4106,10 +4072,9 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
-    "durability": 55,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4117,15 +4082,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 623,
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
-    "durability": 80,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4135,55 +4099,49 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 624,
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
-    "durability": 75,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 625,
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
-    "durability": 65,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 626,
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
-    "durability": 165,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4191,15 +4149,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 627,
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
-    "durability": 240,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4209,55 +4166,49 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 628,
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
-    "durability": 225,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 629,
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
-    "durability": 195,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 630,
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
-    "durability": 165,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4265,15 +4216,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 631,
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
-    "durability": 240,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4283,55 +4233,49 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 632,
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
-    "durability": 225,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 633,
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
-    "durability": 195,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 634,
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
-    "durability": 363,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4339,15 +4283,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 635,
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
-    "durability": 528,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4357,55 +4300,49 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 636,
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
-    "durability": 495,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 637,
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
-    "durability": 429,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 638,
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
-    "durability": 77,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4413,15 +4350,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 639,
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
-    "durability": 112,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4431,55 +4367,49 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 640,
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
-    "durability": 105,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 641,
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
-    "durability": 91,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 642,
     "displayName": "Netherite Helmet",
     "name": "netherite_helmet",
     "stackSize": 1,
-    "durability": 407,
+    "maxDurability": 407,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -4487,15 +4417,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 407
+    ]
   },
   {
     "id": 643,
     "displayName": "Netherite Chestplate",
     "name": "netherite_chestplate",
     "stackSize": 1,
-    "durability": 592,
+    "maxDurability": 592,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4505,45 +4434,40 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 592
+    ]
   },
   {
     "id": 644,
     "displayName": "Netherite Leggings",
     "name": "netherite_leggings",
     "stackSize": 1,
-    "durability": 555,
+    "maxDurability": 555,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 555
+    ]
   },
   {
     "id": 645,
     "displayName": "Netherite Boots",
     "name": "netherite_boots",
     "stackSize": 1,
-    "durability": 481,
+    "maxDurability": 481,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 481
+    ]
   },
   {
     "id": 646,
@@ -4778,13 +4702,12 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
-    "durability": 64,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 685,
@@ -5085,12 +5008,11 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
-    "durability": 238,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 735,
@@ -5755,24 +5677,22 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
-    "durability": 25,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 843,
     "displayName": "Warped Fungus on a Stick",
     "name": "warped_fungus_on_a_stick",
     "stackSize": 64,
-    "durability": 100,
+    "maxDurability": 100,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 100
+    ]
   },
   {
     "id": 844,
@@ -6097,7 +6017,7 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
-    "durability": 336,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -6111,15 +6031,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 898,
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
-    "durability": 432,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -6127,8 +6046,7 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 899,
@@ -6273,13 +6191,12 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
-    "durability": 250,
+    "maxDurability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "trident"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 923,
@@ -6304,13 +6221,12 @@
     "displayName": "Crossbow",
     "name": "crossbow",
     "stackSize": 1,
-    "durability": 326,
+    "maxDurability": 326,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "crossbow"
-    ],
-    "maxDurability": 326
+    ]
   },
   {
     "id": 927,

--- a/data/pc/1.17/items.json
+++ b/data/pc/1.17/items.json
@@ -1,1870 +1,1604 @@
 [
   {
     "id": 0,
-    "name": "air",
     "displayName": "Air",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "air",
+    "stackSize": 0
   },
   {
     "id": 1,
-    "name": "stone",
     "displayName": "Stone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stone",
+    "stackSize": 64
   },
   {
     "id": 2,
-    "name": "granite",
     "displayName": "Granite",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "granite",
+    "stackSize": 64
   },
   {
     "id": 3,
-    "name": "polished_granite",
     "displayName": "Polished Granite",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_granite",
+    "stackSize": 64
   },
   {
     "id": 4,
-    "name": "diorite",
     "displayName": "Diorite",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "diorite",
+    "stackSize": 64
   },
   {
     "id": 5,
-    "name": "polished_diorite",
     "displayName": "Polished Diorite",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_diorite",
+    "stackSize": 64
   },
   {
     "id": 6,
-    "name": "andesite",
     "displayName": "Andesite",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "andesite",
+    "stackSize": 64
   },
   {
     "id": 7,
-    "name": "polished_andesite",
     "displayName": "Polished Andesite",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_andesite",
+    "stackSize": 64
   },
   {
     "id": 8,
-    "name": "deepslate",
     "displayName": "Deepslate",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "deepslate",
+    "stackSize": 64
   },
   {
     "id": 9,
-    "name": "cobbled_deepslate",
     "displayName": "Cobbled Deepslate",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cobbled_deepslate",
+    "stackSize": 64
   },
   {
     "id": 10,
-    "name": "polished_deepslate",
     "displayName": "Polished Deepslate",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_deepslate",
+    "stackSize": 64
   },
   {
     "id": 11,
-    "name": "calcite",
     "displayName": "Calcite",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "calcite",
+    "stackSize": 64
   },
   {
     "id": 12,
-    "name": "tuff",
     "displayName": "Tuff",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "tuff",
+    "stackSize": 64
   },
   {
     "id": 13,
-    "name": "dripstone_block",
     "displayName": "Dripstone Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dripstone_block",
+    "stackSize": 64
   },
   {
     "id": 14,
-    "name": "grass_block",
     "displayName": "Grass Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "grass_block",
+    "stackSize": 64
   },
   {
     "id": 15,
-    "name": "dirt",
     "displayName": "Dirt",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dirt",
+    "stackSize": 64
   },
   {
     "id": 16,
-    "name": "coarse_dirt",
     "displayName": "Coarse Dirt",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "coarse_dirt",
+    "stackSize": 64
   },
   {
     "id": 17,
-    "name": "podzol",
     "displayName": "Podzol",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "podzol",
+    "stackSize": 64
   },
   {
     "id": 18,
-    "name": "rooted_dirt",
     "displayName": "Rooted Dirt",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "rooted_dirt",
+    "stackSize": 64
   },
   {
     "id": 19,
-    "name": "crimson_nylium",
     "displayName": "Crimson Nylium",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crimson_nylium",
+    "stackSize": 64
   },
   {
     "id": 20,
-    "name": "warped_nylium",
     "displayName": "Warped Nylium",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "warped_nylium",
+    "stackSize": 64
   },
   {
     "id": 21,
-    "name": "cobblestone",
     "displayName": "Cobblestone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cobblestone",
+    "stackSize": 64
   },
   {
     "id": 22,
-    "name": "oak_planks",
     "displayName": "Oak Planks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oak_planks",
+    "stackSize": 64
   },
   {
     "id": 23,
-    "name": "spruce_planks",
     "displayName": "Spruce Planks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spruce_planks",
+    "stackSize": 64
   },
   {
     "id": 24,
-    "name": "birch_planks",
     "displayName": "Birch Planks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "birch_planks",
+    "stackSize": 64
   },
   {
     "id": 25,
-    "name": "jungle_planks",
     "displayName": "Jungle Planks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "jungle_planks",
+    "stackSize": 64
   },
   {
     "id": 26,
-    "name": "acacia_planks",
     "displayName": "Acacia Planks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "acacia_planks",
+    "stackSize": 64
   },
   {
     "id": 27,
-    "name": "dark_oak_planks",
     "displayName": "Dark Oak Planks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dark_oak_planks",
+    "stackSize": 64
   },
   {
     "id": 28,
-    "name": "crimson_planks",
     "displayName": "Crimson Planks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crimson_planks",
+    "stackSize": 64
   },
   {
     "id": 29,
-    "name": "warped_planks",
     "displayName": "Warped Planks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "warped_planks",
+    "stackSize": 64
   },
   {
     "id": 30,
-    "name": "oak_sapling",
     "displayName": "Oak Sapling",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oak_sapling",
+    "stackSize": 64
   },
   {
     "id": 31,
-    "name": "spruce_sapling",
     "displayName": "Spruce Sapling",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spruce_sapling",
+    "stackSize": 64
   },
   {
     "id": 32,
-    "name": "birch_sapling",
     "displayName": "Birch Sapling",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "birch_sapling",
+    "stackSize": 64
   },
   {
     "id": 33,
-    "name": "jungle_sapling",
     "displayName": "Jungle Sapling",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "jungle_sapling",
+    "stackSize": 64
   },
   {
     "id": 34,
-    "name": "acacia_sapling",
     "displayName": "Acacia Sapling",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "acacia_sapling",
+    "stackSize": 64
   },
   {
     "id": 35,
-    "name": "dark_oak_sapling",
     "displayName": "Dark Oak Sapling",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dark_oak_sapling",
+    "stackSize": 64
   },
   {
     "id": 36,
-    "name": "bedrock",
     "displayName": "Bedrock",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bedrock",
+    "stackSize": 64
   },
   {
     "id": 37,
-    "name": "sand",
     "displayName": "Sand",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "sand",
+    "stackSize": 64
   },
   {
     "id": 38,
-    "name": "red_sand",
     "displayName": "Red Sand",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "red_sand",
+    "stackSize": 64
   },
   {
     "id": 39,
-    "name": "gravel",
     "displayName": "Gravel",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gravel",
+    "stackSize": 64
   },
   {
     "id": 40,
-    "name": "coal_ore",
     "displayName": "Coal Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "coal_ore",
+    "stackSize": 64
   },
   {
     "id": 41,
-    "name": "deepslate_coal_ore",
     "displayName": "Deepslate Coal Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "deepslate_coal_ore",
+    "stackSize": 64
   },
   {
     "id": 42,
-    "name": "iron_ore",
     "displayName": "Iron Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "iron_ore",
+    "stackSize": 64
   },
   {
     "id": 43,
-    "name": "deepslate_iron_ore",
     "displayName": "Deepslate Iron Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "deepslate_iron_ore",
+    "stackSize": 64
   },
   {
     "id": 44,
-    "name": "copper_ore",
     "displayName": "Copper Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "copper_ore",
+    "stackSize": 64
   },
   {
     "id": 45,
-    "name": "deepslate_copper_ore",
     "displayName": "Deepslate Copper Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "deepslate_copper_ore",
+    "stackSize": 64
   },
   {
     "id": 46,
-    "name": "gold_ore",
     "displayName": "Gold Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gold_ore",
+    "stackSize": 64
   },
   {
     "id": 47,
-    "name": "deepslate_gold_ore",
     "displayName": "Deepslate Gold Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "deepslate_gold_ore",
+    "stackSize": 64
   },
   {
     "id": 48,
-    "name": "redstone_ore",
     "displayName": "Redstone Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "redstone_ore",
+    "stackSize": 64
   },
   {
     "id": 49,
-    "name": "deepslate_redstone_ore",
     "displayName": "Deepslate Redstone Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "deepslate_redstone_ore",
+    "stackSize": 64
   },
   {
     "id": 50,
-    "name": "emerald_ore",
     "displayName": "Emerald Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "emerald_ore",
+    "stackSize": 64
   },
   {
     "id": 51,
-    "name": "deepslate_emerald_ore",
     "displayName": "Deepslate Emerald Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "deepslate_emerald_ore",
+    "stackSize": 64
   },
   {
     "id": 52,
-    "name": "lapis_ore",
     "displayName": "Lapis Lazuli Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lapis_ore",
+    "stackSize": 64
   },
   {
     "id": 53,
-    "name": "deepslate_lapis_ore",
     "displayName": "Deepslate Lapis Lazuli Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "deepslate_lapis_ore",
+    "stackSize": 64
   },
   {
     "id": 54,
-    "name": "diamond_ore",
     "displayName": "Diamond Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "diamond_ore",
+    "stackSize": 64
   },
   {
     "id": 55,
-    "name": "deepslate_diamond_ore",
     "displayName": "Deepslate Diamond Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "deepslate_diamond_ore",
+    "stackSize": 64
   },
   {
     "id": 56,
-    "name": "nether_gold_ore",
     "displayName": "Nether Gold Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "nether_gold_ore",
+    "stackSize": 64
   },
   {
     "id": 57,
-    "name": "nether_quartz_ore",
     "displayName": "Nether Quartz Ore",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "nether_quartz_ore",
+    "stackSize": 64
   },
   {
     "id": 58,
-    "name": "ancient_debris",
     "displayName": "Ancient Debris",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "ancient_debris",
+    "stackSize": 64
   },
   {
     "id": 59,
-    "name": "coal_block",
     "displayName": "Block of Coal",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "coal_block",
+    "stackSize": 64
   },
   {
     "id": 60,
-    "name": "raw_iron_block",
     "displayName": "Block of Raw Iron",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "raw_iron_block",
+    "stackSize": 64
   },
   {
     "id": 61,
-    "name": "raw_copper_block",
     "displayName": "Block of Raw Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "raw_copper_block",
+    "stackSize": 64
   },
   {
     "id": 62,
-    "name": "raw_gold_block",
     "displayName": "Block of Raw Gold",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "raw_gold_block",
+    "stackSize": 64
   },
   {
     "id": 63,
-    "name": "amethyst_block",
     "displayName": "Block of Amethyst",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "amethyst_block",
+    "stackSize": 64
   },
   {
     "id": 64,
-    "name": "budding_amethyst",
     "displayName": "Budding Amethyst",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "budding_amethyst",
+    "stackSize": 64
   },
   {
     "id": 65,
-    "name": "iron_block",
     "displayName": "Block of Iron",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "iron_block",
+    "stackSize": 64
   },
   {
     "id": 66,
-    "name": "copper_block",
     "displayName": "Block of Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "copper_block",
+    "stackSize": 64
   },
   {
     "id": 67,
-    "name": "gold_block",
     "displayName": "Block of Gold",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gold_block",
+    "stackSize": 64
   },
   {
     "id": 68,
-    "name": "diamond_block",
     "displayName": "Block of Diamond",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "diamond_block",
+    "stackSize": 64
   },
   {
     "id": 69,
-    "name": "netherite_block",
     "displayName": "Block of Netherite",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "netherite_block",
+    "stackSize": 64
   },
   {
     "id": 70,
-    "name": "exposed_copper",
     "displayName": "Exposed Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "exposed_copper",
+    "stackSize": 64
   },
   {
     "id": 71,
-    "name": "weathered_copper",
     "displayName": "Weathered Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "weathered_copper",
+    "stackSize": 64
   },
   {
     "id": 72,
-    "name": "oxidized_copper",
     "displayName": "Oxidized Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oxidized_copper",
+    "stackSize": 64
   },
   {
     "id": 73,
-    "name": "cut_copper",
     "displayName": "Cut Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cut_copper",
+    "stackSize": 64
   },
   {
     "id": 74,
-    "name": "exposed_cut_copper",
     "displayName": "Exposed Cut Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "exposed_cut_copper",
+    "stackSize": 64
   },
   {
     "id": 75,
-    "name": "weathered_cut_copper",
     "displayName": "Weathered Cut Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "weathered_cut_copper",
+    "stackSize": 64
   },
   {
     "id": 76,
-    "name": "oxidized_cut_copper",
     "displayName": "Oxidized Cut Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oxidized_cut_copper",
+    "stackSize": 64
   },
   {
     "id": 77,
-    "name": "cut_copper_stairs",
     "displayName": "Cut Copper Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cut_copper_stairs",
+    "stackSize": 64
   },
   {
     "id": 78,
-    "name": "exposed_cut_copper_stairs",
     "displayName": "Exposed Cut Copper Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "exposed_cut_copper_stairs",
+    "stackSize": 64
   },
   {
     "id": 79,
-    "name": "weathered_cut_copper_stairs",
     "displayName": "Weathered Cut Copper Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "weathered_cut_copper_stairs",
+    "stackSize": 64
   },
   {
     "id": 80,
-    "name": "oxidized_cut_copper_stairs",
     "displayName": "Oxidized Cut Copper Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oxidized_cut_copper_stairs",
+    "stackSize": 64
   },
   {
     "id": 81,
-    "name": "cut_copper_slab",
     "displayName": "Cut Copper Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cut_copper_slab",
+    "stackSize": 64
   },
   {
     "id": 82,
-    "name": "exposed_cut_copper_slab",
     "displayName": "Exposed Cut Copper Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "exposed_cut_copper_slab",
+    "stackSize": 64
   },
   {
     "id": 83,
-    "name": "weathered_cut_copper_slab",
     "displayName": "Weathered Cut Copper Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "weathered_cut_copper_slab",
+    "stackSize": 64
   },
   {
     "id": 84,
-    "name": "oxidized_cut_copper_slab",
     "displayName": "Oxidized Cut Copper Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oxidized_cut_copper_slab",
+    "stackSize": 64
   },
   {
     "id": 85,
-    "name": "waxed_copper_block",
     "displayName": "Waxed Block of Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_copper_block",
+    "stackSize": 64
   },
   {
     "id": 86,
-    "name": "waxed_exposed_copper",
     "displayName": "Waxed Exposed Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_exposed_copper",
+    "stackSize": 64
   },
   {
     "id": 87,
-    "name": "waxed_weathered_copper",
     "displayName": "Waxed Weathered Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_weathered_copper",
+    "stackSize": 64
   },
   {
     "id": 88,
-    "name": "waxed_oxidized_copper",
     "displayName": "Waxed Oxidized Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_oxidized_copper",
+    "stackSize": 64
   },
   {
     "id": 89,
-    "name": "waxed_cut_copper",
     "displayName": "Waxed Cut Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_cut_copper",
+    "stackSize": 64
   },
   {
     "id": 90,
-    "name": "waxed_exposed_cut_copper",
     "displayName": "Waxed Exposed Cut Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_exposed_cut_copper",
+    "stackSize": 64
   },
   {
     "id": 91,
-    "name": "waxed_weathered_cut_copper",
     "displayName": "Waxed Weathered Cut Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_weathered_cut_copper",
+    "stackSize": 64
   },
   {
     "id": 92,
-    "name": "waxed_oxidized_cut_copper",
     "displayName": "Waxed Oxidized Cut Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_oxidized_cut_copper",
+    "stackSize": 64
   },
   {
     "id": 93,
-    "name": "waxed_cut_copper_stairs",
     "displayName": "Waxed Cut Copper Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_cut_copper_stairs",
+    "stackSize": 64
   },
   {
     "id": 94,
-    "name": "waxed_exposed_cut_copper_stairs",
     "displayName": "Waxed Exposed Cut Copper Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_exposed_cut_copper_stairs",
+    "stackSize": 64
   },
   {
     "id": 95,
-    "name": "waxed_weathered_cut_copper_stairs",
     "displayName": "Waxed Weathered Cut Copper Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_weathered_cut_copper_stairs",
+    "stackSize": 64
   },
   {
     "id": 96,
-    "name": "waxed_oxidized_cut_copper_stairs",
     "displayName": "Waxed Oxidized Cut Copper Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_oxidized_cut_copper_stairs",
+    "stackSize": 64
   },
   {
     "id": 97,
-    "name": "waxed_cut_copper_slab",
     "displayName": "Waxed Cut Copper Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_cut_copper_slab",
+    "stackSize": 64
   },
   {
     "id": 98,
-    "name": "waxed_exposed_cut_copper_slab",
     "displayName": "Waxed Exposed Cut Copper Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_exposed_cut_copper_slab",
+    "stackSize": 64
   },
   {
     "id": 99,
-    "name": "waxed_weathered_cut_copper_slab",
     "displayName": "Waxed Weathered Cut Copper Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_weathered_cut_copper_slab",
+    "stackSize": 64
   },
   {
     "id": 100,
-    "name": "waxed_oxidized_cut_copper_slab",
     "displayName": "Waxed Oxidized Cut Copper Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "waxed_oxidized_cut_copper_slab",
+    "stackSize": 64
   },
   {
     "id": 101,
-    "name": "oak_log",
     "displayName": "Oak Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oak_log",
+    "stackSize": 64
   },
   {
     "id": 102,
-    "name": "spruce_log",
     "displayName": "Spruce Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spruce_log",
+    "stackSize": 64
   },
   {
     "id": 103,
-    "name": "birch_log",
     "displayName": "Birch Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "birch_log",
+    "stackSize": 64
   },
   {
     "id": 104,
-    "name": "jungle_log",
     "displayName": "Jungle Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "jungle_log",
+    "stackSize": 64
   },
   {
     "id": 105,
-    "name": "acacia_log",
     "displayName": "Acacia Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "acacia_log",
+    "stackSize": 64
   },
   {
     "id": 106,
-    "name": "dark_oak_log",
     "displayName": "Dark Oak Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dark_oak_log",
+    "stackSize": 64
   },
   {
     "id": 107,
-    "name": "crimson_stem",
     "displayName": "Crimson Stem",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crimson_stem",
+    "stackSize": 64
   },
   {
     "id": 108,
-    "name": "warped_stem",
     "displayName": "Warped Stem",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "warped_stem",
+    "stackSize": 64
   },
   {
     "id": 109,
-    "name": "stripped_oak_log",
     "displayName": "Stripped Oak Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_oak_log",
+    "stackSize": 64
   },
   {
     "id": 110,
-    "name": "stripped_spruce_log",
     "displayName": "Stripped Spruce Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_spruce_log",
+    "stackSize": 64
   },
   {
     "id": 111,
-    "name": "stripped_birch_log",
     "displayName": "Stripped Birch Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_birch_log",
+    "stackSize": 64
   },
   {
     "id": 112,
-    "name": "stripped_jungle_log",
     "displayName": "Stripped Jungle Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_jungle_log",
+    "stackSize": 64
   },
   {
     "id": 113,
-    "name": "stripped_acacia_log",
     "displayName": "Stripped Acacia Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_acacia_log",
+    "stackSize": 64
   },
   {
     "id": 114,
-    "name": "stripped_dark_oak_log",
     "displayName": "Stripped Dark Oak Log",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_dark_oak_log",
+    "stackSize": 64
   },
   {
     "id": 115,
-    "name": "stripped_crimson_stem",
     "displayName": "Stripped Crimson Stem",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_crimson_stem",
+    "stackSize": 64
   },
   {
     "id": 116,
-    "name": "stripped_warped_stem",
     "displayName": "Stripped Warped Stem",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_warped_stem",
+    "stackSize": 64
   },
   {
     "id": 117,
-    "name": "stripped_oak_wood",
     "displayName": "Stripped Oak Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_oak_wood",
+    "stackSize": 64
   },
   {
     "id": 118,
-    "name": "stripped_spruce_wood",
     "displayName": "Stripped Spruce Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_spruce_wood",
+    "stackSize": 64
   },
   {
     "id": 119,
-    "name": "stripped_birch_wood",
     "displayName": "Stripped Birch Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_birch_wood",
+    "stackSize": 64
   },
   {
     "id": 120,
-    "name": "stripped_jungle_wood",
     "displayName": "Stripped Jungle Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_jungle_wood",
+    "stackSize": 64
   },
   {
     "id": 121,
-    "name": "stripped_acacia_wood",
     "displayName": "Stripped Acacia Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_acacia_wood",
+    "stackSize": 64
   },
   {
     "id": 122,
-    "name": "stripped_dark_oak_wood",
     "displayName": "Stripped Dark Oak Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_dark_oak_wood",
+    "stackSize": 64
   },
   {
     "id": 123,
-    "name": "stripped_crimson_hyphae",
     "displayName": "Stripped Crimson Hyphae",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_crimson_hyphae",
+    "stackSize": 64
   },
   {
     "id": 124,
-    "name": "stripped_warped_hyphae",
     "displayName": "Stripped Warped Hyphae",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stripped_warped_hyphae",
+    "stackSize": 64
   },
   {
     "id": 125,
-    "name": "oak_wood",
     "displayName": "Oak Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oak_wood",
+    "stackSize": 64
   },
   {
     "id": 126,
-    "name": "spruce_wood",
     "displayName": "Spruce Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spruce_wood",
+    "stackSize": 64
   },
   {
     "id": 127,
-    "name": "birch_wood",
     "displayName": "Birch Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "birch_wood",
+    "stackSize": 64
   },
   {
     "id": 128,
-    "name": "jungle_wood",
     "displayName": "Jungle Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "jungle_wood",
+    "stackSize": 64
   },
   {
     "id": 129,
-    "name": "acacia_wood",
     "displayName": "Acacia Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "acacia_wood",
+    "stackSize": 64
   },
   {
     "id": 130,
-    "name": "dark_oak_wood",
     "displayName": "Dark Oak Wood",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dark_oak_wood",
+    "stackSize": 64
   },
   {
     "id": 131,
-    "name": "crimson_hyphae",
     "displayName": "Crimson Hyphae",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crimson_hyphae",
+    "stackSize": 64
   },
   {
     "id": 132,
-    "name": "warped_hyphae",
     "displayName": "Warped Hyphae",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "warped_hyphae",
+    "stackSize": 64
   },
   {
     "id": 133,
-    "name": "oak_leaves",
     "displayName": "Oak Leaves",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oak_leaves",
+    "stackSize": 64
   },
   {
     "id": 134,
-    "name": "spruce_leaves",
     "displayName": "Spruce Leaves",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spruce_leaves",
+    "stackSize": 64
   },
   {
     "id": 135,
-    "name": "birch_leaves",
     "displayName": "Birch Leaves",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "birch_leaves",
+    "stackSize": 64
   },
   {
     "id": 136,
-    "name": "jungle_leaves",
     "displayName": "Jungle Leaves",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "jungle_leaves",
+    "stackSize": 64
   },
   {
     "id": 137,
-    "name": "acacia_leaves",
     "displayName": "Acacia Leaves",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "acacia_leaves",
+    "stackSize": 64
   },
   {
     "id": 138,
-    "name": "dark_oak_leaves",
     "displayName": "Dark Oak Leaves",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dark_oak_leaves",
+    "stackSize": 64
   },
   {
     "id": 139,
-    "name": "azalea_leaves",
     "displayName": "Azalea Leaves",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "azalea_leaves",
+    "stackSize": 64
   },
   {
     "id": 140,
-    "name": "flowering_azalea_leaves",
     "displayName": "Flowering Azalea Leaves",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "flowering_azalea_leaves",
+    "stackSize": 64
   },
   {
     "id": 141,
-    "name": "sponge",
     "displayName": "Sponge",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "sponge",
+    "stackSize": 64
   },
   {
     "id": 142,
-    "name": "wet_sponge",
     "displayName": "Wet Sponge",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "wet_sponge",
+    "stackSize": 64
   },
   {
     "id": 143,
-    "name": "glass",
     "displayName": "Glass",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "glass",
+    "stackSize": 64
   },
   {
     "id": 144,
-    "name": "tinted_glass",
     "displayName": "Tinted Glass",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "tinted_glass",
+    "stackSize": 64
   },
   {
     "id": 145,
-    "name": "lapis_block",
     "displayName": "Block of Lapis Lazuli",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lapis_block",
+    "stackSize": 64
   },
   {
     "id": 146,
-    "name": "sandstone",
     "displayName": "Sandstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "sandstone",
+    "stackSize": 64
   },
   {
     "id": 147,
-    "name": "chiseled_sandstone",
     "displayName": "Chiseled Sandstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "chiseled_sandstone",
+    "stackSize": 64
   },
   {
     "id": 148,
-    "name": "cut_sandstone",
     "displayName": "Cut Sandstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cut_sandstone",
+    "stackSize": 64
   },
   {
     "id": 149,
-    "name": "cobweb",
     "displayName": "Cobweb",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cobweb",
+    "stackSize": 64
   },
   {
     "id": 150,
-    "name": "grass",
     "displayName": "Grass",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "grass",
+    "stackSize": 64
   },
   {
     "id": 151,
-    "name": "fern",
     "displayName": "Fern",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "fern",
+    "stackSize": 64
   },
   {
     "id": 152,
-    "name": "azalea",
     "displayName": "Azalea",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "azalea",
+    "stackSize": 64
   },
   {
     "id": 153,
-    "name": "flowering_azalea",
     "displayName": "Flowering Azalea",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "flowering_azalea",
+    "stackSize": 64
   },
   {
     "id": 154,
-    "name": "dead_bush",
     "displayName": "Dead Bush",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dead_bush",
+    "stackSize": 64
   },
   {
     "id": 155,
-    "name": "seagrass",
     "displayName": "Seagrass",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "seagrass",
+    "stackSize": 64
   },
   {
     "id": 156,
-    "name": "sea_pickle",
     "displayName": "Sea Pickle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "sea_pickle",
+    "stackSize": 64
   },
   {
     "id": 157,
-    "name": "white_wool",
     "displayName": "White Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "white_wool",
+    "stackSize": 64
   },
   {
     "id": 158,
-    "name": "orange_wool",
     "displayName": "Orange Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "orange_wool",
+    "stackSize": 64
   },
   {
     "id": 159,
-    "name": "magenta_wool",
     "displayName": "Magenta Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "magenta_wool",
+    "stackSize": 64
   },
   {
     "id": 160,
-    "name": "light_blue_wool",
     "displayName": "Light Blue Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "light_blue_wool",
+    "stackSize": 64
   },
   {
     "id": 161,
-    "name": "yellow_wool",
     "displayName": "Yellow Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "yellow_wool",
+    "stackSize": 64
   },
   {
     "id": 162,
-    "name": "lime_wool",
     "displayName": "Lime Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lime_wool",
+    "stackSize": 64
   },
   {
     "id": 163,
-    "name": "pink_wool",
     "displayName": "Pink Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pink_wool",
+    "stackSize": 64
   },
   {
     "id": 164,
-    "name": "gray_wool",
     "displayName": "Gray Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gray_wool",
+    "stackSize": 64
   },
   {
     "id": 165,
-    "name": "light_gray_wool",
     "displayName": "Light Gray Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "light_gray_wool",
+    "stackSize": 64
   },
   {
     "id": 166,
-    "name": "cyan_wool",
     "displayName": "Cyan Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cyan_wool",
+    "stackSize": 64
   },
   {
     "id": 167,
-    "name": "purple_wool",
     "displayName": "Purple Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "purple_wool",
+    "stackSize": 64
   },
   {
     "id": 168,
-    "name": "blue_wool",
     "displayName": "Blue Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blue_wool",
+    "stackSize": 64
   },
   {
     "id": 169,
-    "name": "brown_wool",
     "displayName": "Brown Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "brown_wool",
+    "stackSize": 64
   },
   {
     "id": 170,
-    "name": "green_wool",
     "displayName": "Green Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "green_wool",
+    "stackSize": 64
   },
   {
     "id": 171,
-    "name": "red_wool",
     "displayName": "Red Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "red_wool",
+    "stackSize": 64
   },
   {
     "id": 172,
-    "name": "black_wool",
     "displayName": "Black Wool",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "black_wool",
+    "stackSize": 64
   },
   {
     "id": 173,
-    "name": "dandelion",
     "displayName": "Dandelion",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dandelion",
+    "stackSize": 64
   },
   {
     "id": 174,
-    "name": "poppy",
     "displayName": "Poppy",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "poppy",
+    "stackSize": 64
   },
   {
     "id": 175,
-    "name": "blue_orchid",
     "displayName": "Blue Orchid",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blue_orchid",
+    "stackSize": 64
   },
   {
     "id": 176,
-    "name": "allium",
     "displayName": "Allium",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "allium",
+    "stackSize": 64
   },
   {
     "id": 177,
-    "name": "azure_bluet",
     "displayName": "Azure Bluet",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "azure_bluet",
+    "stackSize": 64
   },
   {
     "id": 178,
-    "name": "red_tulip",
     "displayName": "Red Tulip",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "red_tulip",
+    "stackSize": 64
   },
   {
     "id": 179,
-    "name": "orange_tulip",
     "displayName": "Orange Tulip",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "orange_tulip",
+    "stackSize": 64
   },
   {
     "id": 180,
-    "name": "white_tulip",
     "displayName": "White Tulip",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "white_tulip",
+    "stackSize": 64
   },
   {
     "id": 181,
-    "name": "pink_tulip",
     "displayName": "Pink Tulip",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pink_tulip",
+    "stackSize": 64
   },
   {
     "id": 182,
-    "name": "oxeye_daisy",
     "displayName": "Oxeye Daisy",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oxeye_daisy",
+    "stackSize": 64
   },
   {
     "id": 183,
-    "name": "cornflower",
     "displayName": "Cornflower",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cornflower",
+    "stackSize": 64
   },
   {
     "id": 184,
-    "name": "lily_of_the_valley",
     "displayName": "Lily of the Valley",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lily_of_the_valley",
+    "stackSize": 64
   },
   {
     "id": 185,
-    "name": "wither_rose",
     "displayName": "Wither Rose",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "wither_rose",
+    "stackSize": 64
   },
   {
     "id": 186,
-    "name": "spore_blossom",
     "displayName": "Spore Blossom",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spore_blossom",
+    "stackSize": 64
   },
   {
     "id": 187,
-    "name": "brown_mushroom",
     "displayName": "Brown Mushroom",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "brown_mushroom",
+    "stackSize": 64
   },
   {
     "id": 188,
-    "name": "red_mushroom",
     "displayName": "Red Mushroom",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "red_mushroom",
+    "stackSize": 64
   },
   {
     "id": 189,
-    "name": "crimson_fungus",
     "displayName": "Crimson Fungus",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crimson_fungus",
+    "stackSize": 64
   },
   {
     "id": 190,
-    "name": "warped_fungus",
     "displayName": "Warped Fungus",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "warped_fungus",
+    "stackSize": 64
   },
   {
     "id": 191,
-    "name": "crimson_roots",
     "displayName": "Crimson Roots",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crimson_roots",
+    "stackSize": 64
   },
   {
     "id": 192,
-    "name": "warped_roots",
     "displayName": "Warped Roots",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "warped_roots",
+    "stackSize": 64
   },
   {
     "id": 193,
-    "name": "nether_sprouts",
     "displayName": "Nether Sprouts",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "nether_sprouts",
+    "stackSize": 64
   },
   {
     "id": 194,
-    "name": "weeping_vines",
     "displayName": "Weeping Vines",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "weeping_vines",
+    "stackSize": 64
   },
   {
     "id": 195,
-    "name": "twisting_vines",
     "displayName": "Twisting Vines",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "twisting_vines",
+    "stackSize": 64
   },
   {
     "id": 196,
-    "name": "sugar_cane",
     "displayName": "Sugar Cane",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "sugar_cane",
+    "stackSize": 64
   },
   {
     "id": 197,
-    "name": "kelp",
     "displayName": "Kelp",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "kelp",
+    "stackSize": 64
   },
   {
     "id": 198,
-    "name": "moss_carpet",
     "displayName": "Moss Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "moss_carpet",
+    "stackSize": 64
   },
   {
     "id": 199,
-    "name": "moss_block",
     "displayName": "Moss Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "moss_block",
+    "stackSize": 64
   },
   {
     "id": 200,
-    "name": "hanging_roots",
     "displayName": "Hanging Roots",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "hanging_roots",
+    "stackSize": 64
   },
   {
     "id": 201,
-    "name": "big_dripleaf",
     "displayName": "Big Dripleaf",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "big_dripleaf",
+    "stackSize": 64
   },
   {
     "id": 202,
-    "name": "small_dripleaf",
     "displayName": "Small Dripleaf",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "small_dripleaf",
+    "stackSize": 64
   },
   {
     "id": 203,
-    "name": "bamboo",
     "displayName": "Bamboo",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bamboo",
+    "stackSize": 64
   },
   {
     "id": 204,
-    "name": "oak_slab",
     "displayName": "Oak Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oak_slab",
+    "stackSize": 64
   },
   {
     "id": 205,
-    "name": "spruce_slab",
     "displayName": "Spruce Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spruce_slab",
+    "stackSize": 64
   },
   {
     "id": 206,
-    "name": "birch_slab",
     "displayName": "Birch Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "birch_slab",
+    "stackSize": 64
   },
   {
     "id": 207,
-    "name": "jungle_slab",
     "displayName": "Jungle Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "jungle_slab",
+    "stackSize": 64
   },
   {
     "id": 208,
-    "name": "acacia_slab",
     "displayName": "Acacia Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "acacia_slab",
+    "stackSize": 64
   },
   {
     "id": 209,
-    "name": "dark_oak_slab",
     "displayName": "Dark Oak Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dark_oak_slab",
+    "stackSize": 64
   },
   {
     "id": 210,
-    "name": "crimson_slab",
     "displayName": "Crimson Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crimson_slab",
+    "stackSize": 64
   },
   {
     "id": 211,
-    "name": "warped_slab",
     "displayName": "Warped Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "warped_slab",
+    "stackSize": 64
   },
   {
     "id": 212,
-    "name": "stone_slab",
     "displayName": "Stone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stone_slab",
+    "stackSize": 64
   },
   {
     "id": 213,
-    "name": "smooth_stone_slab",
     "displayName": "Smooth Stone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "smooth_stone_slab",
+    "stackSize": 64
   },
   {
     "id": 214,
-    "name": "sandstone_slab",
     "displayName": "Sandstone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "sandstone_slab",
+    "stackSize": 64
   },
   {
     "id": 215,
-    "name": "cut_sandstone_slab",
     "displayName": "Cut Sandstone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cut_sandstone_slab",
+    "stackSize": 64
   },
   {
     "id": 216,
-    "name": "petrified_oak_slab",
     "displayName": "Petrified Oak Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "petrified_oak_slab",
+    "stackSize": 64
   },
   {
     "id": 217,
-    "name": "cobblestone_slab",
     "displayName": "Cobblestone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cobblestone_slab",
+    "stackSize": 64
   },
   {
     "id": 218,
-    "name": "brick_slab",
     "displayName": "Brick Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "brick_slab",
+    "stackSize": 64
   },
   {
     "id": 219,
-    "name": "stone_brick_slab",
     "displayName": "Stone Brick Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stone_brick_slab",
+    "stackSize": 64
   },
   {
     "id": 220,
-    "name": "nether_brick_slab",
     "displayName": "Nether Brick Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "nether_brick_slab",
+    "stackSize": 64
   },
   {
     "id": 221,
-    "name": "quartz_slab",
     "displayName": "Quartz Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "quartz_slab",
+    "stackSize": 64
   },
   {
     "id": 222,
-    "name": "red_sandstone_slab",
     "displayName": "Red Sandstone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "red_sandstone_slab",
+    "stackSize": 64
   },
   {
     "id": 223,
-    "name": "cut_red_sandstone_slab",
     "displayName": "Cut Red Sandstone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cut_red_sandstone_slab",
+    "stackSize": 64
   },
   {
     "id": 224,
-    "name": "purpur_slab",
     "displayName": "Purpur Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "purpur_slab",
+    "stackSize": 64
   },
   {
     "id": 225,
-    "name": "prismarine_slab",
     "displayName": "Prismarine Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "prismarine_slab",
+    "stackSize": 64
   },
   {
     "id": 226,
-    "name": "prismarine_brick_slab",
     "displayName": "Prismarine Brick Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "prismarine_brick_slab",
+    "stackSize": 64
   },
   {
     "id": 227,
-    "name": "dark_prismarine_slab",
     "displayName": "Dark Prismarine Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dark_prismarine_slab",
+    "stackSize": 64
   },
   {
     "id": 228,
-    "name": "smooth_quartz",
     "displayName": "Smooth Quartz Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "smooth_quartz",
+    "stackSize": 64
   },
   {
     "id": 229,
-    "name": "smooth_red_sandstone",
     "displayName": "Smooth Red Sandstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "smooth_red_sandstone",
+    "stackSize": 64
   },
   {
     "id": 230,
-    "name": "smooth_sandstone",
     "displayName": "Smooth Sandstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "smooth_sandstone",
+    "stackSize": 64
   },
   {
     "id": 231,
-    "name": "smooth_stone",
     "displayName": "Smooth Stone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "smooth_stone",
+    "stackSize": 64
   },
   {
     "id": 232,
-    "name": "bricks",
     "displayName": "Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bricks",
+    "stackSize": 64
   },
   {
     "id": 233,
-    "name": "bookshelf",
     "displayName": "Bookshelf",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bookshelf",
+    "stackSize": 64
   },
   {
     "id": 234,
-    "name": "mossy_cobblestone",
     "displayName": "Mossy Cobblestone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "mossy_cobblestone",
+    "stackSize": 64
   },
   {
     "id": 235,
-    "name": "obsidian",
     "displayName": "Obsidian",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "obsidian",
+    "stackSize": 64
   },
   {
     "id": 236,
-    "name": "torch",
     "displayName": "Torch",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "torch",
+    "stackSize": 64
   },
   {
     "id": 237,
-    "name": "end_rod",
     "displayName": "End Rod",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "end_rod",
+    "stackSize": 64
   },
   {
     "id": 238,
-    "name": "chorus_plant",
     "displayName": "Chorus Plant",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "chorus_plant",
+    "stackSize": 64
   },
   {
     "id": 239,
-    "name": "chorus_flower",
     "displayName": "Chorus Flower",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "chorus_flower",
+    "stackSize": 64
   },
   {
     "id": 240,
-    "name": "purpur_block",
     "displayName": "Purpur Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "purpur_block",
+    "stackSize": 64
   },
   {
     "id": 241,
-    "name": "purpur_pillar",
     "displayName": "Purpur Pillar",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "purpur_pillar",
+    "stackSize": 64
   },
   {
     "id": 242,
-    "name": "purpur_stairs",
     "displayName": "Purpur Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "purpur_stairs",
+    "stackSize": 64
   },
   {
     "id": 243,
-    "name": "spawner",
     "displayName": "Spawner",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spawner",
+    "stackSize": 64
   },
   {
     "id": 244,
-    "name": "oak_stairs",
     "displayName": "Oak Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oak_stairs",
+    "stackSize": 64
   },
   {
     "id": 245,
-    "name": "chest",
     "displayName": "Chest",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "chest",
+    "stackSize": 64
   },
   {
     "id": 246,
-    "name": "crafting_table",
     "displayName": "Crafting Table",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crafting_table",
+    "stackSize": 64
   },
   {
     "id": 247,
-    "name": "farmland",
     "displayName": "Farmland",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "farmland",
+    "stackSize": 64
   },
   {
     "id": 248,
-    "name": "furnace",
     "displayName": "Furnace",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "furnace",
+    "stackSize": 64
   },
   {
     "id": 249,
-    "name": "ladder",
     "displayName": "Ladder",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "ladder",
+    "stackSize": 64
   },
   {
     "id": 250,
-    "name": "cobblestone_stairs",
     "displayName": "Cobblestone Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cobblestone_stairs",
+    "stackSize": 64
   },
   {
     "id": 251,
-    "name": "snow",
     "displayName": "Snow",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "snow",
+    "stackSize": 64
   },
   {
     "id": 252,
-    "name": "ice",
     "displayName": "Ice",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "ice",
+    "stackSize": 64
   },
   {
     "id": 253,
-    "name": "snow_block",
     "displayName": "Snow Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "snow_block",
+    "stackSize": 64
   },
   {
     "id": 254,
-    "name": "cactus",
     "displayName": "Cactus",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cactus",
+    "stackSize": 64
   },
   {
     "id": 255,
-    "name": "clay",
     "displayName": "Clay",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "clay",
+    "stackSize": 64
   },
   {
     "id": 256,
-    "name": "jukebox",
     "displayName": "Jukebox",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "jukebox",
+    "stackSize": 64
   },
   {
     "id": 257,
-    "name": "oak_fence",
     "displayName": "Oak Fence",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "oak_fence",
+    "stackSize": 64
   },
   {
     "id": 258,
-    "name": "spruce_fence",
     "displayName": "Spruce Fence",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spruce_fence",
+    "stackSize": 64
   },
   {
     "id": 259,
-    "name": "birch_fence",
     "displayName": "Birch Fence",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "birch_fence",
+    "stackSize": 64
   },
   {
     "id": 260,
-    "name": "jungle_fence",
     "displayName": "Jungle Fence",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "jungle_fence",
+    "stackSize": 64
   },
   {
     "id": 261,
-    "name": "acacia_fence",
     "displayName": "Acacia Fence",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "acacia_fence",
+    "stackSize": 64
   },
   {
     "id": 262,
-    "name": "dark_oak_fence",
     "displayName": "Dark Oak Fence",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dark_oak_fence",
+    "stackSize": 64
   },
   {
     "id": 263,
-    "name": "crimson_fence",
     "displayName": "Crimson Fence",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crimson_fence",
+    "stackSize": 64
   },
   {
     "id": 264,
-    "name": "warped_fence",
     "displayName": "Warped Fence",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "warped_fence",
+    "stackSize": 64
   },
   {
     "id": 265,
-    "name": "pumpkin",
     "displayName": "Pumpkin",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pumpkin",
+    "stackSize": 64
   },
   {
     "id": 266,
-    "name": "carved_pumpkin",
     "displayName": "Carved Pumpkin",
+    "name": "carved_pumpkin",
     "stackSize": 64,
     "enchantCategories": [
       "wearable",
@@ -1873,2910 +1607,2495 @@
   },
   {
     "id": 267,
-    "name": "jack_o_lantern",
     "displayName": "Jack o'Lantern",
-    "stackSize": 64,
+    "name": "jack_o_lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 268,
+    "displayName": "Netherrack",
+    "name": "netherrack",
+    "stackSize": 64
+  },
+  {
+    "id": 269,
+    "displayName": "Soul Sand",
+    "name": "soul_sand",
+    "stackSize": 64
+  },
+  {
+    "id": 270,
+    "displayName": "Soul Soil",
+    "name": "soul_soil",
+    "stackSize": 64
+  },
+  {
+    "id": 271,
+    "displayName": "Basalt",
+    "name": "basalt",
+    "stackSize": 64
+  },
+  {
+    "id": 272,
+    "displayName": "Polished Basalt",
+    "name": "polished_basalt",
+    "stackSize": 64
+  },
+  {
+    "id": 273,
+    "displayName": "Smooth Basalt",
+    "name": "smooth_basalt",
+    "stackSize": 64
+  },
+  {
+    "id": 274,
+    "displayName": "Soul Torch",
+    "name": "soul_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 275,
+    "displayName": "Glowstone",
+    "name": "glowstone",
+    "stackSize": 64
+  },
+  {
+    "id": 276,
+    "displayName": "Infested Stone",
+    "name": "infested_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 277,
+    "displayName": "Infested Cobblestone",
+    "name": "infested_cobblestone",
+    "stackSize": 64
+  },
+  {
+    "id": 278,
+    "displayName": "Infested Stone Bricks",
+    "name": "infested_stone_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 279,
+    "displayName": "Infested Mossy Stone Bricks",
+    "name": "infested_mossy_stone_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 280,
+    "displayName": "Infested Cracked Stone Bricks",
+    "name": "infested_cracked_stone_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 281,
+    "displayName": "Infested Chiseled Stone Bricks",
+    "name": "infested_chiseled_stone_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 282,
+    "displayName": "Infested Deepslate",
+    "name": "infested_deepslate",
+    "stackSize": 64
+  },
+  {
+    "id": 283,
+    "displayName": "Stone Bricks",
+    "name": "stone_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 284,
+    "displayName": "Mossy Stone Bricks",
+    "name": "mossy_stone_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 285,
+    "displayName": "Cracked Stone Bricks",
+    "name": "cracked_stone_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 286,
+    "displayName": "Chiseled Stone Bricks",
+    "name": "chiseled_stone_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 287,
+    "displayName": "Deepslate Bricks",
+    "name": "deepslate_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 288,
+    "displayName": "Cracked Deepslate Bricks",
+    "name": "cracked_deepslate_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 289,
+    "displayName": "Deepslate Tiles",
+    "name": "deepslate_tiles",
+    "stackSize": 64
+  },
+  {
+    "id": 290,
+    "displayName": "Cracked Deepslate Tiles",
+    "name": "cracked_deepslate_tiles",
+    "stackSize": 64
+  },
+  {
+    "id": 291,
+    "displayName": "Chiseled Deepslate",
+    "name": "chiseled_deepslate",
+    "stackSize": 64
+  },
+  {
+    "id": 292,
+    "displayName": "Brown Mushroom Block",
+    "name": "brown_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 293,
+    "displayName": "Red Mushroom Block",
+    "name": "red_mushroom_block",
+    "stackSize": 64
+  },
+  {
+    "id": 294,
+    "displayName": "Mushroom Stem",
+    "name": "mushroom_stem",
+    "stackSize": 64
+  },
+  {
+    "id": 295,
+    "displayName": "Iron Bars",
+    "name": "iron_bars",
+    "stackSize": 64
+  },
+  {
+    "id": 296,
+    "displayName": "Chain",
+    "name": "chain",
+    "stackSize": 64
+  },
+  {
+    "id": 297,
+    "displayName": "Glass Pane",
+    "name": "glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 298,
+    "displayName": "Melon",
+    "name": "melon",
+    "stackSize": 64
+  },
+  {
+    "id": 299,
+    "displayName": "Vines",
+    "name": "vine",
+    "stackSize": 64
+  },
+  {
+    "id": 300,
+    "displayName": "Glow Lichen",
+    "name": "glow_lichen",
+    "stackSize": 64
+  },
+  {
+    "id": 301,
+    "displayName": "Brick Stairs",
+    "name": "brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 302,
+    "displayName": "Stone Brick Stairs",
+    "name": "stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 303,
+    "displayName": "Mycelium",
+    "name": "mycelium",
+    "stackSize": 64
+  },
+  {
+    "id": 304,
+    "displayName": "Lily Pad",
+    "name": "lily_pad",
+    "stackSize": 64
+  },
+  {
+    "id": 305,
+    "displayName": "Nether Bricks",
+    "name": "nether_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 306,
+    "displayName": "Cracked Nether Bricks",
+    "name": "cracked_nether_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 307,
+    "displayName": "Chiseled Nether Bricks",
+    "name": "chiseled_nether_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 308,
+    "displayName": "Nether Brick Fence",
+    "name": "nether_brick_fence",
+    "stackSize": 64
+  },
+  {
+    "id": 309,
+    "displayName": "Nether Brick Stairs",
+    "name": "nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 310,
+    "displayName": "Enchanting Table",
+    "name": "enchanting_table",
+    "stackSize": 64
+  },
+  {
+    "id": 311,
+    "displayName": "End Portal Frame",
+    "name": "end_portal_frame",
+    "stackSize": 64
+  },
+  {
+    "id": 312,
+    "displayName": "End Stone",
+    "name": "end_stone",
+    "stackSize": 64
+  },
+  {
+    "id": 313,
+    "displayName": "End Stone Bricks",
+    "name": "end_stone_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 314,
+    "displayName": "Dragon Egg",
+    "name": "dragon_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 315,
+    "displayName": "Sandstone Stairs",
+    "name": "sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 316,
+    "displayName": "Ender Chest",
+    "name": "ender_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 317,
+    "displayName": "Block of Emerald",
+    "name": "emerald_block",
+    "stackSize": 64
+  },
+  {
+    "id": 318,
+    "displayName": "Spruce Stairs",
+    "name": "spruce_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 319,
+    "displayName": "Birch Stairs",
+    "name": "birch_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 320,
+    "displayName": "Jungle Stairs",
+    "name": "jungle_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 321,
+    "displayName": "Crimson Stairs",
+    "name": "crimson_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 322,
+    "displayName": "Warped Stairs",
+    "name": "warped_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 323,
+    "displayName": "Command Block",
+    "name": "command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 324,
+    "displayName": "Beacon",
+    "name": "beacon",
+    "stackSize": 64
+  },
+  {
+    "id": 325,
+    "displayName": "Cobblestone Wall",
+    "name": "cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 326,
+    "displayName": "Mossy Cobblestone Wall",
+    "name": "mossy_cobblestone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 327,
+    "displayName": "Brick Wall",
+    "name": "brick_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 328,
+    "displayName": "Prismarine Wall",
+    "name": "prismarine_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 329,
+    "displayName": "Red Sandstone Wall",
+    "name": "red_sandstone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 330,
+    "displayName": "Mossy Stone Brick Wall",
+    "name": "mossy_stone_brick_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 331,
+    "displayName": "Granite Wall",
+    "name": "granite_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 332,
+    "displayName": "Stone Brick Wall",
+    "name": "stone_brick_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 333,
+    "displayName": "Nether Brick Wall",
+    "name": "nether_brick_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 334,
+    "displayName": "Andesite Wall",
+    "name": "andesite_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 335,
+    "displayName": "Red Nether Brick Wall",
+    "name": "red_nether_brick_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 336,
+    "displayName": "Sandstone Wall",
+    "name": "sandstone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 337,
+    "displayName": "End Stone Brick Wall",
+    "name": "end_stone_brick_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 338,
+    "displayName": "Diorite Wall",
+    "name": "diorite_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 339,
+    "displayName": "Blackstone Wall",
+    "name": "blackstone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 340,
+    "displayName": "Polished Blackstone Wall",
+    "name": "polished_blackstone_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 341,
+    "displayName": "Polished Blackstone Brick Wall",
+    "name": "polished_blackstone_brick_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 342,
+    "displayName": "Cobbled Deepslate Wall",
+    "name": "cobbled_deepslate_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 343,
+    "displayName": "Polished Deepslate Wall",
+    "name": "polished_deepslate_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 344,
+    "displayName": "Deepslate Brick Wall",
+    "name": "deepslate_brick_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 345,
+    "displayName": "Deepslate Tile Wall",
+    "name": "deepslate_tile_wall",
+    "stackSize": 64
+  },
+  {
+    "id": 346,
+    "displayName": "Anvil",
+    "name": "anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 347,
+    "displayName": "Chipped Anvil",
+    "name": "chipped_anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 348,
+    "displayName": "Damaged Anvil",
+    "name": "damaged_anvil",
+    "stackSize": 64
+  },
+  {
+    "id": 349,
+    "displayName": "Chiseled Quartz Block",
+    "name": "chiseled_quartz_block",
+    "stackSize": 64
+  },
+  {
+    "id": 350,
+    "displayName": "Block of Quartz",
+    "name": "quartz_block",
+    "stackSize": 64
+  },
+  {
+    "id": 351,
+    "displayName": "Quartz Bricks",
+    "name": "quartz_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 352,
+    "displayName": "Quartz Pillar",
+    "name": "quartz_pillar",
+    "stackSize": 64
+  },
+  {
+    "id": 353,
+    "displayName": "Quartz Stairs",
+    "name": "quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 354,
+    "displayName": "White Terracotta",
+    "name": "white_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 355,
+    "displayName": "Orange Terracotta",
+    "name": "orange_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 356,
+    "displayName": "Magenta Terracotta",
+    "name": "magenta_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 357,
+    "displayName": "Light Blue Terracotta",
+    "name": "light_blue_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 358,
+    "displayName": "Yellow Terracotta",
+    "name": "yellow_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 359,
+    "displayName": "Lime Terracotta",
+    "name": "lime_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 360,
+    "displayName": "Pink Terracotta",
+    "name": "pink_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 361,
+    "displayName": "Gray Terracotta",
+    "name": "gray_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 362,
+    "displayName": "Light Gray Terracotta",
+    "name": "light_gray_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 363,
+    "displayName": "Cyan Terracotta",
+    "name": "cyan_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 364,
+    "displayName": "Purple Terracotta",
+    "name": "purple_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 365,
+    "displayName": "Blue Terracotta",
+    "name": "blue_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 366,
+    "displayName": "Brown Terracotta",
+    "name": "brown_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 367,
+    "displayName": "Green Terracotta",
+    "name": "green_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 368,
+    "displayName": "Red Terracotta",
+    "name": "red_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 369,
+    "displayName": "Black Terracotta",
+    "name": "black_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 370,
+    "displayName": "Barrier",
+    "name": "barrier",
+    "stackSize": 64
+  },
+  {
+    "id": 371,
+    "displayName": "Light",
+    "name": "light",
+    "stackSize": 64
+  },
+  {
+    "id": 372,
+    "displayName": "Hay Bale",
+    "name": "hay_block",
+    "stackSize": 64
+  },
+  {
+    "id": 373,
+    "displayName": "White Carpet",
+    "name": "white_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 374,
+    "displayName": "Orange Carpet",
+    "name": "orange_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 375,
+    "displayName": "Magenta Carpet",
+    "name": "magenta_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 376,
+    "displayName": "Light Blue Carpet",
+    "name": "light_blue_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 377,
+    "displayName": "Yellow Carpet",
+    "name": "yellow_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 378,
+    "displayName": "Lime Carpet",
+    "name": "lime_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 379,
+    "displayName": "Pink Carpet",
+    "name": "pink_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 380,
+    "displayName": "Gray Carpet",
+    "name": "gray_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 381,
+    "displayName": "Light Gray Carpet",
+    "name": "light_gray_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 382,
+    "displayName": "Cyan Carpet",
+    "name": "cyan_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 383,
+    "displayName": "Purple Carpet",
+    "name": "purple_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 384,
+    "displayName": "Blue Carpet",
+    "name": "blue_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 385,
+    "displayName": "Brown Carpet",
+    "name": "brown_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 386,
+    "displayName": "Green Carpet",
+    "name": "green_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 387,
+    "displayName": "Red Carpet",
+    "name": "red_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 388,
+    "displayName": "Black Carpet",
+    "name": "black_carpet",
+    "stackSize": 64
+  },
+  {
+    "id": 389,
+    "displayName": "Terracotta",
+    "name": "terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 390,
+    "displayName": "Packed Ice",
+    "name": "packed_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 391,
+    "displayName": "Acacia Stairs",
+    "name": "acacia_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 392,
+    "displayName": "Dark Oak Stairs",
+    "name": "dark_oak_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 393,
+    "displayName": "Dirt Path",
+    "name": "dirt_path",
+    "stackSize": 64
+  },
+  {
+    "id": 394,
+    "displayName": "Sunflower",
+    "name": "sunflower",
+    "stackSize": 64
+  },
+  {
+    "id": 395,
+    "displayName": "Lilac",
+    "name": "lilac",
+    "stackSize": 64
+  },
+  {
+    "id": 396,
+    "displayName": "Rose Bush",
+    "name": "rose_bush",
+    "stackSize": 64
+  },
+  {
+    "id": 397,
+    "displayName": "Peony",
+    "name": "peony",
+    "stackSize": 64
+  },
+  {
+    "id": 398,
+    "displayName": "Tall Grass",
+    "name": "tall_grass",
+    "stackSize": 64
+  },
+  {
+    "id": 399,
+    "displayName": "Large Fern",
+    "name": "large_fern",
+    "stackSize": 64
+  },
+  {
+    "id": 400,
+    "displayName": "White Stained Glass",
+    "name": "white_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 401,
+    "displayName": "Orange Stained Glass",
+    "name": "orange_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 402,
+    "displayName": "Magenta Stained Glass",
+    "name": "magenta_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 403,
+    "displayName": "Light Blue Stained Glass",
+    "name": "light_blue_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 404,
+    "displayName": "Yellow Stained Glass",
+    "name": "yellow_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 405,
+    "displayName": "Lime Stained Glass",
+    "name": "lime_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 406,
+    "displayName": "Pink Stained Glass",
+    "name": "pink_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 407,
+    "displayName": "Gray Stained Glass",
+    "name": "gray_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 408,
+    "displayName": "Light Gray Stained Glass",
+    "name": "light_gray_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 409,
+    "displayName": "Cyan Stained Glass",
+    "name": "cyan_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 410,
+    "displayName": "Purple Stained Glass",
+    "name": "purple_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 411,
+    "displayName": "Blue Stained Glass",
+    "name": "blue_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 412,
+    "displayName": "Brown Stained Glass",
+    "name": "brown_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 413,
+    "displayName": "Green Stained Glass",
+    "name": "green_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 414,
+    "displayName": "Red Stained Glass",
+    "name": "red_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 415,
+    "displayName": "Black Stained Glass",
+    "name": "black_stained_glass",
+    "stackSize": 64
+  },
+  {
+    "id": 416,
+    "displayName": "White Stained Glass Pane",
+    "name": "white_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 417,
+    "displayName": "Orange Stained Glass Pane",
+    "name": "orange_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 418,
+    "displayName": "Magenta Stained Glass Pane",
+    "name": "magenta_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 419,
+    "displayName": "Light Blue Stained Glass Pane",
+    "name": "light_blue_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 420,
+    "displayName": "Yellow Stained Glass Pane",
+    "name": "yellow_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 421,
+    "displayName": "Lime Stained Glass Pane",
+    "name": "lime_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 422,
+    "displayName": "Pink Stained Glass Pane",
+    "name": "pink_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 423,
+    "displayName": "Gray Stained Glass Pane",
+    "name": "gray_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 424,
+    "displayName": "Light Gray Stained Glass Pane",
+    "name": "light_gray_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 425,
+    "displayName": "Cyan Stained Glass Pane",
+    "name": "cyan_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 426,
+    "displayName": "Purple Stained Glass Pane",
+    "name": "purple_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 427,
+    "displayName": "Blue Stained Glass Pane",
+    "name": "blue_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 428,
+    "displayName": "Brown Stained Glass Pane",
+    "name": "brown_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 429,
+    "displayName": "Green Stained Glass Pane",
+    "name": "green_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 430,
+    "displayName": "Red Stained Glass Pane",
+    "name": "red_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 431,
+    "displayName": "Black Stained Glass Pane",
+    "name": "black_stained_glass_pane",
+    "stackSize": 64
+  },
+  {
+    "id": 432,
+    "displayName": "Prismarine",
+    "name": "prismarine",
+    "stackSize": 64
+  },
+  {
+    "id": 433,
+    "displayName": "Prismarine Bricks",
+    "name": "prismarine_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 434,
+    "displayName": "Dark Prismarine",
+    "name": "dark_prismarine",
+    "stackSize": 64
+  },
+  {
+    "id": 435,
+    "displayName": "Prismarine Stairs",
+    "name": "prismarine_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 436,
+    "displayName": "Prismarine Brick Stairs",
+    "name": "prismarine_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 437,
+    "displayName": "Dark Prismarine Stairs",
+    "name": "dark_prismarine_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 438,
+    "displayName": "Sea Lantern",
+    "name": "sea_lantern",
+    "stackSize": 64
+  },
+  {
+    "id": 439,
+    "displayName": "Red Sandstone",
+    "name": "red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 440,
+    "displayName": "Chiseled Red Sandstone",
+    "name": "chiseled_red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 441,
+    "displayName": "Cut Red Sandstone",
+    "name": "cut_red_sandstone",
+    "stackSize": 64
+  },
+  {
+    "id": 442,
+    "displayName": "Red Sandstone Stairs",
+    "name": "red_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 443,
+    "displayName": "Repeating Command Block",
+    "name": "repeating_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 444,
+    "displayName": "Chain Command Block",
+    "name": "chain_command_block",
+    "stackSize": 64
+  },
+  {
+    "id": 445,
+    "displayName": "Magma Block",
+    "name": "magma_block",
+    "stackSize": 64
+  },
+  {
+    "id": 446,
+    "displayName": "Nether Wart Block",
+    "name": "nether_wart_block",
+    "stackSize": 64
+  },
+  {
+    "id": 447,
+    "displayName": "Warped Wart Block",
+    "name": "warped_wart_block",
+    "stackSize": 64
+  },
+  {
+    "id": 448,
+    "displayName": "Red Nether Bricks",
+    "name": "red_nether_bricks",
+    "stackSize": 64
+  },
+  {
+    "id": 449,
+    "displayName": "Bone Block",
+    "name": "bone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 450,
+    "displayName": "Structure Void",
+    "name": "structure_void",
+    "stackSize": 64
+  },
+  {
+    "id": 451,
+    "displayName": "Shulker Box",
+    "name": "shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 452,
+    "displayName": "White Shulker Box",
+    "name": "white_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 453,
+    "displayName": "Orange Shulker Box",
+    "name": "orange_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 454,
+    "displayName": "Magenta Shulker Box",
+    "name": "magenta_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 455,
+    "displayName": "Light Blue Shulker Box",
+    "name": "light_blue_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 456,
+    "displayName": "Yellow Shulker Box",
+    "name": "yellow_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 457,
+    "displayName": "Lime Shulker Box",
+    "name": "lime_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 458,
+    "displayName": "Pink Shulker Box",
+    "name": "pink_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 459,
+    "displayName": "Gray Shulker Box",
+    "name": "gray_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 460,
+    "displayName": "Light Gray Shulker Box",
+    "name": "light_gray_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 461,
+    "displayName": "Cyan Shulker Box",
+    "name": "cyan_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 462,
+    "displayName": "Purple Shulker Box",
+    "name": "purple_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 463,
+    "displayName": "Blue Shulker Box",
+    "name": "blue_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 464,
+    "displayName": "Brown Shulker Box",
+    "name": "brown_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 465,
+    "displayName": "Green Shulker Box",
+    "name": "green_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 466,
+    "displayName": "Red Shulker Box",
+    "name": "red_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 467,
+    "displayName": "Black Shulker Box",
+    "name": "black_shulker_box",
+    "stackSize": 1
+  },
+  {
+    "id": 468,
+    "displayName": "White Glazed Terracotta",
+    "name": "white_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 469,
+    "displayName": "Orange Glazed Terracotta",
+    "name": "orange_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 470,
+    "displayName": "Magenta Glazed Terracotta",
+    "name": "magenta_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 471,
+    "displayName": "Light Blue Glazed Terracotta",
+    "name": "light_blue_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 472,
+    "displayName": "Yellow Glazed Terracotta",
+    "name": "yellow_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 473,
+    "displayName": "Lime Glazed Terracotta",
+    "name": "lime_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 474,
+    "displayName": "Pink Glazed Terracotta",
+    "name": "pink_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 475,
+    "displayName": "Gray Glazed Terracotta",
+    "name": "gray_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 476,
+    "displayName": "Light Gray Glazed Terracotta",
+    "name": "light_gray_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 477,
+    "displayName": "Cyan Glazed Terracotta",
+    "name": "cyan_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 478,
+    "displayName": "Purple Glazed Terracotta",
+    "name": "purple_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 479,
+    "displayName": "Blue Glazed Terracotta",
+    "name": "blue_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 480,
+    "displayName": "Brown Glazed Terracotta",
+    "name": "brown_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 481,
+    "displayName": "Green Glazed Terracotta",
+    "name": "green_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 482,
+    "displayName": "Red Glazed Terracotta",
+    "name": "red_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 483,
+    "displayName": "Black Glazed Terracotta",
+    "name": "black_glazed_terracotta",
+    "stackSize": 64
+  },
+  {
+    "id": 484,
+    "displayName": "White Concrete",
+    "name": "white_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 485,
+    "displayName": "Orange Concrete",
+    "name": "orange_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 486,
+    "displayName": "Magenta Concrete",
+    "name": "magenta_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 487,
+    "displayName": "Light Blue Concrete",
+    "name": "light_blue_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 488,
+    "displayName": "Yellow Concrete",
+    "name": "yellow_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 489,
+    "displayName": "Lime Concrete",
+    "name": "lime_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 490,
+    "displayName": "Pink Concrete",
+    "name": "pink_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 491,
+    "displayName": "Gray Concrete",
+    "name": "gray_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 492,
+    "displayName": "Light Gray Concrete",
+    "name": "light_gray_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 493,
+    "displayName": "Cyan Concrete",
+    "name": "cyan_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 494,
+    "displayName": "Purple Concrete",
+    "name": "purple_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 495,
+    "displayName": "Blue Concrete",
+    "name": "blue_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 496,
+    "displayName": "Brown Concrete",
+    "name": "brown_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 497,
+    "displayName": "Green Concrete",
+    "name": "green_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 498,
+    "displayName": "Red Concrete",
+    "name": "red_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 499,
+    "displayName": "Black Concrete",
+    "name": "black_concrete",
+    "stackSize": 64
+  },
+  {
+    "id": 500,
+    "displayName": "White Concrete Powder",
+    "name": "white_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 501,
+    "displayName": "Orange Concrete Powder",
+    "name": "orange_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 502,
+    "displayName": "Magenta Concrete Powder",
+    "name": "magenta_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 503,
+    "displayName": "Light Blue Concrete Powder",
+    "name": "light_blue_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 504,
+    "displayName": "Yellow Concrete Powder",
+    "name": "yellow_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 505,
+    "displayName": "Lime Concrete Powder",
+    "name": "lime_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 506,
+    "displayName": "Pink Concrete Powder",
+    "name": "pink_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 507,
+    "displayName": "Gray Concrete Powder",
+    "name": "gray_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 508,
+    "displayName": "Light Gray Concrete Powder",
+    "name": "light_gray_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 509,
+    "displayName": "Cyan Concrete Powder",
+    "name": "cyan_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 510,
+    "displayName": "Purple Concrete Powder",
+    "name": "purple_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 511,
+    "displayName": "Blue Concrete Powder",
+    "name": "blue_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 512,
+    "displayName": "Brown Concrete Powder",
+    "name": "brown_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 513,
+    "displayName": "Green Concrete Powder",
+    "name": "green_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 514,
+    "displayName": "Red Concrete Powder",
+    "name": "red_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 515,
+    "displayName": "Black Concrete Powder",
+    "name": "black_concrete_powder",
+    "stackSize": 64
+  },
+  {
+    "id": 516,
+    "displayName": "Turtle Egg",
+    "name": "turtle_egg",
+    "stackSize": 64
+  },
+  {
+    "id": 517,
+    "displayName": "Dead Tube Coral Block",
+    "name": "dead_tube_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 518,
+    "displayName": "Dead Brain Coral Block",
+    "name": "dead_brain_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 519,
+    "displayName": "Dead Bubble Coral Block",
+    "name": "dead_bubble_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 520,
+    "displayName": "Dead Fire Coral Block",
+    "name": "dead_fire_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 521,
+    "displayName": "Dead Horn Coral Block",
+    "name": "dead_horn_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 522,
+    "displayName": "Tube Coral Block",
+    "name": "tube_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 523,
+    "displayName": "Brain Coral Block",
+    "name": "brain_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 524,
+    "displayName": "Bubble Coral Block",
+    "name": "bubble_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 525,
+    "displayName": "Fire Coral Block",
+    "name": "fire_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 526,
+    "displayName": "Horn Coral Block",
+    "name": "horn_coral_block",
+    "stackSize": 64
+  },
+  {
+    "id": 527,
+    "displayName": "Tube Coral",
+    "name": "tube_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 528,
+    "displayName": "Brain Coral",
+    "name": "brain_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 529,
+    "displayName": "Bubble Coral",
+    "name": "bubble_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 530,
+    "displayName": "Fire Coral",
+    "name": "fire_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 531,
+    "displayName": "Horn Coral",
+    "name": "horn_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 532,
+    "displayName": "Dead Brain Coral",
+    "name": "dead_brain_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 533,
+    "displayName": "Dead Bubble Coral",
+    "name": "dead_bubble_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 534,
+    "displayName": "Dead Fire Coral",
+    "name": "dead_fire_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 535,
+    "displayName": "Dead Horn Coral",
+    "name": "dead_horn_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 536,
+    "displayName": "Dead Tube Coral",
+    "name": "dead_tube_coral",
+    "stackSize": 64
+  },
+  {
+    "id": 537,
+    "displayName": "Tube Coral Fan",
+    "name": "tube_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 538,
+    "displayName": "Brain Coral Fan",
+    "name": "brain_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 539,
+    "displayName": "Bubble Coral Fan",
+    "name": "bubble_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 540,
+    "displayName": "Fire Coral Fan",
+    "name": "fire_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 541,
+    "displayName": "Horn Coral Fan",
+    "name": "horn_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 542,
+    "displayName": "Dead Tube Coral Fan",
+    "name": "dead_tube_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 543,
+    "displayName": "Dead Brain Coral Fan",
+    "name": "dead_brain_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 544,
+    "displayName": "Dead Bubble Coral Fan",
+    "name": "dead_bubble_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 545,
+    "displayName": "Dead Fire Coral Fan",
+    "name": "dead_fire_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 546,
+    "displayName": "Dead Horn Coral Fan",
+    "name": "dead_horn_coral_fan",
+    "stackSize": 64
+  },
+  {
+    "id": 547,
+    "displayName": "Blue Ice",
+    "name": "blue_ice",
+    "stackSize": 64
+  },
+  {
+    "id": 548,
+    "displayName": "Conduit",
+    "name": "conduit",
+    "stackSize": 64
+  },
+  {
+    "id": 549,
+    "displayName": "Polished Granite Stairs",
+    "name": "polished_granite_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 550,
+    "displayName": "Smooth Red Sandstone Stairs",
+    "name": "smooth_red_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 551,
+    "displayName": "Mossy Stone Brick Stairs",
+    "name": "mossy_stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 552,
+    "displayName": "Polished Diorite Stairs",
+    "name": "polished_diorite_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 553,
+    "displayName": "Mossy Cobblestone Stairs",
+    "name": "mossy_cobblestone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 554,
+    "displayName": "End Stone Brick Stairs",
+    "name": "end_stone_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 555,
+    "displayName": "Stone Stairs",
+    "name": "stone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 556,
+    "displayName": "Smooth Sandstone Stairs",
+    "name": "smooth_sandstone_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 557,
+    "displayName": "Smooth Quartz Stairs",
+    "name": "smooth_quartz_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 558,
+    "displayName": "Granite Stairs",
+    "name": "granite_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 559,
+    "displayName": "Andesite Stairs",
+    "name": "andesite_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 560,
+    "displayName": "Red Nether Brick Stairs",
+    "name": "red_nether_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 561,
+    "displayName": "Polished Andesite Stairs",
+    "name": "polished_andesite_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 562,
+    "displayName": "Diorite Stairs",
+    "name": "diorite_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 563,
+    "displayName": "Cobbled Deepslate Stairs",
+    "name": "cobbled_deepslate_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 564,
+    "displayName": "Polished Deepslate Stairs",
+    "name": "polished_deepslate_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 565,
+    "displayName": "Deepslate Brick Stairs",
+    "name": "deepslate_brick_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 566,
+    "displayName": "Deepslate Tile Stairs",
+    "name": "deepslate_tile_stairs",
+    "stackSize": 64
+  },
+  {
+    "id": 567,
+    "displayName": "Polished Granite Slab",
+    "name": "polished_granite_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 568,
+    "displayName": "Smooth Red Sandstone Slab",
+    "name": "smooth_red_sandstone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 569,
+    "displayName": "Mossy Stone Brick Slab",
+    "name": "mossy_stone_brick_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 570,
+    "displayName": "Polished Diorite Slab",
+    "name": "polished_diorite_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 571,
+    "displayName": "Mossy Cobblestone Slab",
+    "name": "mossy_cobblestone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 572,
+    "displayName": "End Stone Brick Slab",
+    "name": "end_stone_brick_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 573,
+    "displayName": "Smooth Sandstone Slab",
+    "name": "smooth_sandstone_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 574,
+    "displayName": "Smooth Quartz Slab",
+    "name": "smooth_quartz_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 575,
+    "displayName": "Granite Slab",
+    "name": "granite_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 576,
+    "displayName": "Andesite Slab",
+    "name": "andesite_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 577,
+    "displayName": "Red Nether Brick Slab",
+    "name": "red_nether_brick_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 578,
+    "displayName": "Polished Andesite Slab",
+    "name": "polished_andesite_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 579,
+    "displayName": "Diorite Slab",
+    "name": "diorite_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 580,
+    "displayName": "Cobbled Deepslate Slab",
+    "name": "cobbled_deepslate_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 581,
+    "displayName": "Polished Deepslate Slab",
+    "name": "polished_deepslate_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 582,
+    "displayName": "Deepslate Brick Slab",
+    "name": "deepslate_brick_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 583,
+    "displayName": "Deepslate Tile Slab",
+    "name": "deepslate_tile_slab",
+    "stackSize": 64
+  },
+  {
+    "id": 584,
+    "displayName": "Scaffolding",
+    "name": "scaffolding",
+    "stackSize": 64
+  },
+  {
+    "id": 585,
+    "displayName": "Redstone Dust",
+    "name": "redstone",
+    "stackSize": 64
+  },
+  {
+    "id": 586,
+    "displayName": "Redstone Torch",
+    "name": "redstone_torch",
+    "stackSize": 64
+  },
+  {
+    "id": 587,
+    "displayName": "Block of Redstone",
+    "name": "redstone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 588,
+    "displayName": "Redstone Repeater",
+    "name": "repeater",
+    "stackSize": 64
+  },
+  {
+    "id": 589,
+    "displayName": "Redstone Comparator",
+    "name": "comparator",
+    "stackSize": 64
+  },
+  {
+    "id": 590,
+    "displayName": "Piston",
+    "name": "piston",
+    "stackSize": 64
+  },
+  {
+    "id": 591,
+    "displayName": "Sticky Piston",
+    "name": "sticky_piston",
+    "stackSize": 64
+  },
+  {
+    "id": 592,
+    "displayName": "Slime Block",
+    "name": "slime_block",
+    "stackSize": 64
+  },
+  {
+    "id": 593,
+    "displayName": "Honey Block",
+    "name": "honey_block",
+    "stackSize": 64
+  },
+  {
+    "id": 594,
+    "displayName": "Observer",
+    "name": "observer",
+    "stackSize": 64
+  },
+  {
+    "id": 595,
+    "displayName": "Hopper",
+    "name": "hopper",
+    "stackSize": 64
+  },
+  {
+    "id": 596,
+    "displayName": "Dispenser",
+    "name": "dispenser",
+    "stackSize": 64
+  },
+  {
+    "id": 597,
+    "displayName": "Dropper",
+    "name": "dropper",
+    "stackSize": 64
+  },
+  {
+    "id": 598,
+    "displayName": "Lectern",
+    "name": "lectern",
+    "stackSize": 64
+  },
+  {
+    "id": 599,
+    "displayName": "Target",
+    "name": "target",
+    "stackSize": 64
+  },
+  {
+    "id": 600,
+    "displayName": "Lever",
+    "name": "lever",
+    "stackSize": 64
+  },
+  {
+    "id": 601,
+    "displayName": "Lightning Rod",
+    "name": "lightning_rod",
+    "stackSize": 64
+  },
+  {
+    "id": 602,
+    "displayName": "Daylight Detector",
+    "name": "daylight_detector",
+    "stackSize": 64
+  },
+  {
+    "id": 603,
+    "displayName": "Sculk Sensor",
+    "name": "sculk_sensor",
+    "stackSize": 64
+  },
+  {
+    "id": 604,
+    "displayName": "Tripwire Hook",
+    "name": "tripwire_hook",
+    "stackSize": 64
+  },
+  {
+    "id": 605,
+    "displayName": "Trapped Chest",
+    "name": "trapped_chest",
+    "stackSize": 64
+  },
+  {
+    "id": 606,
+    "displayName": "TNT",
+    "name": "tnt",
+    "stackSize": 64
+  },
+  {
+    "id": 607,
+    "displayName": "Redstone Lamp",
+    "name": "redstone_lamp",
+    "stackSize": 64
+  },
+  {
+    "id": 608,
+    "displayName": "Note Block",
+    "name": "note_block",
+    "stackSize": 64
+  },
+  {
+    "id": 609,
+    "displayName": "Stone Button",
+    "name": "stone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 610,
+    "displayName": "Polished Blackstone Button",
+    "name": "polished_blackstone_button",
+    "stackSize": 64
+  },
+  {
+    "id": 611,
+    "displayName": "Oak Button",
+    "name": "oak_button",
+    "stackSize": 64
+  },
+  {
+    "id": 612,
+    "displayName": "Spruce Button",
+    "name": "spruce_button",
+    "stackSize": 64
+  },
+  {
+    "id": 613,
+    "displayName": "Birch Button",
+    "name": "birch_button",
+    "stackSize": 64
+  },
+  {
+    "id": 614,
+    "displayName": "Jungle Button",
+    "name": "jungle_button",
+    "stackSize": 64
+  },
+  {
+    "id": 615,
+    "displayName": "Acacia Button",
+    "name": "acacia_button",
+    "stackSize": 64
+  },
+  {
+    "id": 616,
+    "displayName": "Dark Oak Button",
+    "name": "dark_oak_button",
+    "stackSize": 64
+  },
+  {
+    "id": 617,
+    "displayName": "Crimson Button",
+    "name": "crimson_button",
+    "stackSize": 64
+  },
+  {
+    "id": 618,
+    "displayName": "Warped Button",
+    "name": "warped_button",
+    "stackSize": 64
+  },
+  {
+    "id": 619,
+    "displayName": "Stone Pressure Plate",
+    "name": "stone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 620,
+    "displayName": "Polished Blackstone Pressure Plate",
+    "name": "polished_blackstone_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 621,
+    "displayName": "Light Weighted Pressure Plate",
+    "name": "light_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 622,
+    "displayName": "Heavy Weighted Pressure Plate",
+    "name": "heavy_weighted_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 623,
+    "displayName": "Oak Pressure Plate",
+    "name": "oak_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 624,
+    "displayName": "Spruce Pressure Plate",
+    "name": "spruce_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 625,
+    "displayName": "Birch Pressure Plate",
+    "name": "birch_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 626,
+    "displayName": "Jungle Pressure Plate",
+    "name": "jungle_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 627,
+    "displayName": "Acacia Pressure Plate",
+    "name": "acacia_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 628,
+    "displayName": "Dark Oak Pressure Plate",
+    "name": "dark_oak_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 629,
+    "displayName": "Crimson Pressure Plate",
+    "name": "crimson_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 630,
+    "displayName": "Warped Pressure Plate",
+    "name": "warped_pressure_plate",
+    "stackSize": 64
+  },
+  {
+    "id": 631,
+    "displayName": "Iron Door",
+    "name": "iron_door",
+    "stackSize": 64
+  },
+  {
+    "id": 632,
+    "displayName": "Oak Door",
+    "name": "oak_door",
+    "stackSize": 64
+  },
+  {
+    "id": 633,
+    "displayName": "Spruce Door",
+    "name": "spruce_door",
+    "stackSize": 64
+  },
+  {
+    "id": 634,
+    "displayName": "Birch Door",
+    "name": "birch_door",
+    "stackSize": 64
+  },
+  {
+    "id": 635,
+    "displayName": "Jungle Door",
+    "name": "jungle_door",
+    "stackSize": 64
+  },
+  {
+    "id": 636,
+    "displayName": "Acacia Door",
+    "name": "acacia_door",
+    "stackSize": 64
+  },
+  {
+    "id": 637,
+    "displayName": "Dark Oak Door",
+    "name": "dark_oak_door",
+    "stackSize": 64
+  },
+  {
+    "id": 638,
+    "displayName": "Crimson Door",
+    "name": "crimson_door",
+    "stackSize": 64
+  },
+  {
+    "id": 639,
+    "displayName": "Warped Door",
+    "name": "warped_door",
+    "stackSize": 64
+  },
+  {
+    "id": 640,
+    "displayName": "Iron Trapdoor",
+    "name": "iron_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 641,
+    "displayName": "Oak Trapdoor",
+    "name": "oak_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 642,
+    "displayName": "Spruce Trapdoor",
+    "name": "spruce_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 643,
+    "displayName": "Birch Trapdoor",
+    "name": "birch_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 644,
+    "displayName": "Jungle Trapdoor",
+    "name": "jungle_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 645,
+    "displayName": "Acacia Trapdoor",
+    "name": "acacia_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 646,
+    "displayName": "Dark Oak Trapdoor",
+    "name": "dark_oak_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 647,
+    "displayName": "Crimson Trapdoor",
+    "name": "crimson_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 648,
+    "displayName": "Warped Trapdoor",
+    "name": "warped_trapdoor",
+    "stackSize": 64
+  },
+  {
+    "id": 649,
+    "displayName": "Oak Fence Gate",
+    "name": "oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 650,
+    "displayName": "Spruce Fence Gate",
+    "name": "spruce_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 651,
+    "displayName": "Birch Fence Gate",
+    "name": "birch_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 652,
+    "displayName": "Jungle Fence Gate",
+    "name": "jungle_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 653,
+    "displayName": "Acacia Fence Gate",
+    "name": "acacia_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 654,
+    "displayName": "Dark Oak Fence Gate",
+    "name": "dark_oak_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 655,
+    "displayName": "Crimson Fence Gate",
+    "name": "crimson_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 656,
+    "displayName": "Warped Fence Gate",
+    "name": "warped_fence_gate",
+    "stackSize": 64
+  },
+  {
+    "id": 657,
+    "displayName": "Powered Rail",
+    "name": "powered_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 658,
+    "displayName": "Detector Rail",
+    "name": "detector_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 659,
+    "displayName": "Rail",
+    "name": "rail",
+    "stackSize": 64
+  },
+  {
+    "id": 660,
+    "displayName": "Activator Rail",
+    "name": "activator_rail",
+    "stackSize": 64
+  },
+  {
+    "id": 661,
+    "displayName": "Saddle",
+    "name": "saddle",
+    "stackSize": 1
+  },
+  {
+    "id": 662,
+    "displayName": "Minecart",
+    "name": "minecart",
+    "stackSize": 1
+  },
+  {
+    "id": 663,
+    "displayName": "Minecart with Chest",
+    "name": "chest_minecart",
+    "stackSize": 1
+  },
+  {
+    "id": 664,
+    "displayName": "Minecart with Furnace",
+    "name": "furnace_minecart",
+    "stackSize": 1
+  },
+  {
+    "id": 665,
+    "displayName": "Minecart with TNT",
+    "name": "tnt_minecart",
+    "stackSize": 1
+  },
+  {
+    "id": 666,
+    "displayName": "Minecart with Hopper",
+    "name": "hopper_minecart",
+    "stackSize": 1
+  },
+  {
+    "id": 667,
+    "displayName": "Carrot on a Stick",
+    "name": "carrot_on_a_stick",
+    "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
-      "wearable",
+      "breakable",
       "vanishable"
     ]
   },
   {
-    "id": 268,
-    "name": "netherrack",
-    "displayName": "Netherrack",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 269,
-    "name": "soul_sand",
-    "displayName": "Soul Sand",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 270,
-    "name": "soul_soil",
-    "displayName": "Soul Soil",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 271,
-    "name": "basalt",
-    "displayName": "Basalt",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 272,
-    "name": "polished_basalt",
-    "displayName": "Polished Basalt",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 273,
-    "name": "smooth_basalt",
-    "displayName": "Smooth Basalt",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 274,
-    "name": "soul_torch",
-    "displayName": "Soul Torch",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 275,
-    "name": "glowstone",
-    "displayName": "Glowstone",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 276,
-    "name": "infested_stone",
-    "displayName": "Infested Stone",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 277,
-    "name": "infested_cobblestone",
-    "displayName": "Infested Cobblestone",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 278,
-    "name": "infested_stone_bricks",
-    "displayName": "Infested Stone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 279,
-    "name": "infested_mossy_stone_bricks",
-    "displayName": "Infested Mossy Stone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 280,
-    "name": "infested_cracked_stone_bricks",
-    "displayName": "Infested Cracked Stone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 281,
-    "name": "infested_chiseled_stone_bricks",
-    "displayName": "Infested Chiseled Stone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 282,
-    "name": "infested_deepslate",
-    "displayName": "Infested Deepslate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 283,
-    "name": "stone_bricks",
-    "displayName": "Stone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 284,
-    "name": "mossy_stone_bricks",
-    "displayName": "Mossy Stone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 285,
-    "name": "cracked_stone_bricks",
-    "displayName": "Cracked Stone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 286,
-    "name": "chiseled_stone_bricks",
-    "displayName": "Chiseled Stone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 287,
-    "name": "deepslate_bricks",
-    "displayName": "Deepslate Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 288,
-    "name": "cracked_deepslate_bricks",
-    "displayName": "Cracked Deepslate Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 289,
-    "name": "deepslate_tiles",
-    "displayName": "Deepslate Tiles",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 290,
-    "name": "cracked_deepslate_tiles",
-    "displayName": "Cracked Deepslate Tiles",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 291,
-    "name": "chiseled_deepslate",
-    "displayName": "Chiseled Deepslate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 292,
-    "name": "brown_mushroom_block",
-    "displayName": "Brown Mushroom Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 293,
-    "name": "red_mushroom_block",
-    "displayName": "Red Mushroom Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 294,
-    "name": "mushroom_stem",
-    "displayName": "Mushroom Stem",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 295,
-    "name": "iron_bars",
-    "displayName": "Iron Bars",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 296,
-    "name": "chain",
-    "displayName": "Chain",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 297,
-    "name": "glass_pane",
-    "displayName": "Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 298,
-    "name": "melon",
-    "displayName": "Melon",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 299,
-    "name": "vine",
-    "displayName": "Vines",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 300,
-    "name": "glow_lichen",
-    "displayName": "Glow Lichen",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 301,
-    "name": "brick_stairs",
-    "displayName": "Brick Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 302,
-    "name": "stone_brick_stairs",
-    "displayName": "Stone Brick Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 303,
-    "name": "mycelium",
-    "displayName": "Mycelium",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 304,
-    "name": "lily_pad",
-    "displayName": "Lily Pad",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 305,
-    "name": "nether_bricks",
-    "displayName": "Nether Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 306,
-    "name": "cracked_nether_bricks",
-    "displayName": "Cracked Nether Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 307,
-    "name": "chiseled_nether_bricks",
-    "displayName": "Chiseled Nether Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 308,
-    "name": "nether_brick_fence",
-    "displayName": "Nether Brick Fence",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 309,
-    "name": "nether_brick_stairs",
-    "displayName": "Nether Brick Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 310,
-    "name": "enchanting_table",
-    "displayName": "Enchanting Table",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 311,
-    "name": "end_portal_frame",
-    "displayName": "End Portal Frame",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 312,
-    "name": "end_stone",
-    "displayName": "End Stone",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 313,
-    "name": "end_stone_bricks",
-    "displayName": "End Stone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 314,
-    "name": "dragon_egg",
-    "displayName": "Dragon Egg",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 315,
-    "name": "sandstone_stairs",
-    "displayName": "Sandstone Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 316,
-    "name": "ender_chest",
-    "displayName": "Ender Chest",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 317,
-    "name": "emerald_block",
-    "displayName": "Block of Emerald",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 318,
-    "name": "spruce_stairs",
-    "displayName": "Spruce Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 319,
-    "name": "birch_stairs",
-    "displayName": "Birch Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 320,
-    "name": "jungle_stairs",
-    "displayName": "Jungle Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 321,
-    "name": "crimson_stairs",
-    "displayName": "Crimson Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 322,
-    "name": "warped_stairs",
-    "displayName": "Warped Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 323,
-    "name": "command_block",
-    "displayName": "Command Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 324,
-    "name": "beacon",
-    "displayName": "Beacon",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 325,
-    "name": "cobblestone_wall",
-    "displayName": "Cobblestone Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 326,
-    "name": "mossy_cobblestone_wall",
-    "displayName": "Mossy Cobblestone Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 327,
-    "name": "brick_wall",
-    "displayName": "Brick Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 328,
-    "name": "prismarine_wall",
-    "displayName": "Prismarine Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 329,
-    "name": "red_sandstone_wall",
-    "displayName": "Red Sandstone Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 330,
-    "name": "mossy_stone_brick_wall",
-    "displayName": "Mossy Stone Brick Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 331,
-    "name": "granite_wall",
-    "displayName": "Granite Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 332,
-    "name": "stone_brick_wall",
-    "displayName": "Stone Brick Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 333,
-    "name": "nether_brick_wall",
-    "displayName": "Nether Brick Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 334,
-    "name": "andesite_wall",
-    "displayName": "Andesite Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 335,
-    "name": "red_nether_brick_wall",
-    "displayName": "Red Nether Brick Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 336,
-    "name": "sandstone_wall",
-    "displayName": "Sandstone Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 337,
-    "name": "end_stone_brick_wall",
-    "displayName": "End Stone Brick Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 338,
-    "name": "diorite_wall",
-    "displayName": "Diorite Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 339,
-    "name": "blackstone_wall",
-    "displayName": "Blackstone Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 340,
-    "name": "polished_blackstone_wall",
-    "displayName": "Polished Blackstone Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 341,
-    "name": "polished_blackstone_brick_wall",
-    "displayName": "Polished Blackstone Brick Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 342,
-    "name": "cobbled_deepslate_wall",
-    "displayName": "Cobbled Deepslate Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 343,
-    "name": "polished_deepslate_wall",
-    "displayName": "Polished Deepslate Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 344,
-    "name": "deepslate_brick_wall",
-    "displayName": "Deepslate Brick Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 345,
-    "name": "deepslate_tile_wall",
-    "displayName": "Deepslate Tile Wall",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 346,
-    "name": "anvil",
-    "displayName": "Anvil",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 347,
-    "name": "chipped_anvil",
-    "displayName": "Chipped Anvil",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 348,
-    "name": "damaged_anvil",
-    "displayName": "Damaged Anvil",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 349,
-    "name": "chiseled_quartz_block",
-    "displayName": "Chiseled Quartz Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 350,
-    "name": "quartz_block",
-    "displayName": "Block of Quartz",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 351,
-    "name": "quartz_bricks",
-    "displayName": "Quartz Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 352,
-    "name": "quartz_pillar",
-    "displayName": "Quartz Pillar",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 353,
-    "name": "quartz_stairs",
-    "displayName": "Quartz Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 354,
-    "name": "white_terracotta",
-    "displayName": "White Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 355,
-    "name": "orange_terracotta",
-    "displayName": "Orange Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 356,
-    "name": "magenta_terracotta",
-    "displayName": "Magenta Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 357,
-    "name": "light_blue_terracotta",
-    "displayName": "Light Blue Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 358,
-    "name": "yellow_terracotta",
-    "displayName": "Yellow Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 359,
-    "name": "lime_terracotta",
-    "displayName": "Lime Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 360,
-    "name": "pink_terracotta",
-    "displayName": "Pink Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 361,
-    "name": "gray_terracotta",
-    "displayName": "Gray Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 362,
-    "name": "light_gray_terracotta",
-    "displayName": "Light Gray Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 363,
-    "name": "cyan_terracotta",
-    "displayName": "Cyan Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 364,
-    "name": "purple_terracotta",
-    "displayName": "Purple Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 365,
-    "name": "blue_terracotta",
-    "displayName": "Blue Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 366,
-    "name": "brown_terracotta",
-    "displayName": "Brown Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 367,
-    "name": "green_terracotta",
-    "displayName": "Green Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 368,
-    "name": "red_terracotta",
-    "displayName": "Red Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 369,
-    "name": "black_terracotta",
-    "displayName": "Black Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 370,
-    "name": "barrier",
-    "displayName": "Barrier",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 371,
-    "name": "light",
-    "displayName": "Light",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 372,
-    "name": "hay_block",
-    "displayName": "Hay Bale",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 373,
-    "name": "white_carpet",
-    "displayName": "White Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 374,
-    "name": "orange_carpet",
-    "displayName": "Orange Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 375,
-    "name": "magenta_carpet",
-    "displayName": "Magenta Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 376,
-    "name": "light_blue_carpet",
-    "displayName": "Light Blue Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 377,
-    "name": "yellow_carpet",
-    "displayName": "Yellow Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 378,
-    "name": "lime_carpet",
-    "displayName": "Lime Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 379,
-    "name": "pink_carpet",
-    "displayName": "Pink Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 380,
-    "name": "gray_carpet",
-    "displayName": "Gray Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 381,
-    "name": "light_gray_carpet",
-    "displayName": "Light Gray Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 382,
-    "name": "cyan_carpet",
-    "displayName": "Cyan Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 383,
-    "name": "purple_carpet",
-    "displayName": "Purple Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 384,
-    "name": "blue_carpet",
-    "displayName": "Blue Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 385,
-    "name": "brown_carpet",
-    "displayName": "Brown Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 386,
-    "name": "green_carpet",
-    "displayName": "Green Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 387,
-    "name": "red_carpet",
-    "displayName": "Red Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 388,
-    "name": "black_carpet",
-    "displayName": "Black Carpet",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 389,
-    "name": "terracotta",
-    "displayName": "Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 390,
-    "name": "packed_ice",
-    "displayName": "Packed Ice",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 391,
-    "name": "acacia_stairs",
-    "displayName": "Acacia Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 392,
-    "name": "dark_oak_stairs",
-    "displayName": "Dark Oak Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 393,
-    "name": "dirt_path",
-    "displayName": "Dirt Path",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 394,
-    "name": "sunflower",
-    "displayName": "Sunflower",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 395,
-    "name": "lilac",
-    "displayName": "Lilac",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 396,
-    "name": "rose_bush",
-    "displayName": "Rose Bush",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 397,
-    "name": "peony",
-    "displayName": "Peony",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 398,
-    "name": "tall_grass",
-    "displayName": "Tall Grass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 399,
-    "name": "large_fern",
-    "displayName": "Large Fern",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 400,
-    "name": "white_stained_glass",
-    "displayName": "White Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 401,
-    "name": "orange_stained_glass",
-    "displayName": "Orange Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 402,
-    "name": "magenta_stained_glass",
-    "displayName": "Magenta Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 403,
-    "name": "light_blue_stained_glass",
-    "displayName": "Light Blue Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 404,
-    "name": "yellow_stained_glass",
-    "displayName": "Yellow Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 405,
-    "name": "lime_stained_glass",
-    "displayName": "Lime Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 406,
-    "name": "pink_stained_glass",
-    "displayName": "Pink Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 407,
-    "name": "gray_stained_glass",
-    "displayName": "Gray Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 408,
-    "name": "light_gray_stained_glass",
-    "displayName": "Light Gray Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 409,
-    "name": "cyan_stained_glass",
-    "displayName": "Cyan Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 410,
-    "name": "purple_stained_glass",
-    "displayName": "Purple Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 411,
-    "name": "blue_stained_glass",
-    "displayName": "Blue Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 412,
-    "name": "brown_stained_glass",
-    "displayName": "Brown Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 413,
-    "name": "green_stained_glass",
-    "displayName": "Green Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 414,
-    "name": "red_stained_glass",
-    "displayName": "Red Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 415,
-    "name": "black_stained_glass",
-    "displayName": "Black Stained Glass",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 416,
-    "name": "white_stained_glass_pane",
-    "displayName": "White Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 417,
-    "name": "orange_stained_glass_pane",
-    "displayName": "Orange Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 418,
-    "name": "magenta_stained_glass_pane",
-    "displayName": "Magenta Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 419,
-    "name": "light_blue_stained_glass_pane",
-    "displayName": "Light Blue Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 420,
-    "name": "yellow_stained_glass_pane",
-    "displayName": "Yellow Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 421,
-    "name": "lime_stained_glass_pane",
-    "displayName": "Lime Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 422,
-    "name": "pink_stained_glass_pane",
-    "displayName": "Pink Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 423,
-    "name": "gray_stained_glass_pane",
-    "displayName": "Gray Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 424,
-    "name": "light_gray_stained_glass_pane",
-    "displayName": "Light Gray Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 425,
-    "name": "cyan_stained_glass_pane",
-    "displayName": "Cyan Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 426,
-    "name": "purple_stained_glass_pane",
-    "displayName": "Purple Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 427,
-    "name": "blue_stained_glass_pane",
-    "displayName": "Blue Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 428,
-    "name": "brown_stained_glass_pane",
-    "displayName": "Brown Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 429,
-    "name": "green_stained_glass_pane",
-    "displayName": "Green Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 430,
-    "name": "red_stained_glass_pane",
-    "displayName": "Red Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 431,
-    "name": "black_stained_glass_pane",
-    "displayName": "Black Stained Glass Pane",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 432,
-    "name": "prismarine",
-    "displayName": "Prismarine",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 433,
-    "name": "prismarine_bricks",
-    "displayName": "Prismarine Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 434,
-    "name": "dark_prismarine",
-    "displayName": "Dark Prismarine",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 435,
-    "name": "prismarine_stairs",
-    "displayName": "Prismarine Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 436,
-    "name": "prismarine_brick_stairs",
-    "displayName": "Prismarine Brick Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 437,
-    "name": "dark_prismarine_stairs",
-    "displayName": "Dark Prismarine Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 438,
-    "name": "sea_lantern",
-    "displayName": "Sea Lantern",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 439,
-    "name": "red_sandstone",
-    "displayName": "Red Sandstone",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 440,
-    "name": "chiseled_red_sandstone",
-    "displayName": "Chiseled Red Sandstone",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 441,
-    "name": "cut_red_sandstone",
-    "displayName": "Cut Red Sandstone",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 442,
-    "name": "red_sandstone_stairs",
-    "displayName": "Red Sandstone Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 443,
-    "name": "repeating_command_block",
-    "displayName": "Repeating Command Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 444,
-    "name": "chain_command_block",
-    "displayName": "Chain Command Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 445,
-    "name": "magma_block",
-    "displayName": "Magma Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 446,
-    "name": "nether_wart_block",
-    "displayName": "Nether Wart Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 447,
-    "name": "warped_wart_block",
-    "displayName": "Warped Wart Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 448,
-    "name": "red_nether_bricks",
-    "displayName": "Red Nether Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 449,
-    "name": "bone_block",
-    "displayName": "Bone Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 450,
-    "name": "structure_void",
-    "displayName": "Structure Void",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 451,
-    "name": "shulker_box",
-    "displayName": "Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 452,
-    "name": "white_shulker_box",
-    "displayName": "White Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 453,
-    "name": "orange_shulker_box",
-    "displayName": "Orange Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 454,
-    "name": "magenta_shulker_box",
-    "displayName": "Magenta Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 455,
-    "name": "light_blue_shulker_box",
-    "displayName": "Light Blue Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 456,
-    "name": "yellow_shulker_box",
-    "displayName": "Yellow Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 457,
-    "name": "lime_shulker_box",
-    "displayName": "Lime Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 458,
-    "name": "pink_shulker_box",
-    "displayName": "Pink Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 459,
-    "name": "gray_shulker_box",
-    "displayName": "Gray Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 460,
-    "name": "light_gray_shulker_box",
-    "displayName": "Light Gray Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 461,
-    "name": "cyan_shulker_box",
-    "displayName": "Cyan Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 462,
-    "name": "purple_shulker_box",
-    "displayName": "Purple Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 463,
-    "name": "blue_shulker_box",
-    "displayName": "Blue Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 464,
-    "name": "brown_shulker_box",
-    "displayName": "Brown Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 465,
-    "name": "green_shulker_box",
-    "displayName": "Green Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 466,
-    "name": "red_shulker_box",
-    "displayName": "Red Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 467,
-    "name": "black_shulker_box",
-    "displayName": "Black Shulker Box",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 468,
-    "name": "white_glazed_terracotta",
-    "displayName": "White Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 469,
-    "name": "orange_glazed_terracotta",
-    "displayName": "Orange Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 470,
-    "name": "magenta_glazed_terracotta",
-    "displayName": "Magenta Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 471,
-    "name": "light_blue_glazed_terracotta",
-    "displayName": "Light Blue Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 472,
-    "name": "yellow_glazed_terracotta",
-    "displayName": "Yellow Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 473,
-    "name": "lime_glazed_terracotta",
-    "displayName": "Lime Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 474,
-    "name": "pink_glazed_terracotta",
-    "displayName": "Pink Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 475,
-    "name": "gray_glazed_terracotta",
-    "displayName": "Gray Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 476,
-    "name": "light_gray_glazed_terracotta",
-    "displayName": "Light Gray Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 477,
-    "name": "cyan_glazed_terracotta",
-    "displayName": "Cyan Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 478,
-    "name": "purple_glazed_terracotta",
-    "displayName": "Purple Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 479,
-    "name": "blue_glazed_terracotta",
-    "displayName": "Blue Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 480,
-    "name": "brown_glazed_terracotta",
-    "displayName": "Brown Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 481,
-    "name": "green_glazed_terracotta",
-    "displayName": "Green Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 482,
-    "name": "red_glazed_terracotta",
-    "displayName": "Red Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 483,
-    "name": "black_glazed_terracotta",
-    "displayName": "Black Glazed Terracotta",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 484,
-    "name": "white_concrete",
-    "displayName": "White Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 485,
-    "name": "orange_concrete",
-    "displayName": "Orange Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 486,
-    "name": "magenta_concrete",
-    "displayName": "Magenta Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 487,
-    "name": "light_blue_concrete",
-    "displayName": "Light Blue Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 488,
-    "name": "yellow_concrete",
-    "displayName": "Yellow Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 489,
-    "name": "lime_concrete",
-    "displayName": "Lime Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 490,
-    "name": "pink_concrete",
-    "displayName": "Pink Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 491,
-    "name": "gray_concrete",
-    "displayName": "Gray Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 492,
-    "name": "light_gray_concrete",
-    "displayName": "Light Gray Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 493,
-    "name": "cyan_concrete",
-    "displayName": "Cyan Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 494,
-    "name": "purple_concrete",
-    "displayName": "Purple Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 495,
-    "name": "blue_concrete",
-    "displayName": "Blue Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 496,
-    "name": "brown_concrete",
-    "displayName": "Brown Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 497,
-    "name": "green_concrete",
-    "displayName": "Green Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 498,
-    "name": "red_concrete",
-    "displayName": "Red Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 499,
-    "name": "black_concrete",
-    "displayName": "Black Concrete",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 500,
-    "name": "white_concrete_powder",
-    "displayName": "White Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 501,
-    "name": "orange_concrete_powder",
-    "displayName": "Orange Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 502,
-    "name": "magenta_concrete_powder",
-    "displayName": "Magenta Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 503,
-    "name": "light_blue_concrete_powder",
-    "displayName": "Light Blue Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 504,
-    "name": "yellow_concrete_powder",
-    "displayName": "Yellow Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 505,
-    "name": "lime_concrete_powder",
-    "displayName": "Lime Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 506,
-    "name": "pink_concrete_powder",
-    "displayName": "Pink Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 507,
-    "name": "gray_concrete_powder",
-    "displayName": "Gray Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 508,
-    "name": "light_gray_concrete_powder",
-    "displayName": "Light Gray Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 509,
-    "name": "cyan_concrete_powder",
-    "displayName": "Cyan Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 510,
-    "name": "purple_concrete_powder",
-    "displayName": "Purple Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 511,
-    "name": "blue_concrete_powder",
-    "displayName": "Blue Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 512,
-    "name": "brown_concrete_powder",
-    "displayName": "Brown Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 513,
-    "name": "green_concrete_powder",
-    "displayName": "Green Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 514,
-    "name": "red_concrete_powder",
-    "displayName": "Red Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 515,
-    "name": "black_concrete_powder",
-    "displayName": "Black Concrete Powder",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 516,
-    "name": "turtle_egg",
-    "displayName": "Turtle Egg",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 517,
-    "name": "dead_tube_coral_block",
-    "displayName": "Dead Tube Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 518,
-    "name": "dead_brain_coral_block",
-    "displayName": "Dead Brain Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 519,
-    "name": "dead_bubble_coral_block",
-    "displayName": "Dead Bubble Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 520,
-    "name": "dead_fire_coral_block",
-    "displayName": "Dead Fire Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 521,
-    "name": "dead_horn_coral_block",
-    "displayName": "Dead Horn Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 522,
-    "name": "tube_coral_block",
-    "displayName": "Tube Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 523,
-    "name": "brain_coral_block",
-    "displayName": "Brain Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 524,
-    "name": "bubble_coral_block",
-    "displayName": "Bubble Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 525,
-    "name": "fire_coral_block",
-    "displayName": "Fire Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 526,
-    "name": "horn_coral_block",
-    "displayName": "Horn Coral Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 527,
-    "name": "tube_coral",
-    "displayName": "Tube Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 528,
-    "name": "brain_coral",
-    "displayName": "Brain Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 529,
-    "name": "bubble_coral",
-    "displayName": "Bubble Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 530,
-    "name": "fire_coral",
-    "displayName": "Fire Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 531,
-    "name": "horn_coral",
-    "displayName": "Horn Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 532,
-    "name": "dead_brain_coral",
-    "displayName": "Dead Brain Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 533,
-    "name": "dead_bubble_coral",
-    "displayName": "Dead Bubble Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 534,
-    "name": "dead_fire_coral",
-    "displayName": "Dead Fire Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 535,
-    "name": "dead_horn_coral",
-    "displayName": "Dead Horn Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 536,
-    "name": "dead_tube_coral",
-    "displayName": "Dead Tube Coral",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 537,
-    "name": "tube_coral_fan",
-    "displayName": "Tube Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 538,
-    "name": "brain_coral_fan",
-    "displayName": "Brain Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 539,
-    "name": "bubble_coral_fan",
-    "displayName": "Bubble Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 540,
-    "name": "fire_coral_fan",
-    "displayName": "Fire Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 541,
-    "name": "horn_coral_fan",
-    "displayName": "Horn Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 542,
-    "name": "dead_tube_coral_fan",
-    "displayName": "Dead Tube Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 543,
-    "name": "dead_brain_coral_fan",
-    "displayName": "Dead Brain Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 544,
-    "name": "dead_bubble_coral_fan",
-    "displayName": "Dead Bubble Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 545,
-    "name": "dead_fire_coral_fan",
-    "displayName": "Dead Fire Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 546,
-    "name": "dead_horn_coral_fan",
-    "displayName": "Dead Horn Coral Fan",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 547,
-    "name": "blue_ice",
-    "displayName": "Blue Ice",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 548,
-    "name": "conduit",
-    "displayName": "Conduit",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 549,
-    "name": "polished_granite_stairs",
-    "displayName": "Polished Granite Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 550,
-    "name": "smooth_red_sandstone_stairs",
-    "displayName": "Smooth Red Sandstone Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 551,
-    "name": "mossy_stone_brick_stairs",
-    "displayName": "Mossy Stone Brick Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 552,
-    "name": "polished_diorite_stairs",
-    "displayName": "Polished Diorite Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 553,
-    "name": "mossy_cobblestone_stairs",
-    "displayName": "Mossy Cobblestone Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 554,
-    "name": "end_stone_brick_stairs",
-    "displayName": "End Stone Brick Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 555,
-    "name": "stone_stairs",
-    "displayName": "Stone Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 556,
-    "name": "smooth_sandstone_stairs",
-    "displayName": "Smooth Sandstone Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 557,
-    "name": "smooth_quartz_stairs",
-    "displayName": "Smooth Quartz Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 558,
-    "name": "granite_stairs",
-    "displayName": "Granite Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 559,
-    "name": "andesite_stairs",
-    "displayName": "Andesite Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 560,
-    "name": "red_nether_brick_stairs",
-    "displayName": "Red Nether Brick Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 561,
-    "name": "polished_andesite_stairs",
-    "displayName": "Polished Andesite Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 562,
-    "name": "diorite_stairs",
-    "displayName": "Diorite Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 563,
-    "name": "cobbled_deepslate_stairs",
-    "displayName": "Cobbled Deepslate Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 564,
-    "name": "polished_deepslate_stairs",
-    "displayName": "Polished Deepslate Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 565,
-    "name": "deepslate_brick_stairs",
-    "displayName": "Deepslate Brick Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 566,
-    "name": "deepslate_tile_stairs",
-    "displayName": "Deepslate Tile Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 567,
-    "name": "polished_granite_slab",
-    "displayName": "Polished Granite Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 568,
-    "name": "smooth_red_sandstone_slab",
-    "displayName": "Smooth Red Sandstone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 569,
-    "name": "mossy_stone_brick_slab",
-    "displayName": "Mossy Stone Brick Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 570,
-    "name": "polished_diorite_slab",
-    "displayName": "Polished Diorite Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 571,
-    "name": "mossy_cobblestone_slab",
-    "displayName": "Mossy Cobblestone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 572,
-    "name": "end_stone_brick_slab",
-    "displayName": "End Stone Brick Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 573,
-    "name": "smooth_sandstone_slab",
-    "displayName": "Smooth Sandstone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 574,
-    "name": "smooth_quartz_slab",
-    "displayName": "Smooth Quartz Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 575,
-    "name": "granite_slab",
-    "displayName": "Granite Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 576,
-    "name": "andesite_slab",
-    "displayName": "Andesite Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 577,
-    "name": "red_nether_brick_slab",
-    "displayName": "Red Nether Brick Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 578,
-    "name": "polished_andesite_slab",
-    "displayName": "Polished Andesite Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 579,
-    "name": "diorite_slab",
-    "displayName": "Diorite Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 580,
-    "name": "cobbled_deepslate_slab",
-    "displayName": "Cobbled Deepslate Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 581,
-    "name": "polished_deepslate_slab",
-    "displayName": "Polished Deepslate Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 582,
-    "name": "deepslate_brick_slab",
-    "displayName": "Deepslate Brick Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 583,
-    "name": "deepslate_tile_slab",
-    "displayName": "Deepslate Tile Slab",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 584,
-    "name": "scaffolding",
-    "displayName": "Scaffolding",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 585,
-    "name": "redstone",
-    "displayName": "Redstone Dust",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 586,
-    "name": "redstone_torch",
-    "displayName": "Redstone Torch",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 587,
-    "name": "redstone_block",
-    "displayName": "Block of Redstone",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 588,
-    "name": "repeater",
-    "displayName": "Redstone Repeater",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 589,
-    "name": "comparator",
-    "displayName": "Redstone Comparator",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 590,
-    "name": "piston",
-    "displayName": "Piston",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 591,
-    "name": "sticky_piston",
-    "displayName": "Sticky Piston",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 592,
-    "name": "slime_block",
-    "displayName": "Slime Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 593,
-    "name": "honey_block",
-    "displayName": "Honey Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 594,
-    "name": "observer",
-    "displayName": "Observer",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 595,
-    "name": "hopper",
-    "displayName": "Hopper",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 596,
-    "name": "dispenser",
-    "displayName": "Dispenser",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 597,
-    "name": "dropper",
-    "displayName": "Dropper",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 598,
-    "name": "lectern",
-    "displayName": "Lectern",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 599,
-    "name": "target",
-    "displayName": "Target",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 600,
-    "name": "lever",
-    "displayName": "Lever",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 601,
-    "name": "lightning_rod",
-    "displayName": "Lightning Rod",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 602,
-    "name": "daylight_detector",
-    "displayName": "Daylight Detector",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 603,
-    "name": "sculk_sensor",
-    "displayName": "Sculk Sensor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 604,
-    "name": "tripwire_hook",
-    "displayName": "Tripwire Hook",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 605,
-    "name": "trapped_chest",
-    "displayName": "Trapped Chest",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 606,
-    "name": "tnt",
-    "displayName": "TNT",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 607,
-    "name": "redstone_lamp",
-    "displayName": "Redstone Lamp",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 608,
-    "name": "note_block",
-    "displayName": "Note Block",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 609,
-    "name": "stone_button",
-    "displayName": "Stone Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 610,
-    "name": "polished_blackstone_button",
-    "displayName": "Polished Blackstone Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 611,
-    "name": "oak_button",
-    "displayName": "Oak Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 612,
-    "name": "spruce_button",
-    "displayName": "Spruce Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 613,
-    "name": "birch_button",
-    "displayName": "Birch Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 614,
-    "name": "jungle_button",
-    "displayName": "Jungle Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 615,
-    "name": "acacia_button",
-    "displayName": "Acacia Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 616,
-    "name": "dark_oak_button",
-    "displayName": "Dark Oak Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 617,
-    "name": "crimson_button",
-    "displayName": "Crimson Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 618,
-    "name": "warped_button",
-    "displayName": "Warped Button",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 619,
-    "name": "stone_pressure_plate",
-    "displayName": "Stone Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 620,
-    "name": "polished_blackstone_pressure_plate",
-    "displayName": "Polished Blackstone Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 621,
-    "name": "light_weighted_pressure_plate",
-    "displayName": "Light Weighted Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 622,
-    "name": "heavy_weighted_pressure_plate",
-    "displayName": "Heavy Weighted Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 623,
-    "name": "oak_pressure_plate",
-    "displayName": "Oak Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 624,
-    "name": "spruce_pressure_plate",
-    "displayName": "Spruce Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 625,
-    "name": "birch_pressure_plate",
-    "displayName": "Birch Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 626,
-    "name": "jungle_pressure_plate",
-    "displayName": "Jungle Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 627,
-    "name": "acacia_pressure_plate",
-    "displayName": "Acacia Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 628,
-    "name": "dark_oak_pressure_plate",
-    "displayName": "Dark Oak Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 629,
-    "name": "crimson_pressure_plate",
-    "displayName": "Crimson Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 630,
-    "name": "warped_pressure_plate",
-    "displayName": "Warped Pressure Plate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 631,
-    "name": "iron_door",
-    "displayName": "Iron Door",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 632,
-    "name": "oak_door",
-    "displayName": "Oak Door",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 633,
-    "name": "spruce_door",
-    "displayName": "Spruce Door",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 634,
-    "name": "birch_door",
-    "displayName": "Birch Door",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 635,
-    "name": "jungle_door",
-    "displayName": "Jungle Door",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 636,
-    "name": "acacia_door",
-    "displayName": "Acacia Door",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 637,
-    "name": "dark_oak_door",
-    "displayName": "Dark Oak Door",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 638,
-    "name": "crimson_door",
-    "displayName": "Crimson Door",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 639,
-    "name": "warped_door",
-    "displayName": "Warped Door",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 640,
-    "name": "iron_trapdoor",
-    "displayName": "Iron Trapdoor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 641,
-    "name": "oak_trapdoor",
-    "displayName": "Oak Trapdoor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 642,
-    "name": "spruce_trapdoor",
-    "displayName": "Spruce Trapdoor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 643,
-    "name": "birch_trapdoor",
-    "displayName": "Birch Trapdoor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 644,
-    "name": "jungle_trapdoor",
-    "displayName": "Jungle Trapdoor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 645,
-    "name": "acacia_trapdoor",
-    "displayName": "Acacia Trapdoor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 646,
-    "name": "dark_oak_trapdoor",
-    "displayName": "Dark Oak Trapdoor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 647,
-    "name": "crimson_trapdoor",
-    "displayName": "Crimson Trapdoor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 648,
-    "name": "warped_trapdoor",
-    "displayName": "Warped Trapdoor",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 649,
-    "name": "oak_fence_gate",
-    "displayName": "Oak Fence Gate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 650,
-    "name": "spruce_fence_gate",
-    "displayName": "Spruce Fence Gate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 651,
-    "name": "birch_fence_gate",
-    "displayName": "Birch Fence Gate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 652,
-    "name": "jungle_fence_gate",
-    "displayName": "Jungle Fence Gate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 653,
-    "name": "acacia_fence_gate",
-    "displayName": "Acacia Fence Gate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 654,
-    "name": "dark_oak_fence_gate",
-    "displayName": "Dark Oak Fence Gate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 655,
-    "name": "crimson_fence_gate",
-    "displayName": "Crimson Fence Gate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 656,
-    "name": "warped_fence_gate",
-    "displayName": "Warped Fence Gate",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 657,
-    "name": "powered_rail",
-    "displayName": "Powered Rail",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 658,
-    "name": "detector_rail",
-    "displayName": "Detector Rail",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 659,
-    "name": "rail",
-    "displayName": "Rail",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 660,
-    "name": "activator_rail",
-    "displayName": "Activator Rail",
-    "stackSize": 64,
-    "enchantCategories": []
-  },
-  {
-    "id": 661,
-    "name": "saddle",
-    "displayName": "Saddle",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 662,
-    "name": "minecart",
-    "displayName": "Minecart",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 663,
-    "name": "chest_minecart",
-    "displayName": "Minecart with Chest",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 664,
-    "name": "furnace_minecart",
-    "displayName": "Minecart with Furnace",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 665,
-    "name": "tnt_minecart",
-    "displayName": "Minecart with TNT",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 666,
-    "name": "hopper_minecart",
-    "displayName": "Minecart with Hopper",
-    "stackSize": 1,
-    "enchantCategories": []
-  },
-  {
-    "id": 667,
-    "name": "carrot_on_a_stick",
-    "displayName": "Carrot on a Stick",
-    "stackSize": 1,
-    "enchantCategories": [
-      "breakable",
-      "vanishable"
-    ],
-    "fixedWith": [],
-    "durability": 25,
-    "maxDurability": 25
-  },
-  {
     "id": 668,
-    "name": "warped_fungus_on_a_stick",
     "displayName": "Warped Fungus on a Stick",
-    "stackSize": 1,
+    "name": "warped_fungus_on_a_stick",
+    "stackSize": 64,
+    "maxDurability": 100,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "fixedWith": [],
-    "durability": 100,
-    "maxDurability": 100
+    ]
   },
   {
     "id": 669,
-    "name": "elytra",
     "displayName": "Elytra",
+    "name": "elytra",
     "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "phantom_membrane"
-    ],
-    "durability": 432,
-    "maxDurability": 432
+    ]
   },
   {
     "id": 670,
-    "name": "oak_boat",
     "displayName": "Oak Boat",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "oak_boat",
+    "stackSize": 1
   },
   {
     "id": 671,
-    "name": "spruce_boat",
     "displayName": "Spruce Boat",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "spruce_boat",
+    "stackSize": 1
   },
   {
     "id": 672,
-    "name": "birch_boat",
     "displayName": "Birch Boat",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "birch_boat",
+    "stackSize": 1
   },
   {
     "id": 673,
-    "name": "jungle_boat",
     "displayName": "Jungle Boat",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "jungle_boat",
+    "stackSize": 1
   },
   {
     "id": 674,
-    "name": "acacia_boat",
     "displayName": "Acacia Boat",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "acacia_boat",
+    "stackSize": 1
   },
   {
     "id": 675,
-    "name": "dark_oak_boat",
     "displayName": "Dark Oak Boat",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "dark_oak_boat",
+    "stackSize": 1
   },
   {
     "id": 676,
-    "name": "structure_block",
     "displayName": "Structure Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "structure_block",
+    "stackSize": 64
   },
   {
     "id": 677,
-    "name": "jigsaw",
     "displayName": "Jigsaw Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "jigsaw",
+    "stackSize": 64
   },
   {
     "id": 678,
-    "name": "turtle_helmet",
     "displayName": "Turtle Shell",
+    "name": "turtle_helmet",
     "stackSize": 1,
+    "maxDurability": 275,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -4784,176 +4103,153 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "scute"
-    ],
-    "durability": 275,
-    "maxDurability": 275
+    ]
   },
   {
     "id": 679,
-    "name": "scute",
     "displayName": "Scute",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "scute",
+    "stackSize": 64
   },
   {
     "id": 680,
-    "name": "flint_and_steel",
     "displayName": "Flint and Steel",
+    "name": "flint_and_steel",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "fixedWith": [],
-    "durability": 64,
-    "maxDurability": 64
+    ]
   },
   {
     "id": 681,
-    "name": "apple",
     "displayName": "Apple",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "apple",
+    "stackSize": 64
   },
   {
     "id": 682,
-    "name": "bow",
     "displayName": "Bow",
+    "name": "bow",
     "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "fixedWith": [],
-    "durability": 384,
-    "maxDurability": 384
+    ]
   },
   {
     "id": 683,
-    "name": "arrow",
     "displayName": "Arrow",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "arrow",
+    "stackSize": 64
   },
   {
     "id": 684,
-    "name": "coal",
     "displayName": "Coal",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "coal",
+    "stackSize": 64
   },
   {
     "id": 685,
-    "name": "charcoal",
     "displayName": "Charcoal",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "charcoal",
+    "stackSize": 64
   },
   {
     "id": 686,
-    "name": "diamond",
     "displayName": "Diamond",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "diamond",
+    "stackSize": 64
   },
   {
     "id": 687,
-    "name": "emerald",
     "displayName": "Emerald",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "emerald",
+    "stackSize": 64
   },
   {
     "id": 688,
-    "name": "lapis_lazuli",
     "displayName": "Lapis Lazuli",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lapis_lazuli",
+    "stackSize": 64
   },
   {
     "id": 689,
-    "name": "quartz",
     "displayName": "Nether Quartz",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "quartz",
+    "stackSize": 64
   },
   {
     "id": 690,
-    "name": "amethyst_shard",
     "displayName": "Amethyst Shard",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "amethyst_shard",
+    "stackSize": 64
   },
   {
     "id": 691,
-    "name": "raw_iron",
     "displayName": "Raw Iron",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "raw_iron",
+    "stackSize": 64
   },
   {
     "id": 692,
-    "name": "iron_ingot",
     "displayName": "Iron Ingot",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "iron_ingot",
+    "stackSize": 64
   },
   {
     "id": 693,
-    "name": "raw_copper",
     "displayName": "Raw Copper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "raw_copper",
+    "stackSize": 64
   },
   {
     "id": 694,
-    "name": "copper_ingot",
     "displayName": "Copper Ingot",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "copper_ingot",
+    "stackSize": 64
   },
   {
     "id": 695,
-    "name": "raw_gold",
     "displayName": "Raw Gold",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "raw_gold",
+    "stackSize": 64
   },
   {
     "id": 696,
-    "name": "gold_ingot",
     "displayName": "Gold Ingot",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gold_ingot",
+    "stackSize": 64
   },
   {
     "id": 697,
-    "name": "netherite_ingot",
     "displayName": "Netherite Ingot",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "netherite_ingot",
+    "stackSize": 64
   },
   {
     "id": 698,
-    "name": "netherite_scrap",
     "displayName": "Netherite Scrap",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "netherite_scrap",
+    "stackSize": 64
   },
   {
     "id": 699,
-    "name": "wooden_sword",
     "displayName": "Wooden Sword",
+    "name": "wooden_sword",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "oak_planks",
       "spruce_planks",
       "birch_planks",
@@ -4962,21 +4258,20 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "durability": 59,
-    "maxDurability": 59
+    ]
   },
   {
     "id": 700,
-    "name": "wooden_shovel",
     "displayName": "Wooden Shovel",
+    "name": "wooden_shovel",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "oak_planks",
       "spruce_planks",
       "birch_planks",
@@ -4985,21 +4280,20 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "durability": 59,
-    "maxDurability": 59
+    ]
   },
   {
     "id": 701,
-    "name": "wooden_pickaxe",
     "displayName": "Wooden Pickaxe",
+    "name": "wooden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "oak_planks",
       "spruce_planks",
       "birch_planks",
@@ -5008,21 +4302,20 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "durability": 59,
-    "maxDurability": 59
+    ]
   },
   {
     "id": 702,
-    "name": "wooden_axe",
     "displayName": "Wooden Axe",
+    "name": "wooden_axe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "oak_planks",
       "spruce_planks",
       "birch_planks",
@@ -5031,21 +4324,20 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "durability": 59,
-    "maxDurability": 59
+    ]
   },
   {
     "id": 703,
-    "name": "wooden_hoe",
     "displayName": "Wooden Hoe",
+    "name": "wooden_hoe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "oak_planks",
       "spruce_planks",
       "birch_planks",
@@ -5054,488 +4346,448 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "durability": 59,
-    "maxDurability": 59
+    ]
   },
   {
     "id": 704,
-    "name": "stone_sword",
     "displayName": "Stone Sword",
+    "name": "stone_sword",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
-      "cobbled_deepslate",
+    "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "durability": 131,
-    "maxDurability": 131
+    ]
   },
   {
     "id": 705,
-    "name": "stone_shovel",
     "displayName": "Stone Shovel",
+    "name": "stone_shovel",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
-      "cobbled_deepslate",
+    "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "durability": 131,
-    "maxDurability": 131
+    ]
   },
   {
     "id": 706,
-    "name": "stone_pickaxe",
     "displayName": "Stone Pickaxe",
+    "name": "stone_pickaxe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
-      "cobbled_deepslate",
+    "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "durability": 131,
-    "maxDurability": 131
+    ]
   },
   {
     "id": 707,
-    "name": "stone_axe",
     "displayName": "Stone Axe",
+    "name": "stone_axe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
-      "cobbled_deepslate",
+    "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "durability": 131,
-    "maxDurability": 131
+    ]
   },
   {
     "id": 708,
-    "name": "stone_hoe",
     "displayName": "Stone Hoe",
+    "name": "stone_hoe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
-      "cobbled_deepslate",
+    "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "durability": 131,
-    "maxDurability": 131
+    ]
   },
   {
     "id": 709,
-    "name": "golden_sword",
     "displayName": "Golden Sword",
+    "name": "golden_sword",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "gold_ingot"
-    ],
-    "durability": 32,
-    "maxDurability": 32
+    ]
   },
   {
     "id": 710,
-    "name": "golden_shovel",
     "displayName": "Golden Shovel",
+    "name": "golden_shovel",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "gold_ingot"
-    ],
-    "durability": 32,
-    "maxDurability": 32
+    ]
   },
   {
     "id": 711,
-    "name": "golden_pickaxe",
     "displayName": "Golden Pickaxe",
+    "name": "golden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "gold_ingot"
-    ],
-    "durability": 32,
-    "maxDurability": 32
+    ]
   },
   {
     "id": 712,
-    "name": "golden_axe",
     "displayName": "Golden Axe",
+    "name": "golden_axe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "gold_ingot"
-    ],
-    "durability": 32,
-    "maxDurability": 32
+    ]
   },
   {
     "id": 713,
-    "name": "golden_hoe",
     "displayName": "Golden Hoe",
+    "name": "golden_hoe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "gold_ingot"
-    ],
-    "durability": 32,
-    "maxDurability": 32
+    ]
   },
   {
     "id": 714,
-    "name": "iron_sword",
     "displayName": "Iron Sword",
+    "name": "iron_sword",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 250,
-    "maxDurability": 250
+    ]
   },
   {
     "id": 715,
-    "name": "iron_shovel",
     "displayName": "Iron Shovel",
+    "name": "iron_shovel",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 250,
-    "maxDurability": 250
+    ]
   },
   {
     "id": 716,
-    "name": "iron_pickaxe",
     "displayName": "Iron Pickaxe",
+    "name": "iron_pickaxe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 250,
-    "maxDurability": 250
+    ]
   },
   {
     "id": 717,
-    "name": "iron_axe",
     "displayName": "Iron Axe",
+    "name": "iron_axe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 250,
-    "maxDurability": 250
+    ]
   },
   {
     "id": 718,
-    "name": "iron_hoe",
     "displayName": "Iron Hoe",
+    "name": "iron_hoe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 250,
-    "maxDurability": 250
+    ]
   },
   {
     "id": 719,
-    "name": "diamond_sword",
     "displayName": "Diamond Sword",
+    "name": "diamond_sword",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "diamond"
-    ],
-    "durability": 1561,
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 720,
-    "name": "diamond_shovel",
     "displayName": "Diamond Shovel",
+    "name": "diamond_shovel",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "diamond"
-    ],
-    "durability": 1561,
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 721,
-    "name": "diamond_pickaxe",
     "displayName": "Diamond Pickaxe",
+    "name": "diamond_pickaxe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "diamond"
-    ],
-    "durability": 1561,
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 722,
-    "name": "diamond_axe",
     "displayName": "Diamond Axe",
+    "name": "diamond_axe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "diamond"
-    ],
-    "durability": 1561,
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 723,
-    "name": "diamond_hoe",
     "displayName": "Diamond Hoe",
+    "name": "diamond_hoe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "diamond"
-    ],
-    "durability": 1561,
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 724,
-    "name": "netherite_sword",
     "displayName": "Netherite Sword",
+    "name": "netherite_sword",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "weapon",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "netherite_ingot"
-    ],
-    "durability": 2031,
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 725,
-    "name": "netherite_shovel",
     "displayName": "Netherite Shovel",
+    "name": "netherite_shovel",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "netherite_ingot"
-    ],
-    "durability": 2031,
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 726,
-    "name": "netherite_pickaxe",
     "displayName": "Netherite Pickaxe",
+    "name": "netherite_pickaxe",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "netherite_ingot"
-    ],
-    "durability": 2031,
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 727,
-    "name": "netherite_axe",
     "displayName": "Netherite Axe",
+    "name": "netherite_axe",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "netherite_ingot"
-    ],
-    "durability": 2031,
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 728,
-    "name": "netherite_hoe",
     "displayName": "Netherite Hoe",
+    "name": "netherite_hoe",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "netherite_ingot"
-    ],
-    "durability": 2031,
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 729,
-    "name": "stick",
     "displayName": "Stick",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stick",
+    "stackSize": 64
   },
   {
     "id": 730,
-    "name": "bowl",
     "displayName": "Bowl",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bowl",
+    "stackSize": 64
   },
   {
     "id": 731,
-    "name": "mushroom_stew",
     "displayName": "Mushroom Stew",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "mushroom_stew",
+    "stackSize": 1
   },
   {
     "id": 732,
-    "name": "string",
     "displayName": "String",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "string",
+    "stackSize": 64
   },
   {
     "id": 733,
-    "name": "feather",
     "displayName": "Feather",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "feather",
+    "stackSize": 64
   },
   {
     "id": 734,
-    "name": "gunpowder",
     "displayName": "Gunpowder",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gunpowder",
+    "stackSize": 64
   },
   {
     "id": 735,
-    "name": "wheat_seeds",
     "displayName": "Wheat Seeds",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "wheat_seeds",
+    "stackSize": 64
   },
   {
     "id": 736,
-    "name": "wheat",
     "displayName": "Wheat",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "wheat",
+    "stackSize": 64
   },
   {
     "id": 737,
-    "name": "bread",
     "displayName": "Bread",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bread",
+    "stackSize": 64
   },
   {
     "id": 738,
-    "name": "leather_helmet",
     "displayName": "Leather Cap",
+    "name": "leather_helmet",
     "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -5543,17 +4795,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "leather"
-    ],
-    "durability": 55,
-    "maxDurability": 55
+    ]
   },
   {
     "id": 739,
-    "name": "leather_chestplate",
     "displayName": "Leather Tunic",
+    "name": "leather_chestplate",
     "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -5561,35 +4812,32 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "leather"
-    ],
-    "durability": 80,
-    "maxDurability": 80
+    ]
   },
   {
     "id": 740,
-    "name": "leather_leggings",
     "displayName": "Leather Pants",
+    "name": "leather_leggings",
     "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
-      "armor_legs",
       "breakable",
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "leather"
-    ],
-    "durability": 75,
-    "maxDurability": 75
+    ]
   },
   {
     "id": 741,
-    "name": "leather_boots",
     "displayName": "Leather Boots",
+    "name": "leather_boots",
     "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -5597,17 +4845,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "leather"
-    ],
-    "durability": 65,
-    "maxDurability": 65
+    ]
   },
   {
     "id": 742,
-    "name": "chainmail_helmet",
     "displayName": "Chainmail Helmet",
+    "name": "chainmail_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -5615,17 +4862,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 165,
-    "maxDurability": 165
+    ]
   },
   {
     "id": 743,
-    "name": "chainmail_chestplate",
     "displayName": "Chainmail Chestplate",
+    "name": "chainmail_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -5633,35 +4879,32 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 240,
-    "maxDurability": 240
+    ]
   },
   {
     "id": 744,
-    "name": "chainmail_leggings",
     "displayName": "Chainmail Leggings",
+    "name": "chainmail_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
-      "armor_legs",
       "breakable",
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 225,
-    "maxDurability": 225
+    ]
   },
   {
     "id": 745,
-    "name": "chainmail_boots",
     "displayName": "Chainmail Boots",
+    "name": "chainmail_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -5669,17 +4912,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 195,
-    "maxDurability": 195
+    ]
   },
   {
     "id": 746,
-    "name": "iron_helmet",
     "displayName": "Iron Helmet",
+    "name": "iron_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -5687,17 +4929,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 165,
-    "maxDurability": 165
+    ]
   },
   {
     "id": 747,
-    "name": "iron_chestplate",
     "displayName": "Iron Chestplate",
+    "name": "iron_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -5705,35 +4946,32 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 240,
-    "maxDurability": 240
+    ]
   },
   {
     "id": 748,
-    "name": "iron_leggings",
     "displayName": "Iron Leggings",
+    "name": "iron_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
-      "armor_legs",
       "breakable",
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 225,
-    "maxDurability": 225
+    ]
   },
   {
     "id": 749,
-    "name": "iron_boots",
     "displayName": "Iron Boots",
+    "name": "iron_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -5741,17 +4979,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "iron_ingot"
-    ],
-    "durability": 195,
-    "maxDurability": 195
+    ]
   },
   {
     "id": 750,
-    "name": "diamond_helmet",
     "displayName": "Diamond Helmet",
+    "name": "diamond_helmet",
     "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -5759,17 +4996,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "diamond"
-    ],
-    "durability": 363,
-    "maxDurability": 363
+    ]
   },
   {
     "id": 751,
-    "name": "diamond_chestplate",
     "displayName": "Diamond Chestplate",
+    "name": "diamond_chestplate",
     "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -5777,35 +5013,32 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "diamond"
-    ],
-    "durability": 528,
-    "maxDurability": 528
+    ]
   },
   {
     "id": 752,
-    "name": "diamond_leggings",
     "displayName": "Diamond Leggings",
+    "name": "diamond_leggings",
     "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
-      "armor_legs",
       "breakable",
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "diamond"
-    ],
-    "durability": 495,
-    "maxDurability": 495
+    ]
   },
   {
     "id": 753,
-    "name": "diamond_boots",
     "displayName": "Diamond Boots",
+    "name": "diamond_boots",
     "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -5813,17 +5046,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "diamond"
-    ],
-    "durability": 429,
-    "maxDurability": 429
+    ]
   },
   {
     "id": 754,
-    "name": "golden_helmet",
     "displayName": "Golden Helmet",
+    "name": "golden_helmet",
     "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -5831,17 +5063,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "gold_ingot"
-    ],
-    "durability": 77,
-    "maxDurability": 77
+    ]
   },
   {
     "id": 755,
-    "name": "golden_chestplate",
     "displayName": "Golden Chestplate",
+    "name": "golden_chestplate",
     "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -5849,35 +5080,32 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "gold_ingot"
-    ],
-    "durability": 112,
-    "maxDurability": 112
+    ]
   },
   {
     "id": 756,
-    "name": "golden_leggings",
     "displayName": "Golden Leggings",
+    "name": "golden_leggings",
     "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
-      "armor_legs",
       "breakable",
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "gold_ingot"
-    ],
-    "durability": 105,
-    "maxDurability": 105
+    ]
   },
   {
     "id": 757,
-    "name": "golden_boots",
     "displayName": "Golden Boots",
+    "name": "golden_boots",
     "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -5885,17 +5113,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "gold_ingot"
-    ],
-    "durability": 91,
-    "maxDurability": 91
+    ]
   },
   {
     "id": 758,
-    "name": "netherite_helmet",
     "displayName": "Netherite Helmet",
+    "name": "netherite_helmet",
     "stackSize": 1,
+    "maxDurability": 407,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -5903,17 +5130,16 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "netherite_ingot"
-    ],
-    "durability": 407,
-    "maxDurability": 407
+    ]
   },
   {
     "id": 759,
-    "name": "netherite_chestplate",
     "displayName": "Netherite Chestplate",
+    "name": "netherite_chestplate",
     "stackSize": 1,
+    "maxDurability": 592,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -5921,35 +5147,32 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "netherite_ingot"
-    ],
-    "durability": 592,
-    "maxDurability": 592
+    ]
   },
   {
     "id": 760,
-    "name": "netherite_leggings",
     "displayName": "Netherite Leggings",
+    "name": "netherite_leggings",
     "stackSize": 1,
+    "maxDurability": 555,
     "enchantCategories": [
       "armor",
-      "armor_legs",
       "breakable",
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "netherite_ingot"
-    ],
-    "durability": 555,
-    "maxDurability": 555
+    ]
   },
   {
     "id": 761,
-    "name": "netherite_boots",
     "displayName": "Netherite Boots",
+    "name": "netherite_boots",
     "stackSize": 1,
+    "maxDurability": 481,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -5957,1388 +5180,1183 @@
       "wearable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "netherite_ingot"
-    ],
-    "durability": 481,
-    "maxDurability": 481
+    ]
   },
   {
     "id": 762,
-    "name": "flint",
     "displayName": "Flint",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "flint",
+    "stackSize": 64
   },
   {
     "id": 763,
-    "name": "porkchop",
     "displayName": "Raw Porkchop",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "porkchop",
+    "stackSize": 64
   },
   {
     "id": 764,
-    "name": "cooked_porkchop",
     "displayName": "Cooked Porkchop",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cooked_porkchop",
+    "stackSize": 64
   },
   {
     "id": 765,
-    "name": "painting",
     "displayName": "Painting",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "painting",
+    "stackSize": 64
   },
   {
     "id": 766,
-    "name": "golden_apple",
     "displayName": "Golden Apple",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "golden_apple",
+    "stackSize": 64
   },
   {
     "id": 767,
-    "name": "enchanted_golden_apple",
     "displayName": "Enchanted Golden Apple",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "enchanted_golden_apple",
+    "stackSize": 64
   },
   {
     "id": 768,
-    "name": "oak_sign",
     "displayName": "Oak Sign",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "oak_sign",
+    "stackSize": 16
   },
   {
     "id": 769,
-    "name": "spruce_sign",
     "displayName": "Spruce Sign",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "spruce_sign",
+    "stackSize": 16
   },
   {
     "id": 770,
-    "name": "birch_sign",
     "displayName": "Birch Sign",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "birch_sign",
+    "stackSize": 16
   },
   {
     "id": 771,
-    "name": "jungle_sign",
     "displayName": "Jungle Sign",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "jungle_sign",
+    "stackSize": 16
   },
   {
     "id": 772,
-    "name": "acacia_sign",
     "displayName": "Acacia Sign",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "acacia_sign",
+    "stackSize": 16
   },
   {
     "id": 773,
-    "name": "dark_oak_sign",
     "displayName": "Dark Oak Sign",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "dark_oak_sign",
+    "stackSize": 16
   },
   {
     "id": 774,
-    "name": "crimson_sign",
     "displayName": "Crimson Sign",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "crimson_sign",
+    "stackSize": 16
   },
   {
     "id": 775,
-    "name": "warped_sign",
     "displayName": "Warped Sign",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "warped_sign",
+    "stackSize": 16
   },
   {
     "id": 776,
-    "name": "bucket",
     "displayName": "Bucket",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "bucket",
+    "stackSize": 16
   },
   {
     "id": 777,
-    "name": "water_bucket",
     "displayName": "Water Bucket",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "water_bucket",
+    "stackSize": 1
   },
   {
     "id": 778,
-    "name": "lava_bucket",
     "displayName": "Lava Bucket",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "lava_bucket",
+    "stackSize": 1
   },
   {
     "id": 779,
-    "name": "powder_snow_bucket",
     "displayName": "Powder Snow Bucket",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "powder_snow_bucket",
+    "stackSize": 1
   },
   {
     "id": 780,
-    "name": "snowball",
     "displayName": "Snowball",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "snowball",
+    "stackSize": 16
   },
   {
     "id": 781,
-    "name": "leather",
     "displayName": "Leather",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "leather",
+    "stackSize": 64
   },
   {
     "id": 782,
-    "name": "milk_bucket",
     "displayName": "Milk Bucket",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "milk_bucket",
+    "stackSize": 1
   },
   {
     "id": 783,
-    "name": "pufferfish_bucket",
     "displayName": "Bucket of Pufferfish",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "pufferfish_bucket",
+    "stackSize": 1
   },
   {
     "id": 784,
-    "name": "salmon_bucket",
     "displayName": "Bucket of Salmon",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "salmon_bucket",
+    "stackSize": 1
   },
   {
     "id": 785,
-    "name": "cod_bucket",
     "displayName": "Bucket of Cod",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "cod_bucket",
+    "stackSize": 1
   },
   {
     "id": 786,
-    "name": "tropical_fish_bucket",
     "displayName": "Bucket of Tropical Fish",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "tropical_fish_bucket",
+    "stackSize": 1
   },
   {
     "id": 787,
-    "name": "axolotl_bucket",
     "displayName": "Bucket of Axolotl",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "axolotl_bucket",
+    "stackSize": 1
   },
   {
     "id": 788,
-    "name": "brick",
     "displayName": "Brick",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "brick",
+    "stackSize": 64
   },
   {
     "id": 789,
-    "name": "clay_ball",
     "displayName": "Clay Ball",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "clay_ball",
+    "stackSize": 64
   },
   {
     "id": 790,
-    "name": "dried_kelp_block",
     "displayName": "Dried Kelp Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dried_kelp_block",
+    "stackSize": 64
   },
   {
     "id": 791,
-    "name": "paper",
     "displayName": "Paper",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "paper",
+    "stackSize": 64
   },
   {
     "id": 792,
-    "name": "book",
     "displayName": "Book",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "book",
+    "stackSize": 64
   },
   {
     "id": 793,
-    "name": "slime_ball",
     "displayName": "Slimeball",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "slime_ball",
+    "stackSize": 64
   },
   {
     "id": 794,
-    "name": "egg",
     "displayName": "Egg",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "egg",
+    "stackSize": 16
   },
   {
     "id": 795,
-    "name": "compass",
     "displayName": "Compass",
-    "stackSize": 64,
-    "enchantCategories": [
-      "vanishable"
-    ]
+    "name": "compass",
+    "stackSize": 64
   },
   {
     "id": 796,
-    "name": "bundle",
     "displayName": "Bundle",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "bundle",
+    "stackSize": 1
   },
   {
     "id": 797,
-    "name": "fishing_rod",
     "displayName": "Fishing Rod",
+    "name": "fishing_rod",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
-      "fishing_rod",
       "breakable",
+      "fishing_rod",
       "vanishable"
-    ],
-    "fixedWith": [],
-    "durability": 64,
-    "maxDurability": 64
+    ]
   },
   {
     "id": 798,
-    "name": "clock",
     "displayName": "Clock",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "clock",
+    "stackSize": 64
   },
   {
     "id": 799,
-    "name": "spyglass",
     "displayName": "Spyglass",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "spyglass",
+    "stackSize": 1
   },
   {
     "id": 800,
-    "name": "glowstone_dust",
     "displayName": "Glowstone Dust",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "glowstone_dust",
+    "stackSize": 64
   },
   {
     "id": 801,
-    "name": "cod",
     "displayName": "Raw Cod",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cod",
+    "stackSize": 64
   },
   {
     "id": 802,
-    "name": "salmon",
     "displayName": "Raw Salmon",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "salmon",
+    "stackSize": 64
   },
   {
     "id": 803,
-    "name": "tropical_fish",
     "displayName": "Tropical Fish",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "tropical_fish",
+    "stackSize": 64
   },
   {
     "id": 804,
-    "name": "pufferfish",
     "displayName": "Pufferfish",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pufferfish",
+    "stackSize": 64
   },
   {
     "id": 805,
-    "name": "cooked_cod",
     "displayName": "Cooked Cod",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cooked_cod",
+    "stackSize": 64
   },
   {
     "id": 806,
-    "name": "cooked_salmon",
     "displayName": "Cooked Salmon",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cooked_salmon",
+    "stackSize": 64
   },
   {
     "id": 807,
-    "name": "ink_sac",
     "displayName": "Ink Sac",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "ink_sac",
+    "stackSize": 64
   },
   {
     "id": 808,
-    "name": "glow_ink_sac",
     "displayName": "Glow Ink Sac",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "glow_ink_sac",
+    "stackSize": 64
   },
   {
     "id": 809,
-    "name": "cocoa_beans",
     "displayName": "Cocoa Beans",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cocoa_beans",
+    "stackSize": 64
   },
   {
     "id": 810,
-    "name": "white_dye",
     "displayName": "White Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "white_dye",
+    "stackSize": 64
   },
   {
     "id": 811,
-    "name": "orange_dye",
     "displayName": "Orange Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "orange_dye",
+    "stackSize": 64
   },
   {
     "id": 812,
-    "name": "magenta_dye",
     "displayName": "Magenta Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "magenta_dye",
+    "stackSize": 64
   },
   {
     "id": 813,
-    "name": "light_blue_dye",
     "displayName": "Light Blue Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "light_blue_dye",
+    "stackSize": 64
   },
   {
     "id": 814,
-    "name": "yellow_dye",
     "displayName": "Yellow Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "yellow_dye",
+    "stackSize": 64
   },
   {
     "id": 815,
-    "name": "lime_dye",
     "displayName": "Lime Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lime_dye",
+    "stackSize": 64
   },
   {
     "id": 816,
-    "name": "pink_dye",
     "displayName": "Pink Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pink_dye",
+    "stackSize": 64
   },
   {
     "id": 817,
-    "name": "gray_dye",
     "displayName": "Gray Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gray_dye",
+    "stackSize": 64
   },
   {
     "id": 818,
-    "name": "light_gray_dye",
     "displayName": "Light Gray Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "light_gray_dye",
+    "stackSize": 64
   },
   {
     "id": 819,
-    "name": "cyan_dye",
     "displayName": "Cyan Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cyan_dye",
+    "stackSize": 64
   },
   {
     "id": 820,
-    "name": "purple_dye",
     "displayName": "Purple Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "purple_dye",
+    "stackSize": 64
   },
   {
     "id": 821,
-    "name": "blue_dye",
     "displayName": "Blue Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blue_dye",
+    "stackSize": 64
   },
   {
     "id": 822,
-    "name": "brown_dye",
     "displayName": "Brown Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "brown_dye",
+    "stackSize": 64
   },
   {
     "id": 823,
-    "name": "green_dye",
     "displayName": "Green Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "green_dye",
+    "stackSize": 64
   },
   {
     "id": 824,
-    "name": "red_dye",
     "displayName": "Red Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "red_dye",
+    "stackSize": 64
   },
   {
     "id": 825,
-    "name": "black_dye",
     "displayName": "Black Dye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "black_dye",
+    "stackSize": 64
   },
   {
     "id": 826,
-    "name": "bone_meal",
     "displayName": "Bone Meal",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bone_meal",
+    "stackSize": 64
   },
   {
     "id": 827,
-    "name": "bone",
     "displayName": "Bone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bone",
+    "stackSize": 64
   },
   {
     "id": 828,
-    "name": "sugar",
     "displayName": "Sugar",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "sugar",
+    "stackSize": 64
   },
   {
     "id": 829,
-    "name": "cake",
     "displayName": "Cake",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "cake",
+    "stackSize": 1
   },
   {
     "id": 830,
-    "name": "white_bed",
     "displayName": "White Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "white_bed",
+    "stackSize": 1
   },
   {
     "id": 831,
-    "name": "orange_bed",
     "displayName": "Orange Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "orange_bed",
+    "stackSize": 1
   },
   {
     "id": 832,
-    "name": "magenta_bed",
     "displayName": "Magenta Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "magenta_bed",
+    "stackSize": 1
   },
   {
     "id": 833,
-    "name": "light_blue_bed",
     "displayName": "Light Blue Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "light_blue_bed",
+    "stackSize": 1
   },
   {
     "id": 834,
-    "name": "yellow_bed",
     "displayName": "Yellow Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "yellow_bed",
+    "stackSize": 1
   },
   {
     "id": 835,
-    "name": "lime_bed",
     "displayName": "Lime Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "lime_bed",
+    "stackSize": 1
   },
   {
     "id": 836,
-    "name": "pink_bed",
     "displayName": "Pink Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "pink_bed",
+    "stackSize": 1
   },
   {
     "id": 837,
-    "name": "gray_bed",
     "displayName": "Gray Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "gray_bed",
+    "stackSize": 1
   },
   {
     "id": 838,
-    "name": "light_gray_bed",
     "displayName": "Light Gray Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "light_gray_bed",
+    "stackSize": 1
   },
   {
     "id": 839,
-    "name": "cyan_bed",
     "displayName": "Cyan Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "cyan_bed",
+    "stackSize": 1
   },
   {
     "id": 840,
-    "name": "purple_bed",
     "displayName": "Purple Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "purple_bed",
+    "stackSize": 1
   },
   {
     "id": 841,
-    "name": "blue_bed",
     "displayName": "Blue Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "blue_bed",
+    "stackSize": 1
   },
   {
     "id": 842,
-    "name": "brown_bed",
     "displayName": "Brown Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "brown_bed",
+    "stackSize": 1
   },
   {
     "id": 843,
-    "name": "green_bed",
     "displayName": "Green Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "green_bed",
+    "stackSize": 1
   },
   {
     "id": 844,
-    "name": "red_bed",
     "displayName": "Red Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "red_bed",
+    "stackSize": 1
   },
   {
     "id": 845,
-    "name": "black_bed",
     "displayName": "Black Bed",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "black_bed",
+    "stackSize": 1
   },
   {
     "id": 846,
-    "name": "cookie",
     "displayName": "Cookie",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cookie",
+    "stackSize": 64
   },
   {
     "id": 847,
-    "name": "filled_map",
     "displayName": "Map",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "filled_map",
+    "stackSize": 64
   },
   {
     "id": 848,
-    "name": "shears",
     "displayName": "Shears",
+    "name": "shears",
     "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "fixedWith": [],
-    "durability": 238,
-    "maxDurability": 238
+    ]
   },
   {
     "id": 849,
-    "name": "melon_slice",
     "displayName": "Melon Slice",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "melon_slice",
+    "stackSize": 64
   },
   {
     "id": 850,
-    "name": "dried_kelp",
     "displayName": "Dried Kelp",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dried_kelp",
+    "stackSize": 64
   },
   {
     "id": 851,
-    "name": "pumpkin_seeds",
     "displayName": "Pumpkin Seeds",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pumpkin_seeds",
+    "stackSize": 64
   },
   {
     "id": 852,
-    "name": "melon_seeds",
     "displayName": "Melon Seeds",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "melon_seeds",
+    "stackSize": 64
   },
   {
     "id": 853,
-    "name": "beef",
     "displayName": "Raw Beef",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "beef",
+    "stackSize": 64
   },
   {
     "id": 854,
-    "name": "cooked_beef",
     "displayName": "Steak",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cooked_beef",
+    "stackSize": 64
   },
   {
     "id": 855,
-    "name": "chicken",
     "displayName": "Raw Chicken",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "chicken",
+    "stackSize": 64
   },
   {
     "id": 856,
-    "name": "cooked_chicken",
     "displayName": "Cooked Chicken",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cooked_chicken",
+    "stackSize": 64
   },
   {
     "id": 857,
-    "name": "rotten_flesh",
     "displayName": "Rotten Flesh",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "rotten_flesh",
+    "stackSize": 64
   },
   {
     "id": 858,
-    "name": "ender_pearl",
     "displayName": "Ender Pearl",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "ender_pearl",
+    "stackSize": 16
   },
   {
     "id": 859,
-    "name": "blaze_rod",
     "displayName": "Blaze Rod",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blaze_rod",
+    "stackSize": 64
   },
   {
     "id": 860,
-    "name": "ghast_tear",
     "displayName": "Ghast Tear",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "ghast_tear",
+    "stackSize": 64
   },
   {
     "id": 861,
-    "name": "gold_nugget",
     "displayName": "Gold Nugget",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gold_nugget",
+    "stackSize": 64
   },
   {
     "id": 862,
-    "name": "nether_wart",
     "displayName": "Nether Wart",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "nether_wart",
+    "stackSize": 64
   },
   {
     "id": 863,
-    "name": "potion",
     "displayName": "Potion",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "potion",
+    "stackSize": 1
   },
   {
     "id": 864,
-    "name": "glass_bottle",
     "displayName": "Glass Bottle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "glass_bottle",
+    "stackSize": 64
   },
   {
     "id": 865,
-    "name": "spider_eye",
     "displayName": "Spider Eye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spider_eye",
+    "stackSize": 64
   },
   {
     "id": 866,
-    "name": "fermented_spider_eye",
     "displayName": "Fermented Spider Eye",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "fermented_spider_eye",
+    "stackSize": 64
   },
   {
     "id": 867,
-    "name": "blaze_powder",
     "displayName": "Blaze Powder",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blaze_powder",
+    "stackSize": 64
   },
   {
     "id": 868,
-    "name": "magma_cream",
     "displayName": "Magma Cream",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "magma_cream",
+    "stackSize": 64
   },
   {
     "id": 869,
-    "name": "brewing_stand",
     "displayName": "Brewing Stand",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "brewing_stand",
+    "stackSize": 64
   },
   {
     "id": 870,
-    "name": "cauldron",
     "displayName": "Cauldron",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cauldron",
+    "stackSize": 64
   },
   {
     "id": 871,
-    "name": "ender_eye",
     "displayName": "Eye of Ender",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "ender_eye",
+    "stackSize": 64
   },
   {
     "id": 872,
-    "name": "glistering_melon_slice",
     "displayName": "Glistering Melon Slice",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "glistering_melon_slice",
+    "stackSize": 64
   },
   {
     "id": 873,
-    "name": "axolotl_spawn_egg",
     "displayName": "Axolotl Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "axolotl_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 874,
-    "name": "bat_spawn_egg",
     "displayName": "Bat Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bat_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 875,
-    "name": "bee_spawn_egg",
     "displayName": "Bee Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bee_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 876,
-    "name": "blaze_spawn_egg",
     "displayName": "Blaze Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blaze_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 877,
-    "name": "cat_spawn_egg",
     "displayName": "Cat Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cat_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 878,
-    "name": "cave_spider_spawn_egg",
     "displayName": "Cave Spider Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cave_spider_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 879,
-    "name": "chicken_spawn_egg",
     "displayName": "Chicken Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "chicken_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 880,
-    "name": "cod_spawn_egg",
     "displayName": "Cod Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cod_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 881,
-    "name": "cow_spawn_egg",
     "displayName": "Cow Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cow_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 882,
-    "name": "creeper_spawn_egg",
     "displayName": "Creeper Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "creeper_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 883,
-    "name": "dolphin_spawn_egg",
     "displayName": "Dolphin Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dolphin_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 884,
-    "name": "donkey_spawn_egg",
     "displayName": "Donkey Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "donkey_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 885,
-    "name": "drowned_spawn_egg",
     "displayName": "Drowned Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "drowned_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 886,
-    "name": "elder_guardian_spawn_egg",
     "displayName": "Elder Guardian Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "elder_guardian_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 887,
-    "name": "enderman_spawn_egg",
     "displayName": "Enderman Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "enderman_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 888,
-    "name": "endermite_spawn_egg",
     "displayName": "Endermite Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "endermite_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 889,
-    "name": "evoker_spawn_egg",
     "displayName": "Evoker Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "evoker_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 890,
-    "name": "fox_spawn_egg",
     "displayName": "Fox Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "fox_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 891,
-    "name": "ghast_spawn_egg",
     "displayName": "Ghast Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "ghast_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 892,
-    "name": "glow_squid_spawn_egg",
     "displayName": "Glow Squid Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "glow_squid_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 893,
-    "name": "goat_spawn_egg",
     "displayName": "Goat Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "goat_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 894,
-    "name": "guardian_spawn_egg",
     "displayName": "Guardian Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "guardian_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 895,
-    "name": "hoglin_spawn_egg",
     "displayName": "Hoglin Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "hoglin_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 896,
-    "name": "horse_spawn_egg",
     "displayName": "Horse Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "horse_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 897,
-    "name": "husk_spawn_egg",
     "displayName": "Husk Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "husk_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 898,
-    "name": "llama_spawn_egg",
     "displayName": "Llama Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "llama_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 899,
-    "name": "magma_cube_spawn_egg",
     "displayName": "Magma Cube Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "magma_cube_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 900,
-    "name": "mooshroom_spawn_egg",
     "displayName": "Mooshroom Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "mooshroom_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 901,
-    "name": "mule_spawn_egg",
     "displayName": "Mule Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "mule_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 902,
-    "name": "ocelot_spawn_egg",
     "displayName": "Ocelot Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "ocelot_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 903,
-    "name": "panda_spawn_egg",
     "displayName": "Panda Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "panda_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 904,
-    "name": "parrot_spawn_egg",
     "displayName": "Parrot Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "parrot_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 905,
-    "name": "phantom_spawn_egg",
     "displayName": "Phantom Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "phantom_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 906,
-    "name": "pig_spawn_egg",
     "displayName": "Pig Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pig_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 907,
-    "name": "piglin_spawn_egg",
     "displayName": "Piglin Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "piglin_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 908,
-    "name": "piglin_brute_spawn_egg",
     "displayName": "Piglin Brute Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "piglin_brute_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 909,
-    "name": "pillager_spawn_egg",
     "displayName": "Pillager Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pillager_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 910,
-    "name": "polar_bear_spawn_egg",
     "displayName": "Polar Bear Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polar_bear_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 911,
-    "name": "pufferfish_spawn_egg",
     "displayName": "Pufferfish Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pufferfish_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 912,
-    "name": "rabbit_spawn_egg",
     "displayName": "Rabbit Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "rabbit_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 913,
-    "name": "ravager_spawn_egg",
     "displayName": "Ravager Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "ravager_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 914,
-    "name": "salmon_spawn_egg",
     "displayName": "Salmon Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "salmon_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 915,
-    "name": "sheep_spawn_egg",
     "displayName": "Sheep Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "sheep_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 916,
-    "name": "shulker_spawn_egg",
     "displayName": "Shulker Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "shulker_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 917,
-    "name": "silverfish_spawn_egg",
     "displayName": "Silverfish Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "silverfish_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 918,
-    "name": "skeleton_spawn_egg",
     "displayName": "Skeleton Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "skeleton_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 919,
-    "name": "skeleton_horse_spawn_egg",
     "displayName": "Skeleton Horse Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "skeleton_horse_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 920,
-    "name": "slime_spawn_egg",
     "displayName": "Slime Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "slime_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 921,
-    "name": "spider_spawn_egg",
     "displayName": "Spider Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spider_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 922,
-    "name": "squid_spawn_egg",
     "displayName": "Squid Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "squid_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 923,
-    "name": "stray_spawn_egg",
     "displayName": "Stray Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stray_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 924,
-    "name": "strider_spawn_egg",
     "displayName": "Strider Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "strider_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 925,
-    "name": "trader_llama_spawn_egg",
     "displayName": "Trader Llama Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "trader_llama_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 926,
-    "name": "tropical_fish_spawn_egg",
     "displayName": "Tropical Fish Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "tropical_fish_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 927,
-    "name": "turtle_spawn_egg",
     "displayName": "Turtle Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "turtle_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 928,
-    "name": "vex_spawn_egg",
     "displayName": "Vex Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "vex_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 929,
-    "name": "villager_spawn_egg",
     "displayName": "Villager Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "villager_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 930,
-    "name": "vindicator_spawn_egg",
     "displayName": "Vindicator Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "vindicator_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 931,
-    "name": "wandering_trader_spawn_egg",
     "displayName": "Wandering Trader Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "wandering_trader_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 932,
-    "name": "witch_spawn_egg",
     "displayName": "Witch Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "witch_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 933,
-    "name": "wither_skeleton_spawn_egg",
     "displayName": "Wither Skeleton Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "wither_skeleton_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 934,
-    "name": "wolf_spawn_egg",
     "displayName": "Wolf Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "wolf_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 935,
-    "name": "zoglin_spawn_egg",
     "displayName": "Zoglin Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "zoglin_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 936,
-    "name": "zombie_spawn_egg",
     "displayName": "Zombie Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "zombie_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 937,
-    "name": "zombie_horse_spawn_egg",
     "displayName": "Zombie Horse Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "zombie_horse_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 938,
-    "name": "zombie_villager_spawn_egg",
     "displayName": "Zombie Villager Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "zombie_villager_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 939,
-    "name": "zombified_piglin_spawn_egg",
     "displayName": "Zombified Piglin Spawn Egg",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "zombified_piglin_spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 940,
-    "name": "experience_bottle",
     "displayName": "Bottle o' Enchanting",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "experience_bottle",
+    "stackSize": 64
   },
   {
     "id": 941,
-    "name": "fire_charge",
     "displayName": "Fire Charge",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "fire_charge",
+    "stackSize": 64
   },
   {
     "id": 942,
-    "name": "writable_book",
     "displayName": "Book and Quill",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "writable_book",
+    "stackSize": 1
   },
   {
     "id": 943,
-    "name": "written_book",
     "displayName": "Written Book",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "written_book",
+    "stackSize": 16
   },
   {
     "id": 944,
-    "name": "item_frame",
     "displayName": "Item Frame",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "item_frame",
+    "stackSize": 64
   },
   {
     "id": 945,
-    "name": "glow_item_frame",
     "displayName": "Glow Item Frame",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "glow_item_frame",
+    "stackSize": 64
   },
   {
     "id": 946,
-    "name": "flower_pot",
     "displayName": "Flower Pot",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "flower_pot",
+    "stackSize": 64
   },
   {
     "id": 947,
-    "name": "carrot",
     "displayName": "Carrot",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "carrot",
+    "stackSize": 64
   },
   {
     "id": 948,
-    "name": "potato",
     "displayName": "Potato",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "potato",
+    "stackSize": 64
   },
   {
     "id": 949,
-    "name": "baked_potato",
     "displayName": "Baked Potato",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "baked_potato",
+    "stackSize": 64
   },
   {
     "id": 950,
-    "name": "poisonous_potato",
     "displayName": "Poisonous Potato",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "poisonous_potato",
+    "stackSize": 64
   },
   {
     "id": 951,
-    "name": "map",
     "displayName": "Empty Map",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "map",
+    "stackSize": 64
   },
   {
     "id": 952,
-    "name": "golden_carrot",
     "displayName": "Golden Carrot",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "golden_carrot",
+    "stackSize": 64
   },
   {
     "id": 953,
-    "name": "skeleton_skull",
     "displayName": "Skeleton Skull",
-    "stackSize": 64,
-    "enchantCategories": [
-      "wearable",
-      "vanishable"
-    ]
+    "name": "skeleton_skull",
+    "stackSize": 64
   },
   {
     "id": 954,
-    "name": "wither_skeleton_skull",
     "displayName": "Wither Skeleton Skull",
-    "stackSize": 64,
-    "enchantCategories": [
-      "wearable",
-      "vanishable"
-    ]
+    "name": "wither_skeleton_skull",
+    "stackSize": 64
   },
   {
     "id": 955,
-    "name": "player_head",
     "displayName": "Player Head",
+    "name": "player_head",
     "stackSize": 64,
     "enchantCategories": [
       "wearable",
@@ -7347,8 +6365,8 @@
   },
   {
     "id": 956,
-    "name": "zombie_head",
     "displayName": "Zombie Head",
+    "name": "zombie_head",
     "stackSize": 64,
     "enchantCategories": [
       "wearable",
@@ -7357,8 +6375,8 @@
   },
   {
     "id": 957,
-    "name": "creeper_head",
     "displayName": "Creeper Head",
+    "name": "creeper_head",
     "stackSize": 64,
     "enchantCategories": [
       "wearable",
@@ -7367,8 +6385,8 @@
   },
   {
     "id": 958,
-    "name": "dragon_head",
     "displayName": "Dragon Head",
+    "name": "dragon_head",
     "stackSize": 64,
     "enchantCategories": [
       "wearable",
@@ -7377,364 +6395,315 @@
   },
   {
     "id": 959,
-    "name": "nether_star",
     "displayName": "Nether Star",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "nether_star",
+    "stackSize": 64
   },
   {
     "id": 960,
-    "name": "pumpkin_pie",
     "displayName": "Pumpkin Pie",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pumpkin_pie",
+    "stackSize": 64
   },
   {
     "id": 961,
-    "name": "firework_rocket",
     "displayName": "Firework Rocket",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "firework_rocket",
+    "stackSize": 64
   },
   {
     "id": 962,
-    "name": "firework_star",
     "displayName": "Firework Star",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "firework_star",
+    "stackSize": 64
   },
   {
     "id": 963,
-    "name": "enchanted_book",
     "displayName": "Enchanted Book",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "enchanted_book",
+    "stackSize": 1
   },
   {
     "id": 964,
-    "name": "nether_brick",
     "displayName": "Nether Brick",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "nether_brick",
+    "stackSize": 64
   },
   {
     "id": 965,
-    "name": "prismarine_shard",
     "displayName": "Prismarine Shard",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "prismarine_shard",
+    "stackSize": 64
   },
   {
     "id": 966,
-    "name": "prismarine_crystals",
     "displayName": "Prismarine Crystals",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "prismarine_crystals",
+    "stackSize": 64
   },
   {
     "id": 967,
-    "name": "rabbit",
     "displayName": "Raw Rabbit",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "rabbit",
+    "stackSize": 64
   },
   {
     "id": 968,
-    "name": "cooked_rabbit",
     "displayName": "Cooked Rabbit",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cooked_rabbit",
+    "stackSize": 64
   },
   {
     "id": 969,
-    "name": "rabbit_stew",
     "displayName": "Rabbit Stew",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "rabbit_stew",
+    "stackSize": 1
   },
   {
     "id": 970,
-    "name": "rabbit_foot",
     "displayName": "Rabbit's Foot",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "rabbit_foot",
+    "stackSize": 64
   },
   {
     "id": 971,
-    "name": "rabbit_hide",
     "displayName": "Rabbit Hide",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "rabbit_hide",
+    "stackSize": 64
   },
   {
     "id": 972,
-    "name": "armor_stand",
     "displayName": "Armor Stand",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "armor_stand",
+    "stackSize": 16
   },
   {
     "id": 973,
-    "name": "iron_horse_armor",
     "displayName": "Iron Horse Armor",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "iron_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 974,
-    "name": "golden_horse_armor",
     "displayName": "Golden Horse Armor",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "golden_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 975,
-    "name": "diamond_horse_armor",
     "displayName": "Diamond Horse Armor",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "diamond_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 976,
-    "name": "leather_horse_armor",
     "displayName": "Leather Horse Armor",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "leather_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 977,
-    "name": "lead",
     "displayName": "Lead",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lead",
+    "stackSize": 64
   },
   {
     "id": 978,
-    "name": "name_tag",
     "displayName": "Name Tag",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "name_tag",
+    "stackSize": 64
   },
   {
     "id": 979,
-    "name": "command_block_minecart",
     "displayName": "Minecart with Command Block",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "command_block_minecart",
+    "stackSize": 1
   },
   {
     "id": 980,
-    "name": "mutton",
     "displayName": "Raw Mutton",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "mutton",
+    "stackSize": 64
   },
   {
     "id": 981,
-    "name": "cooked_mutton",
     "displayName": "Cooked Mutton",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cooked_mutton",
+    "stackSize": 64
   },
   {
     "id": 982,
-    "name": "white_banner",
     "displayName": "White Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "white_banner",
+    "stackSize": 16
   },
   {
     "id": 983,
-    "name": "orange_banner",
     "displayName": "Orange Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "orange_banner",
+    "stackSize": 16
   },
   {
     "id": 984,
-    "name": "magenta_banner",
     "displayName": "Magenta Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "magenta_banner",
+    "stackSize": 16
   },
   {
     "id": 985,
-    "name": "light_blue_banner",
     "displayName": "Light Blue Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "light_blue_banner",
+    "stackSize": 16
   },
   {
     "id": 986,
-    "name": "yellow_banner",
     "displayName": "Yellow Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "yellow_banner",
+    "stackSize": 16
   },
   {
     "id": 987,
-    "name": "lime_banner",
     "displayName": "Lime Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "lime_banner",
+    "stackSize": 16
   },
   {
     "id": 988,
-    "name": "pink_banner",
     "displayName": "Pink Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "pink_banner",
+    "stackSize": 16
   },
   {
     "id": 989,
-    "name": "gray_banner",
     "displayName": "Gray Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "gray_banner",
+    "stackSize": 16
   },
   {
     "id": 990,
-    "name": "light_gray_banner",
     "displayName": "Light Gray Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "light_gray_banner",
+    "stackSize": 16
   },
   {
     "id": 991,
-    "name": "cyan_banner",
     "displayName": "Cyan Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "cyan_banner",
+    "stackSize": 16
   },
   {
     "id": 992,
-    "name": "purple_banner",
     "displayName": "Purple Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "purple_banner",
+    "stackSize": 16
   },
   {
     "id": 993,
-    "name": "blue_banner",
     "displayName": "Blue Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "blue_banner",
+    "stackSize": 16
   },
   {
     "id": 994,
-    "name": "brown_banner",
     "displayName": "Brown Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "brown_banner",
+    "stackSize": 16
   },
   {
     "id": 995,
-    "name": "green_banner",
     "displayName": "Green Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "green_banner",
+    "stackSize": 16
   },
   {
     "id": 996,
-    "name": "red_banner",
     "displayName": "Red Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "red_banner",
+    "stackSize": 16
   },
   {
     "id": 997,
-    "name": "black_banner",
     "displayName": "Black Banner",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "black_banner",
+    "stackSize": 16
   },
   {
     "id": 998,
-    "name": "end_crystal",
     "displayName": "End Crystal",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "end_crystal",
+    "stackSize": 64
   },
   {
     "id": 999,
-    "name": "chorus_fruit",
     "displayName": "Chorus Fruit",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "chorus_fruit",
+    "stackSize": 64
   },
   {
     "id": 1000,
-    "name": "popped_chorus_fruit",
     "displayName": "Popped Chorus Fruit",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "popped_chorus_fruit",
+    "stackSize": 64
   },
   {
     "id": 1001,
-    "name": "beetroot",
     "displayName": "Beetroot",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "beetroot",
+    "stackSize": 64
   },
   {
     "id": 1002,
-    "name": "beetroot_seeds",
     "displayName": "Beetroot Seeds",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "beetroot_seeds",
+    "stackSize": 64
   },
   {
     "id": 1003,
-    "name": "beetroot_soup",
     "displayName": "Beetroot Soup",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "beetroot_soup",
+    "stackSize": 1
   },
   {
     "id": 1004,
-    "name": "dragon_breath",
     "displayName": "Dragon's Breath",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "dragon_breath",
+    "stackSize": 64
   },
   {
     "id": 1005,
-    "name": "splash_potion",
     "displayName": "Splash Potion",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "splash_potion",
+    "stackSize": 1
   },
   {
     "id": 1006,
-    "name": "spectral_arrow",
     "displayName": "Spectral Arrow",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "spectral_arrow",
+    "stackSize": 64
   },
   {
     "id": 1007,
-    "name": "tipped_arrow",
     "displayName": "Tipped Arrow",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "tipped_arrow",
+    "stackSize": 64
   },
   {
     "id": 1008,
-    "name": "lingering_potion",
     "displayName": "Lingering Potion",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "lingering_potion",
+    "stackSize": 1
   },
   {
     "id": 1009,
-    "name": "shield",
     "displayName": "Shield",
+    "name": "shield",
     "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
     ],
-    "fixedWith": [
+    "repairWith": [
       "oak_planks",
       "spruce_planks",
       "birch_planks",
@@ -7743,652 +6712,558 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "durability": 336,
-    "maxDurability": 336
+    ]
   },
   {
     "id": 1010,
-    "name": "totem_of_undying",
     "displayName": "Totem of Undying",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "totem_of_undying",
+    "stackSize": 1
   },
   {
     "id": 1011,
-    "name": "shulker_shell",
     "displayName": "Shulker Shell",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "shulker_shell",
+    "stackSize": 64
   },
   {
     "id": 1012,
-    "name": "iron_nugget",
     "displayName": "Iron Nugget",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "iron_nugget",
+    "stackSize": 64
   },
   {
     "id": 1013,
-    "name": "knowledge_book",
     "displayName": "Knowledge Book",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "knowledge_book",
+    "stackSize": 1
   },
   {
     "id": 1014,
-    "name": "debug_stick",
     "displayName": "Debug Stick",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "debug_stick",
+    "stackSize": 1
   },
   {
     "id": 1015,
+    "displayName": "13 Disc",
     "name": "music_disc_13",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1016,
+    "displayName": "Cat Disc",
     "name": "music_disc_cat",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1017,
+    "displayName": "Blocks Disc",
     "name": "music_disc_blocks",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1018,
+    "displayName": "Chirp Disc",
     "name": "music_disc_chirp",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1019,
+    "displayName": "Far Disc",
     "name": "music_disc_far",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1020,
+    "displayName": "Mall Disc",
     "name": "music_disc_mall",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1021,
+    "displayName": "Mellohi Disc",
     "name": "music_disc_mellohi",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1022,
+    "displayName": "Stal Disc",
     "name": "music_disc_stal",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1023,
+    "displayName": "Strad Disc",
     "name": "music_disc_strad",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1024,
+    "displayName": "Ward Disc",
     "name": "music_disc_ward",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1025,
+    "displayName": "11 Disc",
     "name": "music_disc_11",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1026,
+    "displayName": "Wait Disc",
     "name": "music_disc_wait",
-    "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "stackSize": 1
   },
   {
     "id": 1027,
-    "name": "music_disc_pigstep",
     "displayName": "Music Disc",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "music_disc_pigstep",
+    "stackSize": 1
   },
   {
     "id": 1028,
-    "name": "trident",
     "displayName": "Trident",
+    "name": "trident",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
-      "trident",
       "breakable",
-      "vanishable"
-    ],
-    "fixedWith": [],
-    "durability": 250,
-    "maxDurability": 250
+      "vanishable",
+      "trident"
+    ]
   },
   {
     "id": 1029,
-    "name": "phantom_membrane",
     "displayName": "Phantom Membrane",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "phantom_membrane",
+    "stackSize": 64
   },
   {
     "id": 1030,
-    "name": "nautilus_shell",
     "displayName": "Nautilus Shell",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "nautilus_shell",
+    "stackSize": 64
   },
   {
     "id": 1031,
-    "name": "heart_of_the_sea",
     "displayName": "Heart of the Sea",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "heart_of_the_sea",
+    "stackSize": 64
   },
   {
     "id": 1032,
-    "name": "crossbow",
     "displayName": "Crossbow",
+    "name": "crossbow",
     "stackSize": 1,
+    "maxDurability": 326,
     "enchantCategories": [
       "breakable",
-      "crossbow",
-      "vanishable"
-    ],
-    "fixedWith": [],
-    "durability": 326,
-    "maxDurability": 326
+      "vanishable",
+      "crossbow"
+    ]
   },
   {
     "id": 1033,
-    "name": "suspicious_stew",
     "displayName": "Suspicious Stew",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "suspicious_stew",
+    "stackSize": 1
   },
   {
     "id": 1034,
-    "name": "loom",
     "displayName": "Loom",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "loom",
+    "stackSize": 64
   },
   {
     "id": 1035,
-    "name": "flower_banner_pattern",
     "displayName": "Banner Pattern",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "flower_banner_pattern",
+    "stackSize": 1
   },
   {
     "id": 1036,
-    "name": "creeper_banner_pattern",
     "displayName": "Banner Pattern",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "creeper_banner_pattern",
+    "stackSize": 1
   },
   {
     "id": 1037,
-    "name": "skull_banner_pattern",
     "displayName": "Banner Pattern",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "skull_banner_pattern",
+    "stackSize": 1
   },
   {
     "id": 1038,
-    "name": "mojang_banner_pattern",
     "displayName": "Banner Pattern",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "mojang_banner_pattern",
+    "stackSize": 1
   },
   {
     "id": 1039,
-    "name": "globe_banner_pattern",
     "displayName": "Banner Pattern",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "globe_banner_pattern",
+    "stackSize": 1
   },
   {
     "id": 1040,
-    "name": "piglin_banner_pattern",
     "displayName": "Banner Pattern",
-    "stackSize": 1,
-    "enchantCategories": []
+    "name": "piglin_banner_pattern",
+    "stackSize": 1
   },
   {
     "id": 1041,
-    "name": "composter",
     "displayName": "Composter",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "composter",
+    "stackSize": 64
   },
   {
     "id": 1042,
-    "name": "barrel",
     "displayName": "Barrel",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "barrel",
+    "stackSize": 64
   },
   {
     "id": 1043,
-    "name": "smoker",
     "displayName": "Smoker",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "smoker",
+    "stackSize": 64
   },
   {
     "id": 1044,
-    "name": "blast_furnace",
     "displayName": "Blast Furnace",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blast_furnace",
+    "stackSize": 64
   },
   {
     "id": 1045,
-    "name": "cartography_table",
     "displayName": "Cartography Table",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cartography_table",
+    "stackSize": 64
   },
   {
     "id": 1046,
-    "name": "fletching_table",
     "displayName": "Fletching Table",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "fletching_table",
+    "stackSize": 64
   },
   {
     "id": 1047,
-    "name": "grindstone",
     "displayName": "Grindstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "grindstone",
+    "stackSize": 64
   },
   {
     "id": 1048,
-    "name": "smithing_table",
     "displayName": "Smithing Table",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "smithing_table",
+    "stackSize": 64
   },
   {
     "id": 1049,
-    "name": "stonecutter",
     "displayName": "Stonecutter",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "stonecutter",
+    "stackSize": 64
   },
   {
     "id": 1050,
-    "name": "bell",
     "displayName": "Bell",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bell",
+    "stackSize": 64
   },
   {
     "id": 1051,
-    "name": "lantern",
     "displayName": "Lantern",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lantern",
+    "stackSize": 64
   },
   {
     "id": 1052,
-    "name": "soul_lantern",
     "displayName": "Soul Lantern",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "soul_lantern",
+    "stackSize": 64
   },
   {
     "id": 1053,
-    "name": "sweet_berries",
     "displayName": "Sweet Berries",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "sweet_berries",
+    "stackSize": 64
   },
   {
     "id": 1054,
-    "name": "glow_berries",
     "displayName": "Glow Berries",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "glow_berries",
+    "stackSize": 64
   },
   {
     "id": 1055,
-    "name": "campfire",
     "displayName": "Campfire",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "campfire",
+    "stackSize": 64
   },
   {
     "id": 1056,
-    "name": "soul_campfire",
     "displayName": "Soul Campfire",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "soul_campfire",
+    "stackSize": 64
   },
   {
     "id": 1057,
-    "name": "shroomlight",
     "displayName": "Shroomlight",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "shroomlight",
+    "stackSize": 64
   },
   {
     "id": 1058,
-    "name": "honeycomb",
     "displayName": "Honeycomb",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "honeycomb",
+    "stackSize": 64
   },
   {
     "id": 1059,
-    "name": "bee_nest",
     "displayName": "Bee Nest",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "bee_nest",
+    "stackSize": 64
   },
   {
     "id": 1060,
-    "name": "beehive",
     "displayName": "Beehive",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "beehive",
+    "stackSize": 64
   },
   {
     "id": 1061,
-    "name": "honey_bottle",
     "displayName": "Honey Bottle",
-    "stackSize": 16,
-    "enchantCategories": []
+    "name": "honey_bottle",
+    "stackSize": 16
   },
   {
     "id": 1062,
-    "name": "honeycomb_block",
     "displayName": "Honeycomb Block",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "honeycomb_block",
+    "stackSize": 64
   },
   {
     "id": 1063,
-    "name": "lodestone",
     "displayName": "Lodestone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lodestone",
+    "stackSize": 64
   },
   {
     "id": 1064,
-    "name": "crying_obsidian",
     "displayName": "Crying Obsidian",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "crying_obsidian",
+    "stackSize": 64
   },
   {
     "id": 1065,
-    "name": "blackstone",
     "displayName": "Blackstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blackstone",
+    "stackSize": 64
   },
   {
     "id": 1066,
-    "name": "blackstone_slab",
     "displayName": "Blackstone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blackstone_slab",
+    "stackSize": 64
   },
   {
     "id": 1067,
-    "name": "blackstone_stairs",
     "displayName": "Blackstone Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blackstone_stairs",
+    "stackSize": 64
   },
   {
     "id": 1068,
-    "name": "gilded_blackstone",
     "displayName": "Gilded Blackstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gilded_blackstone",
+    "stackSize": 64
   },
   {
     "id": 1069,
-    "name": "polished_blackstone",
     "displayName": "Polished Blackstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_blackstone",
+    "stackSize": 64
   },
   {
     "id": 1070,
-    "name": "polished_blackstone_slab",
     "displayName": "Polished Blackstone Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_blackstone_slab",
+    "stackSize": 64
   },
   {
     "id": 1071,
-    "name": "polished_blackstone_stairs",
     "displayName": "Polished Blackstone Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_blackstone_stairs",
+    "stackSize": 64
   },
   {
     "id": 1072,
-    "name": "chiseled_polished_blackstone",
     "displayName": "Chiseled Polished Blackstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "chiseled_polished_blackstone",
+    "stackSize": 64
   },
   {
     "id": 1073,
-    "name": "polished_blackstone_bricks",
     "displayName": "Polished Blackstone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_blackstone_bricks",
+    "stackSize": 64
   },
   {
     "id": 1074,
-    "name": "polished_blackstone_brick_slab",
     "displayName": "Polished Blackstone Brick Slab",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_blackstone_brick_slab",
+    "stackSize": 64
   },
   {
     "id": 1075,
-    "name": "polished_blackstone_brick_stairs",
     "displayName": "Polished Blackstone Brick Stairs",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "polished_blackstone_brick_stairs",
+    "stackSize": 64
   },
   {
     "id": 1076,
-    "name": "cracked_polished_blackstone_bricks",
     "displayName": "Cracked Polished Blackstone Bricks",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cracked_polished_blackstone_bricks",
+    "stackSize": 64
   },
   {
     "id": 1077,
-    "name": "respawn_anchor",
     "displayName": "Respawn Anchor",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "respawn_anchor",
+    "stackSize": 64
   },
   {
     "id": 1078,
-    "name": "candle",
     "displayName": "Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "candle",
+    "stackSize": 64
   },
   {
     "id": 1079,
-    "name": "white_candle",
     "displayName": "White Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "white_candle",
+    "stackSize": 64
   },
   {
     "id": 1080,
-    "name": "orange_candle",
     "displayName": "Orange Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "orange_candle",
+    "stackSize": 64
   },
   {
     "id": 1081,
-    "name": "magenta_candle",
     "displayName": "Magenta Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "magenta_candle",
+    "stackSize": 64
   },
   {
     "id": 1082,
-    "name": "light_blue_candle",
     "displayName": "Light Blue Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "light_blue_candle",
+    "stackSize": 64
   },
   {
     "id": 1083,
-    "name": "yellow_candle",
     "displayName": "Yellow Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "yellow_candle",
+    "stackSize": 64
   },
   {
     "id": 1084,
-    "name": "lime_candle",
     "displayName": "Lime Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "lime_candle",
+    "stackSize": 64
   },
   {
     "id": 1085,
-    "name": "pink_candle",
     "displayName": "Pink Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pink_candle",
+    "stackSize": 64
   },
   {
     "id": 1086,
-    "name": "gray_candle",
     "displayName": "Gray Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "gray_candle",
+    "stackSize": 64
   },
   {
     "id": 1087,
-    "name": "light_gray_candle",
     "displayName": "Light Gray Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "light_gray_candle",
+    "stackSize": 64
   },
   {
     "id": 1088,
-    "name": "cyan_candle",
     "displayName": "Cyan Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "cyan_candle",
+    "stackSize": 64
   },
   {
     "id": 1089,
-    "name": "purple_candle",
     "displayName": "Purple Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "purple_candle",
+    "stackSize": 64
   },
   {
     "id": 1090,
-    "name": "blue_candle",
     "displayName": "Blue Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "blue_candle",
+    "stackSize": 64
   },
   {
     "id": 1091,
-    "name": "brown_candle",
     "displayName": "Brown Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "brown_candle",
+    "stackSize": 64
   },
   {
     "id": 1092,
-    "name": "green_candle",
     "displayName": "Green Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "green_candle",
+    "stackSize": 64
   },
   {
     "id": 1093,
-    "name": "red_candle",
     "displayName": "Red Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "red_candle",
+    "stackSize": 64
   },
   {
     "id": 1094,
-    "name": "black_candle",
     "displayName": "Black Candle",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "black_candle",
+    "stackSize": 64
   },
   {
     "id": 1095,
-    "name": "small_amethyst_bud",
     "displayName": "Small Amethyst Bud",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "small_amethyst_bud",
+    "stackSize": 64
   },
   {
     "id": 1096,
-    "name": "medium_amethyst_bud",
     "displayName": "Medium Amethyst Bud",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "medium_amethyst_bud",
+    "stackSize": 64
   },
   {
     "id": 1097,
-    "name": "large_amethyst_bud",
     "displayName": "Large Amethyst Bud",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "large_amethyst_bud",
+    "stackSize": 64
   },
   {
     "id": 1098,
-    "name": "amethyst_cluster",
     "displayName": "Amethyst Cluster",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "amethyst_cluster",
+    "stackSize": 64
   },
   {
     "id": 1099,
-    "name": "pointed_dripstone",
     "displayName": "Pointed Dripstone",
-    "stackSize": 64,
-    "enchantCategories": []
+    "name": "pointed_dripstone",
+    "stackSize": 64
   }
 ]

--- a/data/pc/1.7/items.json
+++ b/data/pc/1.7/items.json
@@ -994,7 +994,6 @@
     "displayName": "Iron Shovel",
     "stackSize": 1,
     "name": "iron_shovel",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1010,7 +1009,6 @@
     "displayName": "Iron Pickaxe",
     "stackSize": 1,
     "name": "iron_pickaxe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1026,7 +1024,6 @@
     "displayName": "Iron Axe",
     "stackSize": 1,
     "name": "iron_axe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1042,7 +1039,6 @@
     "displayName": "Flint and Steel",
     "stackSize": 1,
     "name": "flint_and_steel",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -1060,7 +1056,6 @@
     "displayName": "Bow",
     "stackSize": 1,
     "name": "bow",
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -1113,7 +1108,6 @@
     "displayName": "Iron Sword",
     "stackSize": 1,
     "name": "iron_sword",
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1129,7 +1123,6 @@
     "displayName": "Wooden Sword",
     "stackSize": 1,
     "name": "wooden_sword",
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1152,7 +1145,6 @@
     "displayName": "Wooden Shovel",
     "stackSize": 1,
     "name": "wooden_shovel",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1175,7 +1167,6 @@
     "displayName": "Wooden Pickaxe",
     "stackSize": 1,
     "name": "wooden_pickaxe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1198,7 +1189,6 @@
     "displayName": "Wooden Axe",
     "stackSize": 1,
     "name": "wooden_axe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1221,7 +1211,6 @@
     "displayName": "Stone Sword",
     "stackSize": 1,
     "name": "stone_sword",
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1238,7 +1227,6 @@
     "displayName": "Stone Shovel",
     "stackSize": 1,
     "name": "stone_shovel",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1255,7 +1243,6 @@
     "displayName": "Stone Pickaxe",
     "stackSize": 1,
     "name": "stone_pickaxe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1272,7 +1259,6 @@
     "displayName": "Stone Axe",
     "stackSize": 1,
     "name": "stone_axe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1289,7 +1275,6 @@
     "displayName": "Diamond Sword",
     "stackSize": 1,
     "name": "diamond_sword",
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1305,7 +1290,6 @@
     "displayName": "Diamond Shovel",
     "stackSize": 1,
     "name": "diamond_shovel",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1321,7 +1305,6 @@
     "displayName": "Diamond Pickaxe",
     "stackSize": 1,
     "name": "diamond_pickaxe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1337,7 +1320,6 @@
     "displayName": "Diamond Axe",
     "stackSize": 1,
     "name": "diamond_axe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1371,7 +1353,6 @@
     "displayName": "Golden Sword",
     "stackSize": 1,
     "name": "golden_sword",
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1387,7 +1368,6 @@
     "displayName": "Golden Shovel",
     "stackSize": 1,
     "name": "golden_shovel",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1403,7 +1383,6 @@
     "displayName": "Golden Pickaxe",
     "stackSize": 1,
     "name": "golden_pickaxe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1419,7 +1398,6 @@
     "displayName": "Golden Axe",
     "stackSize": 1,
     "name": "golden_axe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1453,7 +1431,6 @@
     "displayName": "Wooden Hoe",
     "stackSize": 1,
     "name": "wooden_hoe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1476,7 +1453,6 @@
     "displayName": "Stone Hoe",
     "stackSize": 1,
     "name": "stone_hoe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1493,7 +1469,6 @@
     "displayName": "Iron Hoe",
     "stackSize": 1,
     "name": "iron_hoe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1509,7 +1484,6 @@
     "displayName": "Diamond Hoe",
     "stackSize": 1,
     "name": "diamond_hoe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1525,7 +1499,6 @@
     "displayName": "Golden Hoe",
     "stackSize": 1,
     "name": "golden_hoe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1559,10 +1532,8 @@
     "displayName": "Leather Cap",
     "stackSize": 1,
     "name": "leather_helmet",
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1578,7 +1549,6 @@
     "displayName": "Leather Tunic",
     "stackSize": 1,
     "name": "leather_chestplate",
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1596,10 +1566,8 @@
     "displayName": "Leather Pants",
     "stackSize": 1,
     "name": "leather_leggings",
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1614,11 +1582,9 @@
     "displayName": "Leather Boots",
     "stackSize": 1,
     "name": "leather_boots",
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1633,10 +1599,8 @@
     "displayName": "Chain Helmet",
     "stackSize": 1,
     "name": "chainmail_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1652,7 +1616,6 @@
     "displayName": "Chain Tunic",
     "stackSize": 1,
     "name": "chainmail_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1670,10 +1633,8 @@
     "displayName": "Chain Leggings",
     "stackSize": 1,
     "name": "chainmail_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1688,11 +1649,9 @@
     "displayName": "Chain Boots",
     "stackSize": 1,
     "name": "chainmail_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1707,10 +1666,8 @@
     "displayName": "Iron Helmet",
     "stackSize": 1,
     "name": "iron_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1726,7 +1683,6 @@
     "displayName": "Iron Chestplate",
     "stackSize": 1,
     "name": "iron_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1744,10 +1700,8 @@
     "displayName": "Iron Leggings",
     "stackSize": 1,
     "name": "iron_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1762,11 +1716,9 @@
     "displayName": "Iron Boots",
     "stackSize": 1,
     "name": "iron_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1781,10 +1733,8 @@
     "displayName": "Diamond Helmet",
     "stackSize": 1,
     "name": "diamond_helmet",
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1800,7 +1750,6 @@
     "displayName": "Diamond Chestplate",
     "stackSize": 1,
     "name": "diamond_chestplate",
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1818,10 +1767,8 @@
     "displayName": "Diamond Leggings",
     "stackSize": 1,
     "name": "diamond_leggings",
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1836,11 +1783,9 @@
     "displayName": "Diamond Boots",
     "stackSize": 1,
     "name": "diamond_boots",
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1855,10 +1800,8 @@
     "displayName": "Golden Helmet",
     "stackSize": 1,
     "name": "golden_helmet",
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1874,7 +1817,6 @@
     "displayName": "Golden Chestplate",
     "stackSize": 1,
     "name": "golden_chestplate",
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1892,10 +1834,8 @@
     "displayName": "Golden Leggings",
     "stackSize": 1,
     "name": "golden_leggings",
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1910,11 +1850,9 @@
     "displayName": "Golden Boots",
     "stackSize": 1,
     "name": "golden_boots",
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2107,7 +2045,6 @@
     "displayName": "Fishing Rod",
     "stackSize": 1,
     "name": "fishing_rod",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -2258,7 +2195,6 @@
     "displayName": "Shears",
     "stackSize": 1,
     "name": "shears",
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -2520,7 +2456,6 @@
     "displayName": "Carrot on a Stick",
     "stackSize": 1,
     "name": "carrot_on_a_stick",
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"

--- a/data/pc/1.8/items.json
+++ b/data/pc/1.8/items.json
@@ -1096,7 +1096,6 @@
     "displayName": "Iron Shovel",
     "stackSize": 1,
     "name": "iron_shovel",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1112,7 +1111,6 @@
     "displayName": "Iron Pickaxe",
     "stackSize": 1,
     "name": "iron_pickaxe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1128,7 +1126,6 @@
     "displayName": "Iron Axe",
     "stackSize": 1,
     "name": "iron_axe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1144,7 +1141,6 @@
     "displayName": "Flint and Steel",
     "stackSize": 1,
     "name": "flint_and_steel",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -1162,7 +1158,6 @@
     "displayName": "Bow",
     "stackSize": 1,
     "name": "bow",
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -1215,7 +1210,6 @@
     "displayName": "Iron Sword",
     "stackSize": 1,
     "name": "iron_sword",
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1231,7 +1225,6 @@
     "displayName": "Wooden Sword",
     "stackSize": 1,
     "name": "wooden_sword",
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1254,7 +1247,6 @@
     "displayName": "Wooden Shovel",
     "stackSize": 1,
     "name": "wooden_shovel",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1277,7 +1269,6 @@
     "displayName": "Wooden Pickaxe",
     "stackSize": 1,
     "name": "wooden_pickaxe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1300,7 +1291,6 @@
     "displayName": "Wooden Axe",
     "stackSize": 1,
     "name": "wooden_axe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1323,7 +1313,6 @@
     "displayName": "Stone Sword",
     "stackSize": 1,
     "name": "stone_sword",
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1340,7 +1329,6 @@
     "displayName": "Stone Shovel",
     "stackSize": 1,
     "name": "stone_shovel",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1357,7 +1345,6 @@
     "displayName": "Stone Pickaxe",
     "stackSize": 1,
     "name": "stone_pickaxe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1374,7 +1361,6 @@
     "displayName": "Stone Axe",
     "stackSize": 1,
     "name": "stone_axe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1391,7 +1377,6 @@
     "displayName": "Diamond Sword",
     "stackSize": 1,
     "name": "diamond_sword",
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1407,7 +1392,6 @@
     "displayName": "Diamond Shovel",
     "stackSize": 1,
     "name": "diamond_shovel",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1423,7 +1407,6 @@
     "displayName": "Diamond Pickaxe",
     "stackSize": 1,
     "name": "diamond_pickaxe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1439,7 +1422,6 @@
     "displayName": "Diamond Axe",
     "stackSize": 1,
     "name": "diamond_axe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1473,7 +1455,6 @@
     "displayName": "Golden Sword",
     "stackSize": 1,
     "name": "golden_sword",
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1489,7 +1470,6 @@
     "displayName": "Golden Shovel",
     "stackSize": 1,
     "name": "golden_shovel",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1505,7 +1485,6 @@
     "displayName": "Golden Pickaxe",
     "stackSize": 1,
     "name": "golden_pickaxe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1521,7 +1500,6 @@
     "displayName": "Golden Axe",
     "stackSize": 1,
     "name": "golden_axe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1555,7 +1533,6 @@
     "displayName": "Wooden Hoe",
     "stackSize": 1,
     "name": "wooden_hoe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1578,7 +1555,6 @@
     "displayName": "Stone Hoe",
     "stackSize": 1,
     "name": "stone_hoe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1595,7 +1571,6 @@
     "displayName": "Iron Hoe",
     "stackSize": 1,
     "name": "iron_hoe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1611,7 +1586,6 @@
     "displayName": "Diamond Hoe",
     "stackSize": 1,
     "name": "diamond_hoe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1627,7 +1601,6 @@
     "displayName": "Golden Hoe",
     "stackSize": 1,
     "name": "golden_hoe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1661,10 +1634,8 @@
     "displayName": "Leather Cap",
     "stackSize": 1,
     "name": "leather_helmet",
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1680,7 +1651,6 @@
     "displayName": "Leather Tunic",
     "stackSize": 1,
     "name": "leather_chestplate",
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1698,10 +1668,8 @@
     "displayName": "Leather Pants",
     "stackSize": 1,
     "name": "leather_leggings",
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1716,11 +1684,9 @@
     "displayName": "Leather Boots",
     "stackSize": 1,
     "name": "leather_boots",
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1735,10 +1701,8 @@
     "displayName": "Chain Helmet",
     "stackSize": 1,
     "name": "chainmail_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1754,7 +1718,6 @@
     "displayName": "Chain Chestplate",
     "stackSize": 1,
     "name": "chainmail_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1772,10 +1735,8 @@
     "displayName": "Chain Leggings",
     "stackSize": 1,
     "name": "chainmail_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1790,11 +1751,9 @@
     "displayName": "Chain Boots",
     "stackSize": 1,
     "name": "chainmail_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1809,10 +1768,8 @@
     "displayName": "Iron Helmet",
     "stackSize": 1,
     "name": "iron_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1828,7 +1785,6 @@
     "displayName": "Iron Chestplate",
     "stackSize": 1,
     "name": "iron_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1846,10 +1802,8 @@
     "displayName": "Iron Leggings",
     "stackSize": 1,
     "name": "iron_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1864,11 +1818,9 @@
     "displayName": "Iron Boots",
     "stackSize": 1,
     "name": "iron_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1883,10 +1835,8 @@
     "displayName": "Diamond Helmet",
     "stackSize": 1,
     "name": "diamond_helmet",
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1902,7 +1852,6 @@
     "displayName": "Diamond Chestplate",
     "stackSize": 1,
     "name": "diamond_chestplate",
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1920,10 +1869,8 @@
     "displayName": "Diamond Leggings",
     "stackSize": 1,
     "name": "diamond_leggings",
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1938,11 +1885,9 @@
     "displayName": "Diamond Boots",
     "stackSize": 1,
     "name": "diamond_boots",
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1957,10 +1902,8 @@
     "displayName": "Golden Helmet",
     "stackSize": 1,
     "name": "golden_helmet",
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1976,7 +1919,6 @@
     "displayName": "Golden Chestplate",
     "stackSize": 1,
     "name": "golden_chestplate",
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1994,10 +1936,8 @@
     "displayName": "Golden Leggings",
     "stackSize": 1,
     "name": "golden_leggings",
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2012,11 +1952,9 @@
     "displayName": "Golden Boots",
     "stackSize": 1,
     "name": "golden_boots",
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2209,7 +2147,6 @@
     "displayName": "Fishing Rod",
     "stackSize": 1,
     "name": "fishing_rod",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -2378,7 +2315,6 @@
     "displayName": "Shears",
     "stackSize": 1,
     "name": "shears",
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -2698,7 +2634,6 @@
     "displayName": "Carrot on a Stick",
     "stackSize": 1,
     "name": "carrot_on_a_stick",
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"

--- a/data/pc/1.9/items.json
+++ b/data/pc/1.9/items.json
@@ -1192,7 +1192,6 @@
     "displayName": "Iron Shovel",
     "stackSize": 1,
     "name": "iron_shovel",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1208,7 +1207,6 @@
     "displayName": "Iron Pickaxe",
     "stackSize": 1,
     "name": "iron_pickaxe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1224,7 +1222,6 @@
     "displayName": "Iron Axe",
     "stackSize": 1,
     "name": "iron_axe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1240,7 +1237,6 @@
     "displayName": "Flint and Steel",
     "stackSize": 1,
     "name": "flint_and_steel",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -1258,7 +1254,6 @@
     "displayName": "Bow",
     "stackSize": 1,
     "name": "bow",
-    "durability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
@@ -1311,7 +1306,6 @@
     "displayName": "Iron Sword",
     "stackSize": 1,
     "name": "iron_sword",
-    "durability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1327,7 +1321,6 @@
     "displayName": "Wooden Sword",
     "stackSize": 1,
     "name": "wooden_sword",
-    "durability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1350,7 +1343,6 @@
     "displayName": "Wooden Shovel",
     "stackSize": 1,
     "name": "wooden_shovel",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1373,7 +1365,6 @@
     "displayName": "Wooden Pickaxe",
     "stackSize": 1,
     "name": "wooden_pickaxe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1396,7 +1387,6 @@
     "displayName": "Wooden Axe",
     "stackSize": 1,
     "name": "wooden_axe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1419,7 +1409,6 @@
     "displayName": "Stone Sword",
     "stackSize": 1,
     "name": "stone_sword",
-    "durability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1436,7 +1425,6 @@
     "displayName": "Stone Shovel",
     "stackSize": 1,
     "name": "stone_shovel",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1453,7 +1441,6 @@
     "displayName": "Stone Pickaxe",
     "stackSize": 1,
     "name": "stone_pickaxe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1470,7 +1457,6 @@
     "displayName": "Stone Axe",
     "stackSize": 1,
     "name": "stone_axe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1487,7 +1473,6 @@
     "displayName": "Diamond Sword",
     "stackSize": 1,
     "name": "diamond_sword",
-    "durability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1503,7 +1488,6 @@
     "displayName": "Diamond Shovel",
     "stackSize": 1,
     "name": "diamond_shovel",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1519,7 +1503,6 @@
     "displayName": "Diamond Pickaxe",
     "stackSize": 1,
     "name": "diamond_pickaxe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1535,7 +1518,6 @@
     "displayName": "Diamond Axe",
     "stackSize": 1,
     "name": "diamond_axe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1569,7 +1551,6 @@
     "displayName": "Golden Sword",
     "stackSize": 1,
     "name": "golden_sword",
-    "durability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1585,7 +1566,6 @@
     "displayName": "Golden Shovel",
     "stackSize": 1,
     "name": "golden_shovel",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1601,7 +1581,6 @@
     "displayName": "Golden Pickaxe",
     "stackSize": 1,
     "name": "golden_pickaxe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1617,7 +1596,6 @@
     "displayName": "Golden Axe",
     "stackSize": 1,
     "name": "golden_axe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1651,7 +1629,6 @@
     "displayName": "Wooden Hoe",
     "stackSize": 1,
     "name": "wooden_hoe",
-    "durability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1674,7 +1651,6 @@
     "displayName": "Stone Hoe",
     "stackSize": 1,
     "name": "stone_hoe",
-    "durability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1691,7 +1667,6 @@
     "displayName": "Iron Hoe",
     "stackSize": 1,
     "name": "iron_hoe",
-    "durability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1707,7 +1682,6 @@
     "displayName": "Diamond Hoe",
     "stackSize": 1,
     "name": "diamond_hoe",
-    "durability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1723,7 +1697,6 @@
     "displayName": "Golden Hoe",
     "stackSize": 1,
     "name": "golden_hoe",
-    "durability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1757,10 +1730,8 @@
     "displayName": "Leather Cap",
     "stackSize": 1,
     "name": "leather_helmet",
-    "durability": 55,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1776,7 +1747,6 @@
     "displayName": "Leather Tunic",
     "stackSize": 1,
     "name": "leather_chestplate",
-    "durability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1794,10 +1764,8 @@
     "displayName": "Leather Pants",
     "stackSize": 1,
     "name": "leather_leggings",
-    "durability": 75,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1812,11 +1780,9 @@
     "displayName": "Leather Boots",
     "stackSize": 1,
     "name": "leather_boots",
-    "durability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1831,10 +1797,8 @@
     "displayName": "Chain Helmet",
     "stackSize": 1,
     "name": "chainmail_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1850,7 +1814,6 @@
     "displayName": "Chain Chestplate",
     "stackSize": 1,
     "name": "chainmail_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1868,10 +1831,8 @@
     "displayName": "Chain Leggings",
     "stackSize": 1,
     "name": "chainmail_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1886,11 +1847,9 @@
     "displayName": "Chain Boots",
     "stackSize": 1,
     "name": "chainmail_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1905,10 +1864,8 @@
     "displayName": "Iron Helmet",
     "stackSize": 1,
     "name": "iron_helmet",
-    "durability": 165,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1924,7 +1881,6 @@
     "displayName": "Iron Chestplate",
     "stackSize": 1,
     "name": "iron_chestplate",
-    "durability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1942,10 +1898,8 @@
     "displayName": "Iron Leggings",
     "stackSize": 1,
     "name": "iron_leggings",
-    "durability": 225,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1960,11 +1914,9 @@
     "displayName": "Iron Boots",
     "stackSize": 1,
     "name": "iron_boots",
-    "durability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -1979,10 +1931,8 @@
     "displayName": "Diamond Helmet",
     "stackSize": 1,
     "name": "diamond_helmet",
-    "durability": 363,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -1998,7 +1948,6 @@
     "displayName": "Diamond Chestplate",
     "stackSize": 1,
     "name": "diamond_chestplate",
-    "durability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2016,10 +1965,8 @@
     "displayName": "Diamond Leggings",
     "stackSize": 1,
     "name": "diamond_leggings",
-    "durability": 495,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2034,11 +1981,9 @@
     "displayName": "Diamond Boots",
     "stackSize": 1,
     "name": "diamond_boots",
-    "durability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2053,10 +1998,8 @@
     "displayName": "Golden Helmet",
     "stackSize": 1,
     "name": "golden_helmet",
-    "durability": 77,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "armor_head",
       "breakable",
       "wearable",
@@ -2072,7 +2015,6 @@
     "displayName": "Golden Chestplate",
     "stackSize": 1,
     "name": "golden_chestplate",
-    "durability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2090,10 +2032,8 @@
     "displayName": "Golden Leggings",
     "stackSize": 1,
     "name": "golden_leggings",
-    "durability": 105,
     "enchantCategories": [
       "armor",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2108,11 +2048,9 @@
     "displayName": "Golden Boots",
     "stackSize": 1,
     "name": "golden_boots",
-    "durability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
-      "armor_chest",
       "breakable",
       "wearable",
       "vanishable"
@@ -2305,7 +2243,6 @@
     "displayName": "Fishing Rod",
     "stackSize": 1,
     "name": "fishing_rod",
-    "durability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
@@ -2474,7 +2411,6 @@
     "displayName": "Shears",
     "stackSize": 1,
     "name": "shears",
-    "durability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -2794,7 +2730,6 @@
     "displayName": "Carrot on a Stick",
     "stackSize": 1,
     "name": "carrot_on_a_stick",
-    "durability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3064,7 +2999,6 @@
     "displayName": "Shield",
     "stackSize": 1,
     "name": "shield",
-    "durability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3086,7 +3020,6 @@
     "displayName": "Elytra",
     "stackSize": 1,
     "name": "elytra",
-    "durability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",

--- a/schemas/items_schema.json
+++ b/schemas/items_schema.json
@@ -28,7 +28,7 @@
           "type": "string"
         }
       },
-      "fixedWith" : {
+      "repairWith" : {
         "description": "describes what items this item can be fixed with in an anvil",
         "type": "array",
         "uniqueItems": true,
@@ -62,11 +62,6 @@
           "required": ["metadata", "displayName"],
           "additionalProperties":false
         }
-      },
-      "durability": {
-        "description": "The durability of an item",
-        "type": ["integer", "null"],
-        "minimum": 0
       }
     },
     "required": ["id", "displayName", "stackSize", "name"],


### PR DESCRIPTION
This commit contains breaking changes and requires discussion, the purpose of this commit is two-fold:

* Fix a data-bug with `enchantCategories` inherited from turbo-invention (see https://github.com/u9g/turbo-invention/pull/1)

* Get all `items.json`s and the associated schema in-line with what's generated by the automated tooling. This causes two changes:
    * Removes the `durability` field, it is always either `null` or a duplicate of `maxDurability`, and turbo-invention only adds `maxDurability`
    * `fixedWith` -> `repairWith`, the data and schema disagreed here, as this field was always called `repairWith` in all versions except 1.17
