### PR TITLE
Make items.json more goodly for great honor of Prismarine Project and Community

### DIFF
--- a/data/pc/1.10/items.json
+++ b/data/pc/1.10/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 64
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -31,7 +25,7 @@
   },
   {
     "id": 5,
-    "displayName": "Wood Planks",
+    "displayName": "Wooden Planks",
     "name": "planks",
     "stackSize": 64
   },
@@ -45,30 +39,6 @@
     "id": 7,
     "displayName": "Bedrock",
     "name": "bedrock",
-    "stackSize": 64
-  },
-  {
-    "id": 8,
-    "displayName": "Water",
-    "name": "flowing_water",
-    "stackSize": 64
-  },
-  {
-    "id": 9,
-    "displayName": "Stationary Water",
-    "name": "water",
-    "stackSize": 64
-  },
-  {
-    "id": 10,
-    "displayName": "Lava",
-    "name": "flowing_lava",
-    "stackSize": 64
-  },
-  {
-    "id": 11,
-    "displayName": "Stationary Lava",
-    "name": "lava",
     "stackSize": 64
   },
   {
@@ -198,21 +168,9 @@
     "stackSize": 64
   },
   {
-    "id": 34,
-    "displayName": "Piston Head",
-    "name": "piston_head",
-    "stackSize": 64
-  },
-  {
     "id": 35,
     "displayName": "Wool",
     "name": "wool",
-    "stackSize": 64
-  },
-  {
-    "id": 36,
-    "displayName": "Block moved by Piston",
-    "name": "piston_extension",
     "stackSize": 64
   },
   {
@@ -252,12 +210,6 @@
     "stackSize": 64
   },
   {
-    "id": 43,
-    "displayName": "Double Stone Slab",
-    "name": "double_stone_slab",
-    "stackSize": 64
-  },
-  {
     "id": 44,
     "displayName": "Stone Slab",
     "name": "stone_slab",
@@ -265,7 +217,7 @@
   },
   {
     "id": 45,
-    "displayName": "Bricks",
+    "displayName": "Brick",
     "name": "brick_block",
     "stackSize": 64
   },
@@ -300,12 +252,6 @@
     "stackSize": 64
   },
   {
-    "id": 51,
-    "displayName": "Fire",
-    "name": "fire",
-    "stackSize": 64
-  },
-  {
     "id": 52,
     "displayName": "Monster Spawner",
     "name": "mob_spawner",
@@ -321,12 +267,6 @@
     "id": 54,
     "displayName": "Chest",
     "name": "chest",
-    "stackSize": 64
-  },
-  {
-    "id": 55,
-    "displayName": "Redstone Wire",
-    "name": "redstone_wire",
     "stackSize": 64
   },
   {
@@ -360,18 +300,6 @@
     "stackSize": 64
   },
   {
-    "id": 62,
-    "displayName": "Burning Furnace",
-    "name": "lit_furnace",
-    "stackSize": 64
-  },
-  {
-    "id": 63,
-    "displayName": "Standing Sign",
-    "name": "standing_sign",
-    "stackSize": 64
-  },
-  {
     "id": 65,
     "displayName": "Ladder",
     "name": "ladder",
@@ -387,12 +315,6 @@
     "id": 67,
     "displayName": "Cobblestone Stairs",
     "name": "stone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 68,
-    "displayName": "Wall Sign",
-    "name": "wall_sign",
     "stackSize": 64
   },
   {
@@ -420,20 +342,8 @@
     "stackSize": 64
   },
   {
-    "id": 74,
-    "displayName": "Glowing Redstone Ore",
-    "name": "lit_redstone_ore",
-    "stackSize": 64
-  },
-  {
-    "id": 75,
-    "displayName": "Redstone Torch (inactive)",
-    "name": "unlit_redstone_torch",
-    "stackSize": 64
-  },
-  {
     "id": 76,
-    "displayName": "Redstone Torch (active)",
+    "displayName": "Redstone Torch",
     "name": "redstone_torch",
     "stackSize": 64
   },
@@ -445,7 +355,7 @@
   },
   {
     "id": 78,
-    "displayName": "Snow (layer)",
+    "displayName": "Snow",
     "name": "snow_layer",
     "stackSize": 64
   },
@@ -481,7 +391,7 @@
   },
   {
     "id": 85,
-    "displayName": "Fence",
+    "displayName": "Oak Fence",
     "name": "fence",
     "stackSize": 64
   },
@@ -510,27 +420,9 @@
     "stackSize": 64
   },
   {
-    "id": 90,
-    "displayName": "Nether Portal",
-    "name": "portal",
-    "stackSize": 64
-  },
-  {
     "id": 91,
     "displayName": "Jack o'Lantern",
     "name": "lit_pumpkin",
-    "stackSize": 64
-  },
-  {
-    "id": 93,
-    "displayName": "Redstone Repeater (inactive)",
-    "name": "unpowered_repeater",
-    "stackSize": 64
-  },
-  {
-    "id": 94,
-    "displayName": "Redstone Repeater (active)",
-    "name": "powered_repeater",
     "stackSize": 64
   },
   {
@@ -541,7 +433,7 @@
   },
   {
     "id": 96,
-    "displayName": "Trapdoor",
+    "displayName": "Wooden Trapdoor",
     "name": "trapdoor",
     "stackSize": 64
   },
@@ -559,13 +451,13 @@
   },
   {
     "id": 99,
-    "displayName": "Brown Mushroom (block)",
+    "displayName": "Brown Mushroom Block",
     "name": "brown_mushroom_block",
     "stackSize": 64
   },
   {
     "id": 100,
-    "displayName": "Red Mushroom (block)",
+    "displayName": "Red Mushroom Block",
     "name": "red_mushroom_block",
     "stackSize": 64
   },
@@ -588,18 +480,6 @@
     "stackSize": 64
   },
   {
-    "id": 104,
-    "displayName": "Pumpkin Stem",
-    "name": "pumpkin_stem",
-    "stackSize": 64
-  },
-  {
-    "id": 105,
-    "displayName": "Melon Stem",
-    "name": "melon_stem",
-    "stackSize": 64
-  },
-  {
     "id": 106,
     "displayName": "Vines",
     "name": "vine",
@@ -607,7 +487,7 @@
   },
   {
     "id": 107,
-    "displayName": "Fence Gate",
+    "displayName": "Oak Fence Gate",
     "name": "fence_gate",
     "stackSize": 64
   },
@@ -660,12 +540,6 @@
     "stackSize": 64
   },
   {
-    "id": 119,
-    "displayName": "End Portal",
-    "name": "end_portal",
-    "stackSize": 64
-  },
-  {
     "id": 120,
     "displayName": "End Portal Frame",
     "name": "end_portal_frame",
@@ -685,32 +559,14 @@
   },
   {
     "id": 123,
-    "displayName": "Redstone Lamp (inactive)",
+    "displayName": "Redstone Lamp",
     "name": "redstone_lamp",
     "stackSize": 64
   },
   {
-    "id": 124,
-    "displayName": "Redstone Lamp (active)",
-    "name": "lit_redstone_lamp",
-    "stackSize": 64
-  },
-  {
-    "id": 125,
-    "displayName": "Double Wooden Slab",
-    "name": "double_wooden_slab",
-    "stackSize": 64
-  },
-  {
     "id": 126,
-    "displayName": "Wooden Slab",
+    "displayName": "Wood Slab",
     "name": "wooden_slab",
-    "stackSize": 64
-  },
-  {
-    "id": 127,
-    "displayName": "Cocoa",
-    "name": "cocoa",
     "stackSize": 64
   },
   {
@@ -735,12 +591,6 @@
     "id": 131,
     "displayName": "Tripwire Hook",
     "name": "tripwire_hook",
-    "stackSize": 64
-  },
-  {
-    "id": 132,
-    "displayName": "Tripwire",
-    "name": "tripwire",
     "stackSize": 64
   },
   {
@@ -786,18 +636,6 @@
     "stackSize": 64
   },
   {
-    "id": 141,
-    "displayName": "Carrot",
-    "name": "carrots",
-    "stackSize": 64
-  },
-  {
-    "id": 142,
-    "displayName": "Potato",
-    "name": "potatoes",
-    "stackSize": 64
-  },
-  {
     "id": 143,
     "displayName": "Wooden Button",
     "name": "wooden_button",
@@ -828,20 +666,8 @@
     "stackSize": 64
   },
   {
-    "id": 149,
-    "displayName": "Redstone Comparator",
-    "name": "unpowered_comparator",
-    "stackSize": 64
-  },
-  {
-    "id": 150,
-    "displayName": "Redstone Comparator (deprecated)",
-    "name": "powered_comparator",
-    "stackSize": 64
-  },
-  {
     "id": 151,
-    "displayName": "Daylight Sensor",
+    "displayName": "Daylight Detector",
     "name": "daylight_detector",
     "stackSize": 64
   },
@@ -853,7 +679,7 @@
   },
   {
     "id": 153,
-    "displayName": "Nether Quartz Ore",
+    "displayName": "Nether Quartz",
     "name": "quartz_ore",
     "stackSize": 64
   },
@@ -889,7 +715,7 @@
   },
   {
     "id": 159,
-    "displayName": "Stained Clay",
+    "displayName": "Stained Hardened Clay",
     "name": "stained_hardened_clay",
     "stackSize": 64
   },
@@ -901,13 +727,13 @@
   },
   {
     "id": 161,
-    "displayName": "Leaves (Acacia/Dark Oak)",
+    "displayName": "Leaves",
     "name": "leaves2",
     "stackSize": 64
   },
   {
     "id": 162,
-    "displayName": "Wood (Acacia/Dark Oak)",
+    "displayName": "Wood",
     "name": "log2",
     "stackSize": 64
   },
@@ -990,24 +816,6 @@
     "stackSize": 64
   },
   {
-    "id": 176,
-    "displayName": "Standing Banner",
-    "name": "standing_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 177,
-    "displayName": "Wall Banner",
-    "name": "wall_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 178,
-    "displayName": "Inverted Daylight Sensor",
-    "name": "daylight_detector_inverted",
-    "stackSize": 64
-  },
-  {
     "id": 179,
     "displayName": "Red Sandstone",
     "name": "red_sandstone",
@@ -1017,12 +825,6 @@
     "id": 180,
     "displayName": "Red Sandstone Stairs",
     "name": "red_sandstone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 181,
-    "displayName": "Double Red Sandstone Slab",
-    "name": "double_stone_slab2",
     "stackSize": 64
   },
   {
@@ -1128,12 +930,6 @@
     "stackSize": 64
   },
   {
-    "id": 204,
-    "displayName": "Purpur Double Slab",
-    "name": "purpur_double_slab",
-    "stackSize": 64
-  },
-  {
     "id": 205,
     "displayName": "Purpur Slab",
     "name": "purpur_slab",
@@ -1146,21 +942,9 @@
     "stackSize": 64
   },
   {
-    "id": 207,
-    "displayName": "Beetroot Seeds",
-    "name": "beetroots",
-    "stackSize": 64
-  },
-  {
     "id": 208,
     "displayName": "Grass Path",
     "name": "grass_path",
-    "stackSize": 64
-  },
-  {
-    "id": 209,
-    "displayName": "End Gateway",
-    "name": "end_gateway",
     "stackSize": 64
   },
   {
@@ -1176,9 +960,33 @@
     "stackSize": 64
   },
   {
-    "id": 212,
-    "displayName": "Frosted Ice",
-    "name": "frosted_ice",
+    "id": 213,
+    "displayName": "Magma Block",
+    "name": "magma",
+    "stackSize": 64
+  },
+  {
+    "id": 214,
+    "displayName": "Nether Wart Block",
+    "name": "nether_wart_block",
+    "stackSize": 64
+  },
+  {
+    "id": 215,
+    "displayName": "Red Nether Brick",
+    "name": "red_nether_brick",
+    "stackSize": 64
+  },
+  {
+    "id": 216,
+    "displayName": "Bone Block",
+    "name": "bone_block",
+    "stackSize": 64
+  },
+  {
+    "id": 217,
+    "displayName": "Structure Void",
+    "name": "structure_void",
     "stackSize": 64
   },
   {
@@ -1190,8 +998,9 @@
   {
     "id": 256,
     "displayName": "Iron Shovel",
-    "stackSize": 1,
     "name": "iron_shovel",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1199,14 +1008,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 257,
     "displayName": "Iron Pickaxe",
-    "stackSize": 1,
     "name": "iron_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1214,14 +1023,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 258,
     "displayName": "Iron Axe",
-    "stackSize": 1,
     "name": "iron_axe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1229,49 +1038,48 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 259,
     "displayName": "Flint and Steel",
-    "stackSize": 1,
     "name": "flint_and_steel",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 260,
     "displayName": "Apple",
-    "stackSize": 64,
-    "name": "apple"
+    "name": "apple",
+    "stackSize": 64
   },
   {
     "id": 261,
     "displayName": "Bow",
-    "stackSize": 1,
     "name": "bow",
+    "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 262,
     "displayName": "Arrow",
-    "stackSize": 64,
-    "name": "arrow"
+    "name": "arrow",
+    "stackSize": 64
   },
   {
     "id": 263,
     "displayName": "Coal",
-    "stackSize": 64,
     "name": "coal",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -1286,26 +1094,27 @@
   {
     "id": 264,
     "displayName": "Diamond",
-    "stackSize": 64,
-    "name": "diamond"
+    "name": "diamond",
+    "stackSize": 64
   },
   {
     "id": 265,
     "displayName": "Iron Ingot",
-    "stackSize": 64,
-    "name": "iron_ingot"
+    "name": "iron_ingot",
+    "stackSize": 64
   },
   {
     "id": 266,
     "displayName": "Gold Ingot",
-    "stackSize": 64,
-    "name": "gold_ingot"
+    "name": "gold_ingot",
+    "stackSize": 64
   },
   {
     "id": 267,
     "displayName": "Iron Sword",
-    "stackSize": 1,
     "name": "iron_sword",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1313,14 +1122,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 268,
     "displayName": "Wooden Sword",
-    "stackSize": 1,
     "name": "wooden_sword",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1335,14 +1144,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 269,
     "displayName": "Wooden Shovel",
-    "stackSize": 1,
     "name": "wooden_shovel",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1357,14 +1166,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 270,
     "displayName": "Wooden Pickaxe",
-    "stackSize": 1,
     "name": "wooden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1379,14 +1188,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 271,
     "displayName": "Wooden Axe",
-    "stackSize": 1,
     "name": "wooden_axe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1401,14 +1210,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 272,
     "displayName": "Stone Sword",
-    "stackSize": 1,
     "name": "stone_sword",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1417,14 +1226,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 273,
     "displayName": "Stone Shovel",
-    "stackSize": 1,
     "name": "stone_shovel",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1433,14 +1242,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 274,
     "displayName": "Stone Pickaxe",
-    "stackSize": 1,
     "name": "stone_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1449,14 +1258,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 275,
     "displayName": "Stone Axe",
-    "stackSize": 1,
     "name": "stone_axe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1465,14 +1274,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 276,
     "displayName": "Diamond Sword",
-    "stackSize": 1,
     "name": "diamond_sword",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1480,14 +1289,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 277,
     "displayName": "Diamond Shovel",
-    "stackSize": 1,
     "name": "diamond_shovel",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1495,14 +1304,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 278,
     "displayName": "Diamond Pickaxe",
-    "stackSize": 1,
     "name": "diamond_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1510,14 +1319,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 279,
     "displayName": "Diamond Axe",
-    "stackSize": 1,
     "name": "diamond_axe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1525,32 +1334,32 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 280,
     "displayName": "Stick",
-    "stackSize": 64,
-    "name": "stick"
+    "name": "stick",
+    "stackSize": 64
   },
   {
     "id": 281,
     "displayName": "Bowl",
-    "stackSize": 64,
-    "name": "bowl"
+    "name": "bowl",
+    "stackSize": 64
   },
   {
     "id": 282,
     "displayName": "Mushroom Stew",
-    "stackSize": 1,
-    "name": "mushroom_stew"
+    "name": "mushroom_stew",
+    "stackSize": 1
   },
   {
     "id": 283,
     "displayName": "Golden Sword",
-    "stackSize": 1,
     "name": "golden_sword",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1558,14 +1367,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 284,
     "displayName": "Golden Shovel",
-    "stackSize": 1,
     "name": "golden_shovel",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1573,14 +1382,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 285,
     "displayName": "Golden Pickaxe",
-    "stackSize": 1,
     "name": "golden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1588,14 +1397,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 286,
     "displayName": "Golden Axe",
-    "stackSize": 1,
     "name": "golden_axe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1603,32 +1412,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 287,
     "displayName": "String",
-    "stackSize": 64,
-    "name": "string"
+    "name": "string",
+    "stackSize": 64
   },
   {
     "id": 288,
     "displayName": "Feather",
-    "stackSize": 64,
-    "name": "feather"
+    "name": "feather",
+    "stackSize": 64
   },
   {
     "id": 289,
     "displayName": "Gunpowder",
-    "stackSize": 64,
-    "name": "gunpowder"
+    "name": "gunpowder",
+    "stackSize": 64
   },
   {
     "id": 290,
     "displayName": "Wooden Hoe",
-    "stackSize": 1,
     "name": "wooden_hoe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1643,14 +1452,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 291,
     "displayName": "Stone Hoe",
-    "stackSize": 1,
     "name": "stone_hoe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1659,14 +1468,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 292,
     "displayName": "Iron Hoe",
-    "stackSize": 1,
     "name": "iron_hoe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1674,14 +1483,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 293,
     "displayName": "Diamond Hoe",
-    "stackSize": 1,
     "name": "diamond_hoe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1689,14 +1498,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 294,
     "displayName": "Golden Hoe",
-    "stackSize": 1,
     "name": "golden_hoe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1704,32 +1513,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 295,
     "displayName": "Seeds",
-    "stackSize": 64,
-    "name": "wheat_seeds"
+    "name": "wheat_seeds",
+    "stackSize": 64
   },
   {
     "id": 296,
     "displayName": "Wheat",
-    "stackSize": 64,
-    "name": "wheat"
+    "name": "wheat",
+    "stackSize": 64
   },
   {
     "id": 297,
     "displayName": "Bread",
-    "stackSize": 64,
-    "name": "bread"
+    "name": "bread",
+    "stackSize": 64
   },
   {
     "id": 298,
     "displayName": "Leather Cap",
-    "stackSize": 1,
     "name": "leather_helmet",
+    "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1739,14 +1548,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 299,
     "displayName": "Leather Tunic",
-    "stackSize": 1,
     "name": "leather_chestplate",
+    "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1756,14 +1565,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 300,
     "displayName": "Leather Pants",
-    "stackSize": 1,
     "name": "leather_leggings",
+    "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1772,14 +1581,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 301,
     "displayName": "Leather Boots",
-    "stackSize": 1,
     "name": "leather_boots",
+    "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1789,14 +1598,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 302,
     "displayName": "Chain Helmet",
-    "stackSize": 1,
     "name": "chainmail_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1806,14 +1615,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 303,
     "displayName": "Chain Chestplate",
-    "stackSize": 1,
     "name": "chainmail_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1823,14 +1632,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 304,
     "displayName": "Chain Leggings",
-    "stackSize": 1,
     "name": "chainmail_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1839,14 +1648,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 305,
     "displayName": "Chain Boots",
-    "stackSize": 1,
     "name": "chainmail_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1856,14 +1665,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 306,
     "displayName": "Iron Helmet",
-    "stackSize": 1,
     "name": "iron_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1873,14 +1682,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 307,
     "displayName": "Iron Chestplate",
-    "stackSize": 1,
     "name": "iron_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1890,14 +1699,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 308,
     "displayName": "Iron Leggings",
-    "stackSize": 1,
     "name": "iron_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1906,14 +1715,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 309,
     "displayName": "Iron Boots",
-    "stackSize": 1,
     "name": "iron_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1923,14 +1732,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 310,
     "displayName": "Diamond Helmet",
-    "stackSize": 1,
     "name": "diamond_helmet",
+    "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1940,14 +1749,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 311,
     "displayName": "Diamond Chestplate",
-    "stackSize": 1,
     "name": "diamond_chestplate",
+    "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1957,14 +1766,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 312,
     "displayName": "Diamond Leggings",
-    "stackSize": 1,
     "name": "diamond_leggings",
+    "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1973,14 +1782,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 313,
     "displayName": "Diamond Boots",
-    "stackSize": 1,
     "name": "diamond_boots",
+    "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1990,14 +1799,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 314,
     "displayName": "Golden Helmet",
-    "stackSize": 1,
     "name": "golden_helmet",
+    "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2007,14 +1816,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 315,
     "displayName": "Golden Chestplate",
-    "stackSize": 1,
     "name": "golden_chestplate",
+    "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2024,14 +1833,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 316,
     "displayName": "Golden Leggings",
-    "stackSize": 1,
     "name": "golden_leggings",
+    "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2040,14 +1849,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 317,
     "displayName": "Golden Boots",
-    "stackSize": 1,
     "name": "golden_boots",
+    "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2057,38 +1866,37 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 318,
     "displayName": "Flint",
-    "stackSize": 64,
-    "name": "flint"
+    "name": "flint",
+    "stackSize": 64
   },
   {
     "id": 319,
     "displayName": "Raw Porkchop",
-    "stackSize": 64,
-    "name": "porkchop"
+    "name": "porkchop",
+    "stackSize": 64
   },
   {
     "id": 320,
     "displayName": "Cooked Porkchop",
-    "stackSize": 64,
-    "name": "cooked_porkchop"
+    "name": "cooked_porkchop",
+    "stackSize": 64
   },
   {
     "id": 321,
     "displayName": "Painting",
-    "stackSize": 64,
-    "name": "painting"
+    "name": "painting",
+    "stackSize": 64
   },
   {
     "id": 322,
     "displayName": "Golden Apple",
-    "stackSize": 64,
     "name": "golden_apple",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2103,170 +1911,170 @@
   {
     "id": 323,
     "displayName": "Sign",
-    "stackSize": 16,
-    "name": "sign"
+    "name": "sign",
+    "stackSize": 16
   },
   {
     "id": 324,
     "displayName": "Oak Door",
-    "stackSize": 64,
-    "name": "wooden_door"
+    "name": "wooden_door",
+    "stackSize": 64
   },
   {
     "id": 325,
     "displayName": "Bucket",
-    "stackSize": 16,
-    "name": "bucket"
+    "name": "bucket",
+    "stackSize": 16
   },
   {
     "id": 326,
     "displayName": "Water Bucket",
-    "stackSize": 1,
-    "name": "water_bucket"
+    "name": "water_bucket",
+    "stackSize": 1
   },
   {
     "id": 327,
     "displayName": "Lava Bucket",
-    "stackSize": 1,
-    "name": "lava_bucket"
+    "name": "lava_bucket",
+    "stackSize": 1
   },
   {
     "id": 328,
     "displayName": "Minecart",
-    "stackSize": 1,
-    "name": "minecart"
+    "name": "minecart",
+    "stackSize": 1
   },
   {
     "id": 329,
     "displayName": "Saddle",
-    "stackSize": 1,
-    "name": "saddle"
+    "name": "saddle",
+    "stackSize": 1
   },
   {
     "id": 330,
     "displayName": "Iron Door",
-    "stackSize": 64,
-    "name": "iron_door"
+    "name": "iron_door",
+    "stackSize": 64
   },
   {
     "id": 331,
     "displayName": "Redstone",
-    "stackSize": 64,
-    "name": "redstone"
+    "name": "redstone",
+    "stackSize": 64
   },
   {
     "id": 332,
     "displayName": "Snowball",
-    "stackSize": 16,
-    "name": "snowball"
+    "name": "snowball",
+    "stackSize": 16
   },
   {
     "id": 333,
     "displayName": "Boat",
-    "stackSize": 1,
-    "name": "boat"
+    "name": "boat",
+    "stackSize": 1
   },
   {
     "id": 334,
     "displayName": "Leather",
-    "stackSize": 64,
-    "name": "leather"
+    "name": "leather",
+    "stackSize": 64
   },
   {
     "id": 335,
     "displayName": "Milk",
-    "stackSize": 1,
-    "name": "milk_bucket"
+    "name": "milk_bucket",
+    "stackSize": 1
   },
   {
     "id": 336,
     "displayName": "Brick",
-    "stackSize": 64,
-    "name": "brick"
+    "name": "brick",
+    "stackSize": 64
   },
   {
     "id": 337,
     "displayName": "Clay",
-    "stackSize": 64,
-    "name": "clay_ball"
+    "name": "clay_ball",
+    "stackSize": 64
   },
   {
     "id": 338,
-    "displayName": "Sugar Cane",
-    "stackSize": 64,
-    "name": "reeds"
+    "displayName": "Sugar Canes",
+    "name": "reeds",
+    "stackSize": 64
   },
   {
     "id": 339,
     "displayName": "Paper",
-    "stackSize": 64,
-    "name": "paper"
+    "name": "paper",
+    "stackSize": 64
   },
   {
     "id": 340,
     "displayName": "Book",
-    "stackSize": 64,
-    "name": "book"
+    "name": "book",
+    "stackSize": 64
   },
   {
     "id": 341,
     "displayName": "Slimeball",
-    "stackSize": 64,
-    "name": "slime_ball"
+    "name": "slime_ball",
+    "stackSize": 64
   },
   {
     "id": 342,
     "displayName": "Minecart with Chest",
-    "stackSize": 1,
-    "name": "chest_minecart"
+    "name": "chest_minecart",
+    "stackSize": 1
   },
   {
     "id": 343,
     "displayName": "Minecart with Furnace",
-    "stackSize": 1,
-    "name": "furnace_minecart"
+    "name": "furnace_minecart",
+    "stackSize": 1
   },
   {
     "id": 344,
     "displayName": "Egg",
-    "stackSize": 16,
-    "name": "egg"
+    "name": "egg",
+    "stackSize": 16
   },
   {
     "id": 345,
     "displayName": "Compass",
-    "stackSize": 64,
-    "name": "compass"
+    "name": "compass",
+    "stackSize": 64
   },
   {
     "id": 346,
     "displayName": "Fishing Rod",
-    "stackSize": 1,
     "name": "fishing_rod",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 347,
     "displayName": "Clock",
-    "stackSize": 64,
-    "name": "clock"
+    "name": "clock",
+    "stackSize": 64
   },
   {
     "id": 348,
     "displayName": "Glowstone Dust",
-    "stackSize": 64,
-    "name": "glowstone_dust"
+    "name": "glowstone_dust",
+    "stackSize": 64
   },
   {
     "id": 349,
-    "displayName": "Raw Fish",
-    "stackSize": 64,
+    "displayName": "Fish",
     "name": "fish",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2289,14 +2097,14 @@
   {
     "id": 350,
     "displayName": "Cooked Fish",
-    "stackSize": 64,
-    "name": "cooked_fish"
+    "name": "cooked_fish",
+    "stackSize": 64
   },
   {
     "id": 351,
     "displayName": "Dye",
-    "stackSize": 64,
     "name": "dye",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2367,241 +2175,241 @@
   {
     "id": 352,
     "displayName": "Bone",
-    "stackSize": 64,
-    "name": "bone"
+    "name": "bone",
+    "stackSize": 64
   },
   {
     "id": 353,
     "displayName": "Sugar",
-    "stackSize": 64,
-    "name": "sugar"
+    "name": "sugar",
+    "stackSize": 64
   },
   {
     "id": 354,
     "displayName": "Cake",
-    "stackSize": 1,
-    "name": "cake"
+    "name": "cake",
+    "stackSize": 1
   },
   {
     "id": 355,
     "displayName": "Bed",
-    "stackSize": 1,
-    "name": "bed"
+    "name": "bed",
+    "stackSize": 1
   },
   {
     "id": 356,
     "displayName": "Redstone Repeater",
-    "stackSize": 64,
-    "name": "repeater"
+    "name": "repeater",
+    "stackSize": 64
   },
   {
     "id": 357,
     "displayName": "Cookie",
-    "stackSize": 64,
-    "name": "cookie"
+    "name": "cookie",
+    "stackSize": 64
   },
   {
     "id": 358,
     "displayName": "Map",
-    "stackSize": 64,
-    "name": "filled_map"
+    "name": "filled_map",
+    "stackSize": 64
   },
   {
     "id": 359,
     "displayName": "Shears",
-    "stackSize": 1,
     "name": "shears",
+    "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 360,
     "displayName": "Melon",
-    "stackSize": 64,
-    "name": "melon"
+    "name": "melon",
+    "stackSize": 64
   },
   {
     "id": 361,
     "displayName": "Pumpkin Seeds",
-    "stackSize": 64,
-    "name": "pumpkin_seeds"
+    "name": "pumpkin_seeds",
+    "stackSize": 64
   },
   {
     "id": 362,
     "displayName": "Melon Seeds",
-    "stackSize": 64,
-    "name": "melon_seeds"
+    "name": "melon_seeds",
+    "stackSize": 64
   },
   {
     "id": 363,
     "displayName": "Raw Beef",
-    "stackSize": 64,
-    "name": "beef"
+    "name": "beef",
+    "stackSize": 64
   },
   {
     "id": 364,
     "displayName": "Steak",
-    "stackSize": 64,
-    "name": "cooked_beef"
+    "name": "cooked_beef",
+    "stackSize": 64
   },
   {
     "id": 365,
     "displayName": "Raw Chicken",
-    "stackSize": 64,
-    "name": "chicken"
+    "name": "chicken",
+    "stackSize": 64
   },
   {
     "id": 366,
     "displayName": "Cooked Chicken",
-    "stackSize": 64,
-    "name": "cooked_chicken"
+    "name": "cooked_chicken",
+    "stackSize": 64
   },
   {
     "id": 367,
     "displayName": "Rotten Flesh",
-    "stackSize": 64,
-    "name": "rotten_flesh"
+    "name": "rotten_flesh",
+    "stackSize": 64
   },
   {
     "id": 368,
     "displayName": "Ender Pearl",
-    "stackSize": 16,
-    "name": "ender_pearl"
+    "name": "ender_pearl",
+    "stackSize": 16
   },
   {
     "id": 369,
     "displayName": "Blaze Rod",
-    "stackSize": 64,
-    "name": "blaze_rod"
+    "name": "blaze_rod",
+    "stackSize": 64
   },
   {
     "id": 370,
     "displayName": "Ghast Tear",
-    "stackSize": 64,
-    "name": "ghast_tear"
+    "name": "ghast_tear",
+    "stackSize": 64
   },
   {
     "id": 371,
     "displayName": "Gold Nugget",
-    "stackSize": 64,
-    "name": "gold_nugget"
+    "name": "gold_nugget",
+    "stackSize": 64
   },
   {
     "id": 372,
     "displayName": "Nether Wart",
-    "stackSize": 64,
-    "name": "nether_wart"
+    "name": "nether_wart",
+    "stackSize": 64
   },
   {
     "id": 373,
     "displayName": "Potion",
-    "stackSize": 1,
-    "name": "potion"
+    "name": "potion",
+    "stackSize": 1
   },
   {
     "id": 374,
     "displayName": "Glass Bottle",
-    "stackSize": 64,
-    "name": "glass_bottle"
+    "name": "glass_bottle",
+    "stackSize": 64
   },
   {
     "id": 375,
     "displayName": "Spider Eye",
-    "stackSize": 64,
-    "name": "spider_eye"
+    "name": "spider_eye",
+    "stackSize": 64
   },
   {
     "id": 376,
     "displayName": "Fermented Spider Eye",
-    "stackSize": 64,
-    "name": "fermented_spider_eye"
+    "name": "fermented_spider_eye",
+    "stackSize": 64
   },
   {
     "id": 377,
     "displayName": "Blaze Powder",
-    "stackSize": 64,
-    "name": "blaze_powder"
+    "name": "blaze_powder",
+    "stackSize": 64
   },
   {
     "id": 378,
     "displayName": "Magma Cream",
-    "stackSize": 64,
-    "name": "magma_cream"
+    "name": "magma_cream",
+    "stackSize": 64
   },
   {
     "id": 379,
     "displayName": "Brewing Stand",
-    "stackSize": 64,
-    "name": "brewing_stand"
+    "name": "brewing_stand",
+    "stackSize": 64
   },
   {
     "id": 380,
     "displayName": "Cauldron",
-    "stackSize": 64,
-    "name": "cauldron"
+    "name": "cauldron",
+    "stackSize": 64
   },
   {
     "id": 381,
     "displayName": "Eye of Ender",
-    "stackSize": 64,
-    "name": "ender_eye"
+    "name": "ender_eye",
+    "stackSize": 64
   },
   {
     "id": 382,
     "displayName": "Glistering Melon",
-    "stackSize": 64,
-    "name": "speckled_melon"
+    "name": "speckled_melon",
+    "stackSize": 64
   },
   {
     "id": 383,
     "displayName": "Spawn Egg",
-    "stackSize": 64,
-    "name": "spawn_egg"
+    "name": "spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 384,
     "displayName": "Bottle o' Enchanting",
-    "stackSize": 64,
-    "name": "experience_bottle"
+    "name": "experience_bottle",
+    "stackSize": 64
   },
   {
     "id": 385,
     "displayName": "Fire Charge",
-    "stackSize": 64,
-    "name": "fire_charge"
+    "name": "fire_charge",
+    "stackSize": 64
   },
   {
     "id": 386,
     "displayName": "Book and Quill",
-    "stackSize": 1,
-    "name": "writable_book"
+    "name": "writable_book",
+    "stackSize": 1
   },
   {
     "id": 387,
     "displayName": "Written Book",
-    "stackSize": 16,
-    "name": "written_book"
+    "name": "written_book",
+    "stackSize": 16
   },
   {
     "id": 388,
     "displayName": "Emerald",
-    "stackSize": 64,
-    "name": "emerald"
+    "name": "emerald",
+    "stackSize": 64
   },
   {
     "id": 389,
     "displayName": "Item Frame",
-    "stackSize": 64,
-    "name": "item_frame"
+    "name": "item_frame",
+    "stackSize": 64
   },
   {
     "id": 390,
     "displayName": "Flower Pot",
-    "stackSize": 64,
     "name": "flower_pot",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2664,44 +2472,44 @@
   {
     "id": 391,
     "displayName": "Carrot",
-    "stackSize": 64,
-    "name": "carrot"
+    "name": "carrot",
+    "stackSize": 64
   },
   {
     "id": 392,
     "displayName": "Potato",
-    "stackSize": 64,
-    "name": "potato"
+    "name": "potato",
+    "stackSize": 64
   },
   {
     "id": 393,
     "displayName": "Baked Potato",
-    "stackSize": 64,
-    "name": "baked_potato"
+    "name": "baked_potato",
+    "stackSize": 64
   },
   {
     "id": 394,
     "displayName": "Poisonous Potato",
-    "stackSize": 64,
-    "name": "poisonous_potato"
+    "name": "poisonous_potato",
+    "stackSize": 64
   },
   {
     "id": 395,
     "displayName": "Empty Map",
-    "stackSize": 64,
-    "name": "map"
+    "name": "map",
+    "stackSize": 64
   },
   {
     "id": 396,
     "displayName": "Golden Carrot",
-    "stackSize": 64,
-    "name": "golden_carrot"
+    "name": "golden_carrot",
+    "stackSize": 64
   },
   {
     "id": 397,
-    "displayName": "Mob head",
-    "stackSize": 64,
+    "displayName": "Skull",
     "name": "skull",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2728,277 +2536,278 @@
   {
     "id": 398,
     "displayName": "Carrot on a Stick",
-    "stackSize": 1,
     "name": "carrot_on_a_stick",
+    "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 399,
     "displayName": "Nether Star",
-    "stackSize": 64,
-    "name": "nether_star"
+    "name": "nether_star",
+    "stackSize": 64
   },
   {
     "id": 400,
     "displayName": "Pumpkin Pie",
-    "stackSize": 64,
-    "name": "pumpkin_pie"
+    "name": "pumpkin_pie",
+    "stackSize": 64
   },
   {
     "id": 401,
     "displayName": "Firework Rocket",
-    "stackSize": 64,
-    "name": "fireworks"
+    "name": "fireworks",
+    "stackSize": 64
   },
   {
     "id": 402,
     "displayName": "Firework Star",
-    "stackSize": 64,
-    "name": "firework_charge"
+    "name": "firework_charge",
+    "stackSize": 64
   },
   {
     "id": 403,
     "displayName": "Enchanted Book",
-    "stackSize": 1,
-    "name": "enchanted_book"
+    "name": "enchanted_book",
+    "stackSize": 1
   },
   {
     "id": 404,
     "displayName": "Redstone Comparator",
-    "stackSize": 64,
-    "name": "comparator"
+    "name": "comparator",
+    "stackSize": 64
   },
   {
     "id": 405,
     "displayName": "Nether Brick",
-    "stackSize": 64,
-    "name": "netherbrick"
+    "name": "netherbrick",
+    "stackSize": 64
   },
   {
     "id": 406,
     "displayName": "Nether Quartz",
-    "stackSize": 64,
-    "name": "quartz"
+    "name": "quartz",
+    "stackSize": 64
   },
   {
     "id": 407,
     "displayName": "Minecart with TNT",
-    "stackSize": 1,
-    "name": "tnt_minecart"
+    "name": "tnt_minecart",
+    "stackSize": 1
   },
   {
     "id": 408,
     "displayName": "Minecart with Hopper",
-    "stackSize": 1,
-    "name": "hopper_minecart"
+    "name": "hopper_minecart",
+    "stackSize": 1
   },
   {
     "id": 409,
     "displayName": "Prismarine Shard",
-    "stackSize": 64,
-    "name": "prismarine_shard"
+    "name": "prismarine_shard",
+    "stackSize": 64
   },
   {
     "id": 410,
     "displayName": "Prismarine Crystals",
-    "stackSize": 64,
-    "name": "prismarine_crystals"
+    "name": "prismarine_crystals",
+    "stackSize": 64
   },
   {
     "id": 411,
     "displayName": "Raw Rabbit",
-    "stackSize": 64,
-    "name": "rabbit"
+    "name": "rabbit",
+    "stackSize": 64
   },
   {
     "id": 412,
     "displayName": "Cooked Rabbit",
-    "stackSize": 64,
-    "name": "cooked_rabbit"
+    "name": "cooked_rabbit",
+    "stackSize": 64
   },
   {
     "id": 413,
     "displayName": "Rabbit Stew",
-    "stackSize": 1,
-    "name": "rabbit_stew"
+    "name": "rabbit_stew",
+    "stackSize": 1
   },
   {
     "id": 414,
     "displayName": "Rabbit's Foot",
-    "stackSize": 64,
-    "name": "rabbit_foot"
+    "name": "rabbit_foot",
+    "stackSize": 64
   },
   {
     "id": 415,
     "displayName": "Rabbit Hide",
-    "stackSize": 64,
-    "name": "rabbit_hide"
+    "name": "rabbit_hide",
+    "stackSize": 64
   },
   {
     "id": 416,
     "displayName": "Armor Stand",
-    "stackSize": 16,
-    "name": "armor_stand"
+    "name": "armor_stand",
+    "stackSize": 16
   },
   {
     "id": 417,
     "displayName": "Iron Horse Armor",
-    "stackSize": 1,
-    "name": "iron_horse_armor"
+    "name": "iron_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 418,
-    "displayName": "Golden Horse Armor",
-    "stackSize": 1,
-    "name": "golden_horse_armor"
+    "displayName": "Gold Horse Armor",
+    "name": "golden_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 419,
     "displayName": "Diamond Horse Armor",
-    "stackSize": 1,
-    "name": "diamond_horse_armor"
+    "name": "diamond_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 420,
     "displayName": "Lead",
-    "stackSize": 64,
-    "name": "lead"
+    "name": "lead",
+    "stackSize": 64
   },
   {
     "id": 421,
     "displayName": "Name Tag",
-    "stackSize": 64,
-    "name": "name_tag"
+    "name": "name_tag",
+    "stackSize": 64
   },
   {
     "id": 422,
     "displayName": "Minecart with Command Block",
-    "stackSize": 1,
-    "name": "command_block_minecart"
+    "name": "command_block_minecart",
+    "stackSize": 1
   },
   {
     "id": 423,
     "displayName": "Raw Mutton",
-    "stackSize": 64,
-    "name": "mutton"
+    "name": "mutton",
+    "stackSize": 64
   },
   {
     "id": 424,
     "displayName": "Cooked Mutton",
-    "stackSize": 64,
-    "name": "cooked_mutton"
+    "name": "cooked_mutton",
+    "stackSize": 64
   },
   {
     "id": 425,
     "displayName": "Banner",
-    "stackSize": 16,
-    "name": "banner"
+    "name": "banner",
+    "stackSize": 16
   },
   {
     "id": 426,
     "displayName": "End Crystal",
-    "stackSize": 64,
-    "name": "end_crystal"
+    "name": "end_crystal",
+    "stackSize": 64
   },
   {
     "id": 427,
     "displayName": "Spruce Door",
-    "stackSize": 64,
-    "name": "spruce_door"
+    "name": "spruce_door",
+    "stackSize": 64
   },
   {
     "id": 428,
     "displayName": "Birch Door",
-    "stackSize": 64,
-    "name": "birch_door"
+    "name": "birch_door",
+    "stackSize": 64
   },
   {
     "id": 429,
     "displayName": "Jungle Door",
-    "stackSize": 64,
-    "name": "jungle_door"
+    "name": "jungle_door",
+    "stackSize": 64
   },
   {
     "id": 430,
     "displayName": "Acacia Door",
-    "stackSize": 64,
-    "name": "acacia_door"
+    "name": "acacia_door",
+    "stackSize": 64
   },
   {
     "id": 431,
     "displayName": "Dark Oak Door",
-    "stackSize": 64,
-    "name": "dark_oak_door"
+    "name": "dark_oak_door",
+    "stackSize": 64
   },
   {
     "id": 432,
     "displayName": "Chorus Fruit",
-    "stackSize": 64,
-    "name": "chorus_fruit"
+    "name": "chorus_fruit",
+    "stackSize": 64
   },
   {
     "id": 433,
     "displayName": "Popped Chorus Fruit",
-    "stackSize": 64,
-    "name": "chorus_fruit_popped"
+    "name": "chorus_fruit_popped",
+    "stackSize": 64
   },
   {
     "id": 434,
     "displayName": "Beetroot",
-    "stackSize": 64,
-    "name": "beetroot"
+    "name": "beetroot",
+    "stackSize": 64
   },
   {
     "id": 435,
     "displayName": "Beetroot Seeds",
-    "stackSize": 64,
-    "name": "beetroot_seeds"
+    "name": "beetroot_seeds",
+    "stackSize": 64
   },
   {
     "id": 436,
     "displayName": "Beetroot Soup",
-    "stackSize": 1,
-    "name": "beetroot_soup"
+    "name": "beetroot_soup",
+    "stackSize": 1
   },
   {
     "id": 437,
     "displayName": "Dragon's Breath",
-    "stackSize": 64,
-    "name": "dragon_breath"
+    "name": "dragon_breath",
+    "stackSize": 64
   },
   {
     "id": 438,
     "displayName": "Splash Potion",
-    "stackSize": 1,
-    "name": "splash_potion"
+    "name": "splash_potion",
+    "stackSize": 1
   },
   {
     "id": 439,
     "displayName": "Spectral Arrow",
-    "stackSize": 64,
-    "name": "spectral_arrow"
+    "name": "spectral_arrow",
+    "stackSize": 64
   },
   {
     "id": 440,
     "displayName": "Tipped Arrow",
-    "stackSize": 64,
-    "name": "tipped_arrow"
+    "name": "tipped_arrow",
+    "stackSize": 64
   },
   {
     "id": 441,
     "displayName": "Lingering Potion",
-    "stackSize": 1,
-    "name": "lingering_potion"
+    "name": "lingering_potion",
+    "stackSize": 1
   },
   {
     "id": 442,
     "displayName": "Shield",
-    "stackSize": 1,
     "name": "shield",
+    "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3012,14 +2821,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 443,
     "displayName": "Elytra",
-    "stackSize": 1,
     "name": "elytra",
+    "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -3027,109 +2836,108 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 444,
     "displayName": "Spruce Boat",
-    "stackSize": 1,
-    "name": "spruce_boat"
+    "name": "spruce_boat",
+    "stackSize": 1
   },
   {
     "id": 445,
     "displayName": "Birch Boat",
-    "stackSize": 1,
-    "name": "birch_boat"
+    "name": "birch_boat",
+    "stackSize": 1
   },
   {
     "id": 446,
     "displayName": "Jungle Boat",
-    "stackSize": 1,
-    "name": "jungle_boat"
+    "name": "jungle_boat",
+    "stackSize": 1
   },
   {
     "id": 447,
     "displayName": "Acacia Boat",
-    "stackSize": 1,
-    "name": "acacia_boat"
+    "name": "acacia_boat",
+    "stackSize": 1
   },
   {
     "id": 448,
     "displayName": "Dark Oak Boat",
-    "stackSize": 1,
-    "name": "dark_oak_boat"
+    "name": "dark_oak_boat",
+    "stackSize": 1
   },
   {
     "id": 2256,
     "displayName": "13 Disc",
-    "stackSize": 1,
-    "name": "record_13"
+    "name": "record_13",
+    "stackSize": 1
   },
   {
     "id": 2257,
     "displayName": "Cat Disc",
-    "stackSize": 1,
-    "name": "record_cat"
+    "name": "record_cat",
+    "stackSize": 1
   },
   {
     "id": 2258,
     "displayName": "Blocks Disc",
-    "stackSize": 1,
-    "name": "record_blocks"
+    "name": "record_blocks",
+    "stackSize": 1
   },
   {
     "id": 2259,
     "displayName": "Chirp Disc",
-    "stackSize": 1,
-    "name": "record_chirp"
+    "name": "record_chirp",
+    "stackSize": 1
   },
   {
     "id": 2260,
     "displayName": "Far Disc",
-    "stackSize": 1,
-    "name": "record_far"
+    "name": "record_far",
+    "stackSize": 1
   },
   {
     "id": 2261,
     "displayName": "Mall Disc",
-    "stackSize": 1,
-    "name": "record_mall"
+    "name": "record_mall",
+    "stackSize": 1
   },
   {
     "id": 2262,
     "displayName": "Mellohi Disc",
-    "stackSize": 1,
-    "name": "record_mellohi"
+    "name": "record_mellohi",
+    "stackSize": 1
   },
   {
     "id": 2263,
     "displayName": "Stal Disc",
-    "stackSize": 1,
-    "name": "record_stal"
+    "name": "record_stal",
+    "stackSize": 1
   },
   {
     "id": 2264,
     "displayName": "Strad Disc",
-    "stackSize": 1,
-    "name": "record_strad"
+    "name": "record_strad",
+    "stackSize": 1
   },
   {
     "id": 2265,
     "displayName": "Ward Disc",
-    "stackSize": 1,
-    "name": "record_ward"
+    "name": "record_ward",
+    "stackSize": 1
   },
   {
     "id": 2266,
     "displayName": "11 Disc",
-    "stackSize": 1,
-    "name": "record_11"
+    "name": "record_11",
+    "stackSize": 1
   },
   {
     "id": 2267,
     "displayName": "Wait Disc",
-    "stackSize": 1,
-    "name": "record_wait"
+    "name": "record_wait",
+    "stackSize": 1
   }
 ]

--- a/data/pc/1.11/items.json
+++ b/data/pc/1.11/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 64
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -31,7 +25,7 @@
   },
   {
     "id": 5,
-    "displayName": "Wood Planks",
+    "displayName": "Wooden Planks",
     "name": "planks",
     "stackSize": 64
   },
@@ -45,30 +39,6 @@
     "id": 7,
     "displayName": "Bedrock",
     "name": "bedrock",
-    "stackSize": 64
-  },
-  {
-    "id": 8,
-    "displayName": "Water",
-    "name": "flowing_water",
-    "stackSize": 64
-  },
-  {
-    "id": 9,
-    "displayName": "Stationary Water",
-    "name": "water",
-    "stackSize": 64
-  },
-  {
-    "id": 10,
-    "displayName": "Lava",
-    "name": "flowing_lava",
-    "stackSize": 64
-  },
-  {
-    "id": 11,
-    "displayName": "Stationary Lava",
-    "name": "lava",
     "stackSize": 64
   },
   {
@@ -198,21 +168,9 @@
     "stackSize": 64
   },
   {
-    "id": 34,
-    "displayName": "Piston Head",
-    "name": "piston_head",
-    "stackSize": 64
-  },
-  {
     "id": 35,
     "displayName": "Wool",
     "name": "wool",
-    "stackSize": 64
-  },
-  {
-    "id": 36,
-    "displayName": "Block moved by Piston",
-    "name": "piston_extension",
     "stackSize": 64
   },
   {
@@ -252,12 +210,6 @@
     "stackSize": 64
   },
   {
-    "id": 43,
-    "displayName": "Double Stone Slab",
-    "name": "double_stone_slab",
-    "stackSize": 64
-  },
-  {
     "id": 44,
     "displayName": "Stone Slab",
     "name": "stone_slab",
@@ -265,7 +217,7 @@
   },
   {
     "id": 45,
-    "displayName": "Bricks",
+    "displayName": "Brick",
     "name": "brick_block",
     "stackSize": 64
   },
@@ -300,12 +252,6 @@
     "stackSize": 64
   },
   {
-    "id": 51,
-    "displayName": "Fire",
-    "name": "fire",
-    "stackSize": 64
-  },
-  {
     "id": 52,
     "displayName": "Monster Spawner",
     "name": "mob_spawner",
@@ -321,12 +267,6 @@
     "id": 54,
     "displayName": "Chest",
     "name": "chest",
-    "stackSize": 64
-  },
-  {
-    "id": 55,
-    "displayName": "Redstone Wire",
-    "name": "redstone_wire",
     "stackSize": 64
   },
   {
@@ -360,18 +300,6 @@
     "stackSize": 64
   },
   {
-    "id": 62,
-    "displayName": "Burning Furnace",
-    "name": "lit_furnace",
-    "stackSize": 64
-  },
-  {
-    "id": 63,
-    "displayName": "Standing Sign",
-    "name": "standing_sign",
-    "stackSize": 64
-  },
-  {
     "id": 65,
     "displayName": "Ladder",
     "name": "ladder",
@@ -387,12 +315,6 @@
     "id": 67,
     "displayName": "Cobblestone Stairs",
     "name": "stone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 68,
-    "displayName": "Wall Sign",
-    "name": "wall_sign",
     "stackSize": 64
   },
   {
@@ -420,20 +342,8 @@
     "stackSize": 64
   },
   {
-    "id": 74,
-    "displayName": "Glowing Redstone Ore",
-    "name": "lit_redstone_ore",
-    "stackSize": 64
-  },
-  {
-    "id": 75,
-    "displayName": "Redstone Torch (inactive)",
-    "name": "unlit_redstone_torch",
-    "stackSize": 64
-  },
-  {
     "id": 76,
-    "displayName": "Redstone Torch (active)",
+    "displayName": "Redstone Torch",
     "name": "redstone_torch",
     "stackSize": 64
   },
@@ -445,7 +355,7 @@
   },
   {
     "id": 78,
-    "displayName": "Snow (layer)",
+    "displayName": "Snow",
     "name": "snow_layer",
     "stackSize": 64
   },
@@ -481,7 +391,7 @@
   },
   {
     "id": 85,
-    "displayName": "Fence",
+    "displayName": "Oak Fence",
     "name": "fence",
     "stackSize": 64
   },
@@ -510,27 +420,9 @@
     "stackSize": 64
   },
   {
-    "id": 90,
-    "displayName": "Nether Portal",
-    "name": "portal",
-    "stackSize": 64
-  },
-  {
     "id": 91,
     "displayName": "Jack o'Lantern",
     "name": "lit_pumpkin",
-    "stackSize": 64
-  },
-  {
-    "id": 93,
-    "displayName": "Redstone Repeater (inactive)",
-    "name": "unpowered_repeater",
-    "stackSize": 64
-  },
-  {
-    "id": 94,
-    "displayName": "Redstone Repeater (active)",
-    "name": "powered_repeater",
     "stackSize": 64
   },
   {
@@ -541,7 +433,7 @@
   },
   {
     "id": 96,
-    "displayName": "Trapdoor",
+    "displayName": "Wooden Trapdoor",
     "name": "trapdoor",
     "stackSize": 64
   },
@@ -559,13 +451,13 @@
   },
   {
     "id": 99,
-    "displayName": "Brown Mushroom (block)",
+    "displayName": "Brown Mushroom Block",
     "name": "brown_mushroom_block",
     "stackSize": 64
   },
   {
     "id": 100,
-    "displayName": "Red Mushroom (block)",
+    "displayName": "Red Mushroom Block",
     "name": "red_mushroom_block",
     "stackSize": 64
   },
@@ -588,18 +480,6 @@
     "stackSize": 64
   },
   {
-    "id": 104,
-    "displayName": "Pumpkin Stem",
-    "name": "pumpkin_stem",
-    "stackSize": 64
-  },
-  {
-    "id": 105,
-    "displayName": "Melon Stem",
-    "name": "melon_stem",
-    "stackSize": 64
-  },
-  {
     "id": 106,
     "displayName": "Vines",
     "name": "vine",
@@ -607,7 +487,7 @@
   },
   {
     "id": 107,
-    "displayName": "Fence Gate",
+    "displayName": "Oak Fence Gate",
     "name": "fence_gate",
     "stackSize": 64
   },
@@ -660,12 +540,6 @@
     "stackSize": 64
   },
   {
-    "id": 119,
-    "displayName": "End Portal",
-    "name": "end_portal",
-    "stackSize": 64
-  },
-  {
     "id": 120,
     "displayName": "End Portal Frame",
     "name": "end_portal_frame",
@@ -685,32 +559,14 @@
   },
   {
     "id": 123,
-    "displayName": "Redstone Lamp (inactive)",
+    "displayName": "Redstone Lamp",
     "name": "redstone_lamp",
     "stackSize": 64
   },
   {
-    "id": 124,
-    "displayName": "Redstone Lamp (active)",
-    "name": "lit_redstone_lamp",
-    "stackSize": 64
-  },
-  {
-    "id": 125,
-    "displayName": "Double Wooden Slab",
-    "name": "double_wooden_slab",
-    "stackSize": 64
-  },
-  {
     "id": 126,
-    "displayName": "Wooden Slab",
+    "displayName": "Wood Slab",
     "name": "wooden_slab",
-    "stackSize": 64
-  },
-  {
-    "id": 127,
-    "displayName": "Cocoa",
-    "name": "cocoa",
     "stackSize": 64
   },
   {
@@ -735,12 +591,6 @@
     "id": 131,
     "displayName": "Tripwire Hook",
     "name": "tripwire_hook",
-    "stackSize": 64
-  },
-  {
-    "id": 132,
-    "displayName": "Tripwire",
-    "name": "tripwire",
     "stackSize": 64
   },
   {
@@ -786,18 +636,6 @@
     "stackSize": 64
   },
   {
-    "id": 141,
-    "displayName": "Carrot",
-    "name": "carrots",
-    "stackSize": 64
-  },
-  {
-    "id": 142,
-    "displayName": "Potato",
-    "name": "potatoes",
-    "stackSize": 64
-  },
-  {
     "id": 143,
     "displayName": "Wooden Button",
     "name": "wooden_button",
@@ -828,20 +666,8 @@
     "stackSize": 64
   },
   {
-    "id": 149,
-    "displayName": "Redstone Comparator",
-    "name": "unpowered_comparator",
-    "stackSize": 64
-  },
-  {
-    "id": 150,
-    "displayName": "Redstone Comparator (deprecated)",
-    "name": "powered_comparator",
-    "stackSize": 64
-  },
-  {
     "id": 151,
-    "displayName": "Daylight Sensor",
+    "displayName": "Daylight Detector",
     "name": "daylight_detector",
     "stackSize": 64
   },
@@ -853,7 +679,7 @@
   },
   {
     "id": 153,
-    "displayName": "Nether Quartz Ore",
+    "displayName": "Nether Quartz",
     "name": "quartz_ore",
     "stackSize": 64
   },
@@ -889,7 +715,7 @@
   },
   {
     "id": 159,
-    "displayName": "Stained Clay",
+    "displayName": "Stained Hardened Clay",
     "name": "stained_hardened_clay",
     "stackSize": 64
   },
@@ -901,13 +727,13 @@
   },
   {
     "id": 161,
-    "displayName": "Leaves (Acacia/Dark Oak)",
+    "displayName": "Leaves",
     "name": "leaves2",
     "stackSize": 64
   },
   {
     "id": 162,
-    "displayName": "Wood (Acacia/Dark Oak)",
+    "displayName": "Wood",
     "name": "log2",
     "stackSize": 64
   },
@@ -990,24 +816,6 @@
     "stackSize": 64
   },
   {
-    "id": 176,
-    "displayName": "Standing Banner",
-    "name": "standing_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 177,
-    "displayName": "Wall Banner",
-    "name": "wall_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 178,
-    "displayName": "Inverted Daylight Sensor",
-    "name": "daylight_detector_inverted",
-    "stackSize": 64
-  },
-  {
     "id": 179,
     "displayName": "Red Sandstone",
     "name": "red_sandstone",
@@ -1017,12 +825,6 @@
     "id": 180,
     "displayName": "Red Sandstone Stairs",
     "name": "red_sandstone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 181,
-    "displayName": "Double Red Sandstone Slab",
-    "name": "double_stone_slab2",
     "stackSize": 64
   },
   {
@@ -1128,12 +930,6 @@
     "stackSize": 64
   },
   {
-    "id": 204,
-    "displayName": "Purpur Double Slab",
-    "name": "purpur_double_slab",
-    "stackSize": 64
-  },
-  {
     "id": 205,
     "displayName": "Purpur Slab",
     "name": "purpur_slab",
@@ -1146,21 +942,9 @@
     "stackSize": 64
   },
   {
-    "id": 207,
-    "displayName": "Beetroot Seeds",
-    "name": "beetroots",
-    "stackSize": 64
-  },
-  {
     "id": 208,
     "displayName": "Grass Path",
     "name": "grass_path",
-    "stackSize": 64
-  },
-  {
-    "id": 209,
-    "displayName": "End Gateway",
-    "name": "end_gateway",
     "stackSize": 64
   },
   {
@@ -1173,12 +957,6 @@
     "id": 211,
     "displayName": "Chain Command Block",
     "name": "chain_command_block",
-    "stackSize": 64
-  },
-  {
-    "id": 212,
-    "displayName": "Frosted Ice",
-    "name": "frosted_ice",
     "stackSize": 64
   },
   {
@@ -1268,7 +1046,7 @@
   {
     "id": 227,
     "displayName": "Light Gray Shulker Box",
-    "name": "light_gray_shulker_box",
+    "name": "silver_shulker_box",
     "stackSize": 64
   },
   {
@@ -1322,8 +1100,9 @@
   {
     "id": 256,
     "displayName": "Iron Shovel",
-    "stackSize": 1,
     "name": "iron_shovel",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1331,14 +1110,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 257,
     "displayName": "Iron Pickaxe",
-    "stackSize": 1,
     "name": "iron_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1346,14 +1125,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 258,
     "displayName": "Iron Axe",
-    "stackSize": 1,
     "name": "iron_axe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1361,49 +1140,48 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 259,
     "displayName": "Flint and Steel",
-    "stackSize": 1,
     "name": "flint_and_steel",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 260,
     "displayName": "Apple",
-    "stackSize": 64,
-    "name": "apple"
+    "name": "apple",
+    "stackSize": 64
   },
   {
     "id": 261,
     "displayName": "Bow",
-    "stackSize": 1,
     "name": "bow",
+    "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 262,
     "displayName": "Arrow",
-    "stackSize": 64,
-    "name": "arrow"
+    "name": "arrow",
+    "stackSize": 64
   },
   {
     "id": 263,
     "displayName": "Coal",
-    "stackSize": 64,
     "name": "coal",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -1418,26 +1196,27 @@
   {
     "id": 264,
     "displayName": "Diamond",
-    "stackSize": 64,
-    "name": "diamond"
+    "name": "diamond",
+    "stackSize": 64
   },
   {
     "id": 265,
     "displayName": "Iron Ingot",
-    "stackSize": 64,
-    "name": "iron_ingot"
+    "name": "iron_ingot",
+    "stackSize": 64
   },
   {
     "id": 266,
     "displayName": "Gold Ingot",
-    "stackSize": 64,
-    "name": "gold_ingot"
+    "name": "gold_ingot",
+    "stackSize": 64
   },
   {
     "id": 267,
     "displayName": "Iron Sword",
-    "stackSize": 1,
     "name": "iron_sword",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1445,14 +1224,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 268,
     "displayName": "Wooden Sword",
-    "stackSize": 1,
     "name": "wooden_sword",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1467,14 +1246,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 269,
     "displayName": "Wooden Shovel",
-    "stackSize": 1,
     "name": "wooden_shovel",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1489,14 +1268,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 270,
     "displayName": "Wooden Pickaxe",
-    "stackSize": 1,
     "name": "wooden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1511,14 +1290,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 271,
     "displayName": "Wooden Axe",
-    "stackSize": 1,
     "name": "wooden_axe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1533,14 +1312,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 272,
     "displayName": "Stone Sword",
-    "stackSize": 1,
     "name": "stone_sword",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1549,14 +1328,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 273,
     "displayName": "Stone Shovel",
-    "stackSize": 1,
     "name": "stone_shovel",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1565,14 +1344,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 274,
     "displayName": "Stone Pickaxe",
-    "stackSize": 1,
     "name": "stone_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1581,14 +1360,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 275,
     "displayName": "Stone Axe",
-    "stackSize": 1,
     "name": "stone_axe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1597,14 +1376,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 276,
     "displayName": "Diamond Sword",
-    "stackSize": 1,
     "name": "diamond_sword",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1612,14 +1391,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 277,
     "displayName": "Diamond Shovel",
-    "stackSize": 1,
     "name": "diamond_shovel",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1627,14 +1406,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 278,
     "displayName": "Diamond Pickaxe",
-    "stackSize": 1,
     "name": "diamond_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1642,14 +1421,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 279,
     "displayName": "Diamond Axe",
-    "stackSize": 1,
     "name": "diamond_axe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1657,32 +1436,32 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 280,
     "displayName": "Stick",
-    "stackSize": 64,
-    "name": "stick"
+    "name": "stick",
+    "stackSize": 64
   },
   {
     "id": 281,
     "displayName": "Bowl",
-    "stackSize": 64,
-    "name": "bowl"
+    "name": "bowl",
+    "stackSize": 64
   },
   {
     "id": 282,
     "displayName": "Mushroom Stew",
-    "stackSize": 1,
-    "name": "mushroom_stew"
+    "name": "mushroom_stew",
+    "stackSize": 1
   },
   {
     "id": 283,
     "displayName": "Golden Sword",
-    "stackSize": 1,
     "name": "golden_sword",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1690,14 +1469,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 284,
     "displayName": "Golden Shovel",
-    "stackSize": 1,
     "name": "golden_shovel",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1705,14 +1484,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 285,
     "displayName": "Golden Pickaxe",
-    "stackSize": 1,
     "name": "golden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1720,14 +1499,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 286,
     "displayName": "Golden Axe",
-    "stackSize": 1,
     "name": "golden_axe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1735,32 +1514,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 287,
     "displayName": "String",
-    "stackSize": 64,
-    "name": "string"
+    "name": "string",
+    "stackSize": 64
   },
   {
     "id": 288,
     "displayName": "Feather",
-    "stackSize": 64,
-    "name": "feather"
+    "name": "feather",
+    "stackSize": 64
   },
   {
     "id": 289,
     "displayName": "Gunpowder",
-    "stackSize": 64,
-    "name": "gunpowder"
+    "name": "gunpowder",
+    "stackSize": 64
   },
   {
     "id": 290,
     "displayName": "Wooden Hoe",
-    "stackSize": 1,
     "name": "wooden_hoe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1775,14 +1554,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 291,
     "displayName": "Stone Hoe",
-    "stackSize": 1,
     "name": "stone_hoe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1791,14 +1570,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 292,
     "displayName": "Iron Hoe",
-    "stackSize": 1,
     "name": "iron_hoe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1806,14 +1585,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 293,
     "displayName": "Diamond Hoe",
-    "stackSize": 1,
     "name": "diamond_hoe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1821,14 +1600,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 294,
     "displayName": "Golden Hoe",
-    "stackSize": 1,
     "name": "golden_hoe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1836,32 +1615,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 295,
     "displayName": "Seeds",
-    "stackSize": 64,
-    "name": "wheat_seeds"
+    "name": "wheat_seeds",
+    "stackSize": 64
   },
   {
     "id": 296,
     "displayName": "Wheat",
-    "stackSize": 64,
-    "name": "wheat"
+    "name": "wheat",
+    "stackSize": 64
   },
   {
     "id": 297,
     "displayName": "Bread",
-    "stackSize": 64,
-    "name": "bread"
+    "name": "bread",
+    "stackSize": 64
   },
   {
     "id": 298,
     "displayName": "Leather Cap",
-    "stackSize": 1,
     "name": "leather_helmet",
+    "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1871,14 +1650,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 299,
     "displayName": "Leather Tunic",
-    "stackSize": 1,
     "name": "leather_chestplate",
+    "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1888,14 +1667,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 300,
     "displayName": "Leather Pants",
-    "stackSize": 1,
     "name": "leather_leggings",
+    "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1904,14 +1683,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 301,
     "displayName": "Leather Boots",
-    "stackSize": 1,
     "name": "leather_boots",
+    "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1921,14 +1700,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 302,
     "displayName": "Chain Helmet",
-    "stackSize": 1,
     "name": "chainmail_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1938,14 +1717,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 303,
     "displayName": "Chain Chestplate",
-    "stackSize": 1,
     "name": "chainmail_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1955,14 +1734,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 304,
     "displayName": "Chain Leggings",
-    "stackSize": 1,
     "name": "chainmail_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1971,14 +1750,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 305,
     "displayName": "Chain Boots",
-    "stackSize": 1,
     "name": "chainmail_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1988,14 +1767,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 306,
     "displayName": "Iron Helmet",
-    "stackSize": 1,
     "name": "iron_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2005,14 +1784,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 307,
     "displayName": "Iron Chestplate",
-    "stackSize": 1,
     "name": "iron_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2022,14 +1801,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 308,
     "displayName": "Iron Leggings",
-    "stackSize": 1,
     "name": "iron_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2038,14 +1817,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 309,
     "displayName": "Iron Boots",
-    "stackSize": 1,
     "name": "iron_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2055,14 +1834,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 310,
     "displayName": "Diamond Helmet",
-    "stackSize": 1,
     "name": "diamond_helmet",
+    "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2072,14 +1851,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 311,
     "displayName": "Diamond Chestplate",
-    "stackSize": 1,
     "name": "diamond_chestplate",
+    "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2089,14 +1868,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 312,
     "displayName": "Diamond Leggings",
-    "stackSize": 1,
     "name": "diamond_leggings",
+    "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2105,14 +1884,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 313,
     "displayName": "Diamond Boots",
-    "stackSize": 1,
     "name": "diamond_boots",
+    "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2122,14 +1901,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 314,
     "displayName": "Golden Helmet",
-    "stackSize": 1,
     "name": "golden_helmet",
+    "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2139,14 +1918,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 315,
     "displayName": "Golden Chestplate",
-    "stackSize": 1,
     "name": "golden_chestplate",
+    "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2156,14 +1935,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 316,
     "displayName": "Golden Leggings",
-    "stackSize": 1,
     "name": "golden_leggings",
+    "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2172,14 +1951,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 317,
     "displayName": "Golden Boots",
-    "stackSize": 1,
     "name": "golden_boots",
+    "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2189,38 +1968,37 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 318,
     "displayName": "Flint",
-    "stackSize": 64,
-    "name": "flint"
+    "name": "flint",
+    "stackSize": 64
   },
   {
     "id": 319,
     "displayName": "Raw Porkchop",
-    "stackSize": 64,
-    "name": "porkchop"
+    "name": "porkchop",
+    "stackSize": 64
   },
   {
     "id": 320,
     "displayName": "Cooked Porkchop",
-    "stackSize": 64,
-    "name": "cooked_porkchop"
+    "name": "cooked_porkchop",
+    "stackSize": 64
   },
   {
     "id": 321,
     "displayName": "Painting",
-    "stackSize": 64,
-    "name": "painting"
+    "name": "painting",
+    "stackSize": 64
   },
   {
     "id": 322,
     "displayName": "Golden Apple",
-    "stackSize": 64,
     "name": "golden_apple",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2235,170 +2013,170 @@
   {
     "id": 323,
     "displayName": "Sign",
-    "stackSize": 16,
-    "name": "sign"
+    "name": "sign",
+    "stackSize": 16
   },
   {
     "id": 324,
     "displayName": "Oak Door",
-    "stackSize": 64,
-    "name": "wooden_door"
+    "name": "wooden_door",
+    "stackSize": 64
   },
   {
     "id": 325,
     "displayName": "Bucket",
-    "stackSize": 16,
-    "name": "bucket"
+    "name": "bucket",
+    "stackSize": 16
   },
   {
     "id": 326,
     "displayName": "Water Bucket",
-    "stackSize": 1,
-    "name": "water_bucket"
+    "name": "water_bucket",
+    "stackSize": 1
   },
   {
     "id": 327,
     "displayName": "Lava Bucket",
-    "stackSize": 1,
-    "name": "lava_bucket"
+    "name": "lava_bucket",
+    "stackSize": 1
   },
   {
     "id": 328,
     "displayName": "Minecart",
-    "stackSize": 1,
-    "name": "minecart"
+    "name": "minecart",
+    "stackSize": 1
   },
   {
     "id": 329,
     "displayName": "Saddle",
-    "stackSize": 1,
-    "name": "saddle"
+    "name": "saddle",
+    "stackSize": 1
   },
   {
     "id": 330,
     "displayName": "Iron Door",
-    "stackSize": 64,
-    "name": "iron_door"
+    "name": "iron_door",
+    "stackSize": 64
   },
   {
     "id": 331,
     "displayName": "Redstone",
-    "stackSize": 64,
-    "name": "redstone"
+    "name": "redstone",
+    "stackSize": 64
   },
   {
     "id": 332,
     "displayName": "Snowball",
-    "stackSize": 16,
-    "name": "snowball"
+    "name": "snowball",
+    "stackSize": 16
   },
   {
     "id": 333,
     "displayName": "Boat",
-    "stackSize": 1,
-    "name": "boat"
+    "name": "boat",
+    "stackSize": 1
   },
   {
     "id": 334,
     "displayName": "Leather",
-    "stackSize": 64,
-    "name": "leather"
+    "name": "leather",
+    "stackSize": 64
   },
   {
     "id": 335,
     "displayName": "Milk",
-    "stackSize": 1,
-    "name": "milk_bucket"
+    "name": "milk_bucket",
+    "stackSize": 1
   },
   {
     "id": 336,
     "displayName": "Brick",
-    "stackSize": 64,
-    "name": "brick"
+    "name": "brick",
+    "stackSize": 64
   },
   {
     "id": 337,
     "displayName": "Clay",
-    "stackSize": 64,
-    "name": "clay_ball"
+    "name": "clay_ball",
+    "stackSize": 64
   },
   {
     "id": 338,
-    "displayName": "Sugar Cane",
-    "stackSize": 64,
-    "name": "reeds"
+    "displayName": "Sugar Canes",
+    "name": "reeds",
+    "stackSize": 64
   },
   {
     "id": 339,
     "displayName": "Paper",
-    "stackSize": 64,
-    "name": "paper"
+    "name": "paper",
+    "stackSize": 64
   },
   {
     "id": 340,
     "displayName": "Book",
-    "stackSize": 64,
-    "name": "book"
+    "name": "book",
+    "stackSize": 64
   },
   {
     "id": 341,
     "displayName": "Slimeball",
-    "stackSize": 64,
-    "name": "slime_ball"
+    "name": "slime_ball",
+    "stackSize": 64
   },
   {
     "id": 342,
     "displayName": "Minecart with Chest",
-    "stackSize": 1,
-    "name": "chest_minecart"
+    "name": "chest_minecart",
+    "stackSize": 1
   },
   {
     "id": 343,
     "displayName": "Minecart with Furnace",
-    "stackSize": 1,
-    "name": "furnace_minecart"
+    "name": "furnace_minecart",
+    "stackSize": 1
   },
   {
     "id": 344,
     "displayName": "Egg",
-    "stackSize": 16,
-    "name": "egg"
+    "name": "egg",
+    "stackSize": 16
   },
   {
     "id": 345,
     "displayName": "Compass",
-    "stackSize": 64,
-    "name": "compass"
+    "name": "compass",
+    "stackSize": 64
   },
   {
     "id": 346,
     "displayName": "Fishing Rod",
-    "stackSize": 1,
     "name": "fishing_rod",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 347,
     "displayName": "Clock",
-    "stackSize": 64,
-    "name": "clock"
+    "name": "clock",
+    "stackSize": 64
   },
   {
     "id": 348,
     "displayName": "Glowstone Dust",
-    "stackSize": 64,
-    "name": "glowstone_dust"
+    "name": "glowstone_dust",
+    "stackSize": 64
   },
   {
     "id": 349,
-    "displayName": "Raw Fish",
-    "stackSize": 64,
+    "displayName": "Fish",
     "name": "fish",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2421,32 +2199,14 @@
   {
     "id": 350,
     "displayName": "Cooked Fish",
-    "stackSize": 64,
     "name": "cooked_fish",
-    "variations": [
-      {
-        "metadata": 0,
-        "displayName": "Raw Fish"
-      },
-      {
-        "metadata": 1,
-        "displayName": "Raw Salmon"
-      },
-      {
-        "metadata": 2,
-        "displayName": "Clownfish"
-      },
-      {
-        "metadata": 3,
-        "displayName": "Pufferfish"
-      }
-    ]
+    "stackSize": 64
   },
   {
     "id": 351,
     "displayName": "Dye",
-    "stackSize": 64,
     "name": "dye",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2517,283 +2277,341 @@
   {
     "id": 352,
     "displayName": "Bone",
-    "stackSize": 64,
-    "name": "bone"
+    "name": "bone",
+    "stackSize": 64
   },
   {
     "id": 353,
     "displayName": "Sugar",
-    "stackSize": 64,
-    "name": "sugar"
+    "name": "sugar",
+    "stackSize": 64
   },
   {
     "id": 354,
     "displayName": "Cake",
-    "stackSize": 1,
-    "name": "cake"
+    "name": "cake",
+    "stackSize": 1
   },
   {
     "id": 355,
     "displayName": "Bed",
-    "stackSize": 1,
-    "name": "bed"
+    "name": "bed",
+    "stackSize": 1
   },
   {
     "id": 356,
     "displayName": "Redstone Repeater",
-    "stackSize": 64,
-    "name": "repeater"
+    "name": "repeater",
+    "stackSize": 64
   },
   {
     "id": 357,
     "displayName": "Cookie",
-    "stackSize": 64,
-    "name": "cookie"
+    "name": "cookie",
+    "stackSize": 64
   },
   {
     "id": 358,
     "displayName": "Map",
-    "stackSize": 64,
-    "name": "filled_map"
+    "name": "filled_map",
+    "stackSize": 64
   },
   {
     "id": 359,
     "displayName": "Shears",
-    "stackSize": 1,
     "name": "shears",
+    "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 360,
     "displayName": "Melon",
-    "stackSize": 64,
-    "name": "melon"
+    "name": "melon",
+    "stackSize": 64
   },
   {
     "id": 361,
     "displayName": "Pumpkin Seeds",
-    "stackSize": 64,
-    "name": "pumpkin_seeds"
+    "name": "pumpkin_seeds",
+    "stackSize": 64
   },
   {
     "id": 362,
     "displayName": "Melon Seeds",
-    "stackSize": 64,
-    "name": "melon_seeds"
+    "name": "melon_seeds",
+    "stackSize": 64
   },
   {
     "id": 363,
     "displayName": "Raw Beef",
-    "stackSize": 64,
-    "name": "beef"
+    "name": "beef",
+    "stackSize": 64
   },
   {
     "id": 364,
     "displayName": "Steak",
-    "stackSize": 64,
-    "name": "cooked_beef"
+    "name": "cooked_beef",
+    "stackSize": 64
   },
   {
     "id": 365,
     "displayName": "Raw Chicken",
-    "stackSize": 64,
-    "name": "chicken"
+    "name": "chicken",
+    "stackSize": 64
   },
   {
     "id": 366,
     "displayName": "Cooked Chicken",
-    "stackSize": 64,
-    "name": "cooked_chicken"
+    "name": "cooked_chicken",
+    "stackSize": 64
   },
   {
     "id": 367,
     "displayName": "Rotten Flesh",
-    "stackSize": 64,
-    "name": "rotten_flesh"
+    "name": "rotten_flesh",
+    "stackSize": 64
   },
   {
     "id": 368,
     "displayName": "Ender Pearl",
-    "stackSize": 16,
-    "name": "ender_pearl"
+    "name": "ender_pearl",
+    "stackSize": 64
   },
   {
     "id": 369,
     "displayName": "Blaze Rod",
-    "stackSize": 64,
-    "name": "blaze_rod"
+    "name": "blaze_rod",
+    "stackSize": 64
   },
   {
     "id": 370,
     "displayName": "Ghast Tear",
-    "stackSize": 64,
-    "name": "ghast_tear"
+    "name": "ghast_tear",
+    "stackSize": 64
   },
   {
     "id": 371,
     "displayName": "Gold Nugget",
-    "stackSize": 64,
-    "name": "gold_nugget"
+    "name": "gold_nugget",
+    "stackSize": 64
   },
   {
     "id": 372,
     "displayName": "Nether Wart",
-    "stackSize": 64,
-    "name": "nether_wart"
+    "name": "nether_wart",
+    "stackSize": 64
   },
   {
     "id": 373,
     "displayName": "Potion",
-    "stackSize": 1,
-    "name": "potion"
+    "name": "potion",
+    "stackSize": 1
   },
   {
     "id": 374,
     "displayName": "Glass Bottle",
-    "stackSize": 64,
-    "name": "glass_bottle"
+    "name": "glass_bottle",
+    "stackSize": 64
   },
   {
     "id": 375,
     "displayName": "Spider Eye",
-    "stackSize": 64,
-    "name": "spider_eye"
+    "name": "spider_eye",
+    "stackSize": 64
   },
   {
     "id": 376,
     "displayName": "Fermented Spider Eye",
-    "stackSize": 64,
-    "name": "fermented_spider_eye"
+    "name": "fermented_spider_eye",
+    "stackSize": 64
   },
   {
     "id": 377,
     "displayName": "Blaze Powder",
-    "stackSize": 64,
-    "name": "blaze_powder"
+    "name": "blaze_powder",
+    "stackSize": 64
   },
   {
     "id": 378,
     "displayName": "Magma Cream",
-    "stackSize": 64,
-    "name": "magma_cream"
+    "name": "magma_cream",
+    "stackSize": 64
   },
   {
     "id": 379,
     "displayName": "Brewing Stand",
-    "stackSize": 64,
-    "name": "brewing_stand"
+    "name": "brewing_stand",
+    "stackSize": 64
   },
   {
     "id": 380,
     "displayName": "Cauldron",
-    "stackSize": 64,
-    "name": "cauldron"
+    "name": "cauldron",
+    "stackSize": 64
   },
   {
     "id": 381,
     "displayName": "Eye of Ender",
-    "stackSize": 64,
-    "name": "ender_eye"
+    "name": "ender_eye",
+    "stackSize": 64
   },
   {
     "id": 382,
     "displayName": "Glistering Melon",
-    "stackSize": 64,
-    "name": "speckled_melon"
+    "name": "speckled_melon",
+    "stackSize": 64
   },
   {
     "id": 383,
     "displayName": "Spawn Egg",
-    "stackSize": 64,
-    "name": "spawn_egg"
+    "name": "spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 384,
     "displayName": "Bottle o' Enchanting",
-    "stackSize": 64,
-    "name": "experience_bottle"
+    "name": "experience_bottle",
+    "stackSize": 64
   },
   {
     "id": 385,
     "displayName": "Fire Charge",
-    "stackSize": 64,
-    "name": "fire_charge"
+    "name": "fire_charge",
+    "stackSize": 64
   },
   {
     "id": 386,
     "displayName": "Book and Quill",
-    "stackSize": 1,
-    "name": "writable_book"
+    "name": "writable_book",
+    "stackSize": 1
   },
   {
     "id": 387,
     "displayName": "Written Book",
-    "stackSize": 16,
-    "name": "written_book"
+    "name": "written_book",
+    "stackSize": 16
   },
   {
     "id": 388,
     "displayName": "Emerald",
-    "stackSize": 64,
-    "name": "emerald"
+    "name": "emerald",
+    "stackSize": 64
   },
   {
     "id": 389,
     "displayName": "Item Frame",
-    "stackSize": 64,
-    "name": "item_frame"
+    "name": "item_frame",
+    "stackSize": 64
   },
   {
     "id": 390,
     "displayName": "Flower Pot",
+    "name": "flower_pot",
     "stackSize": 64,
-    "name": "flower_pot"
+    "variations": [
+      {
+        "metadata": 0,
+        "displayName": "Empty Flower Pot"
+      },
+      {
+        "metadata": 1,
+        "displayName": "Poppy Flower Pot"
+      },
+      {
+        "metadata": 2,
+        "displayName": "Dandelion Flower Pot"
+      },
+      {
+        "metadata": 3,
+        "displayName": "Oak sapling Flower Pot"
+      },
+      {
+        "metadata": 4,
+        "displayName": "Spruce sapling Flower Pot"
+      },
+      {
+        "metadata": 5,
+        "displayName": "Birch sapling Flower Pot"
+      },
+      {
+        "metadata": 6,
+        "displayName": "Jungle sapling Flower Pot"
+      },
+      {
+        "metadata": 7,
+        "displayName": "Red mushroom Flower Pot"
+      },
+      {
+        "metadata": 8,
+        "displayName": "Brown mushroom Flower Pot"
+      },
+      {
+        "metadata": 9,
+        "displayName": "Cactus Flower Pot"
+      },
+      {
+        "metadata": 10,
+        "displayName": "Dead bush Flower Pot"
+      },
+      {
+        "metadata": 11,
+        "displayName": "Fern Flower Pot"
+      },
+      {
+        "metadata": 12,
+        "displayName": "Acacia sapling Flower Pot"
+      },
+      {
+        "metadata": 13,
+        "displayName": "Dark oak sapling Flower Pot"
+      }
+    ]
   },
   {
     "id": 391,
     "displayName": "Carrot",
-    "stackSize": 64,
-    "name": "carrot"
+    "name": "carrot",
+    "stackSize": 64
   },
   {
     "id": 392,
     "displayName": "Potato",
-    "stackSize": 64,
-    "name": "potato"
+    "name": "potato",
+    "stackSize": 64
   },
   {
     "id": 393,
     "displayName": "Baked Potato",
-    "stackSize": 64,
-    "name": "baked_potato"
+    "name": "baked_potato",
+    "stackSize": 64
   },
   {
     "id": 394,
     "displayName": "Poisonous Potato",
-    "stackSize": 64,
-    "name": "poisonous_potato"
+    "name": "poisonous_potato",
+    "stackSize": 64
   },
   {
     "id": 395,
     "displayName": "Empty Map",
-    "stackSize": 64,
-    "name": "map"
+    "name": "map",
+    "stackSize": 64
   },
   {
     "id": 396,
     "displayName": "Golden Carrot",
-    "stackSize": 64,
-    "name": "golden_carrot"
+    "name": "golden_carrot",
+    "stackSize": 64
   },
   {
     "id": 397,
-    "displayName": "Mob head",
-    "stackSize": 64,
+    "displayName": "Skull",
     "name": "skull",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2820,277 +2638,278 @@
   {
     "id": 398,
     "displayName": "Carrot on a Stick",
-    "stackSize": 1,
     "name": "carrot_on_a_stick",
+    "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 399,
     "displayName": "Nether Star",
-    "stackSize": 64,
-    "name": "nether_star"
+    "name": "nether_star",
+    "stackSize": 64
   },
   {
     "id": 400,
     "displayName": "Pumpkin Pie",
-    "stackSize": 64,
-    "name": "pumpkin_pie"
+    "name": "pumpkin_pie",
+    "stackSize": 64
   },
   {
     "id": 401,
     "displayName": "Firework Rocket",
-    "stackSize": 64,
-    "name": "fireworks"
+    "name": "fireworks",
+    "stackSize": 64
   },
   {
     "id": 402,
     "displayName": "Firework Star",
-    "stackSize": 64,
-    "name": "firework_charge"
+    "name": "firework_charge",
+    "stackSize": 64
   },
   {
     "id": 403,
     "displayName": "Enchanted Book",
-    "stackSize": 1,
-    "name": "enchanted_book"
+    "name": "enchanted_book",
+    "stackSize": 1
   },
   {
     "id": 404,
     "displayName": "Redstone Comparator",
-    "stackSize": 64,
-    "name": "comparator"
+    "name": "comparator",
+    "stackSize": 64
   },
   {
     "id": 405,
     "displayName": "Nether Brick",
-    "stackSize": 64,
-    "name": "netherbrick"
+    "name": "netherbrick",
+    "stackSize": 64
   },
   {
     "id": 406,
     "displayName": "Nether Quartz",
-    "stackSize": 64,
-    "name": "quartz"
+    "name": "quartz",
+    "stackSize": 64
   },
   {
     "id": 407,
     "displayName": "Minecart with TNT",
-    "stackSize": 1,
-    "name": "tnt_minecart"
+    "name": "tnt_minecart",
+    "stackSize": 1
   },
   {
     "id": 408,
     "displayName": "Minecart with Hopper",
-    "stackSize": 1,
-    "name": "hopper_minecart"
+    "name": "hopper_minecart",
+    "stackSize": 1
   },
   {
     "id": 409,
     "displayName": "Prismarine Shard",
-    "stackSize": 64,
-    "name": "prismarine_shard"
+    "name": "prismarine_shard",
+    "stackSize": 64
   },
   {
     "id": 410,
     "displayName": "Prismarine Crystals",
-    "stackSize": 64,
-    "name": "prismarine_crystals"
+    "name": "prismarine_crystals",
+    "stackSize": 64
   },
   {
     "id": 411,
     "displayName": "Raw Rabbit",
-    "stackSize": 64,
-    "name": "rabbit"
+    "name": "rabbit",
+    "stackSize": 64
   },
   {
     "id": 412,
     "displayName": "Cooked Rabbit",
-    "stackSize": 64,
-    "name": "cooked_rabbit"
+    "name": "cooked_rabbit",
+    "stackSize": 64
   },
   {
     "id": 413,
     "displayName": "Rabbit Stew",
-    "stackSize": 1,
-    "name": "rabbit_stew"
+    "name": "rabbit_stew",
+    "stackSize": 1
   },
   {
     "id": 414,
     "displayName": "Rabbit's Foot",
-    "stackSize": 64,
-    "name": "rabbit_foot"
+    "name": "rabbit_foot",
+    "stackSize": 64
   },
   {
     "id": 415,
     "displayName": "Rabbit Hide",
-    "stackSize": 64,
-    "name": "rabbit_hide"
+    "name": "rabbit_hide",
+    "stackSize": 64
   },
   {
     "id": 416,
     "displayName": "Armor Stand",
-    "stackSize": 16,
-    "name": "armor_stand"
+    "name": "armor_stand",
+    "stackSize": 16
   },
   {
     "id": 417,
     "displayName": "Iron Horse Armor",
-    "stackSize": 1,
-    "name": "iron_horse_armor"
+    "name": "iron_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 418,
-    "displayName": "Golden Horse Armor",
-    "stackSize": 1,
-    "name": "golden_horse_armor"
+    "displayName": "Gold Horse Armor",
+    "name": "golden_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 419,
     "displayName": "Diamond Horse Armor",
-    "stackSize": 1,
-    "name": "diamond_horse_armor"
+    "name": "diamond_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 420,
     "displayName": "Lead",
-    "stackSize": 64,
-    "name": "lead"
+    "name": "lead",
+    "stackSize": 64
   },
   {
     "id": 421,
     "displayName": "Name Tag",
-    "stackSize": 64,
-    "name": "name_tag"
+    "name": "name_tag",
+    "stackSize": 64
   },
   {
     "id": 422,
     "displayName": "Minecart with Command Block",
-    "stackSize": 1,
-    "name": "command_block_minecart"
+    "name": "command_block_minecart",
+    "stackSize": 1
   },
   {
     "id": 423,
     "displayName": "Raw Mutton",
-    "stackSize": 64,
-    "name": "mutton"
+    "name": "mutton",
+    "stackSize": 64
   },
   {
     "id": 424,
     "displayName": "Cooked Mutton",
-    "stackSize": 64,
-    "name": "cooked_mutton"
+    "name": "cooked_mutton",
+    "stackSize": 64
   },
   {
     "id": 425,
     "displayName": "Banner",
-    "stackSize": 16,
-    "name": "banner"
+    "name": "banner",
+    "stackSize": 16
   },
   {
     "id": 426,
     "displayName": "End Crystal",
-    "stackSize": 64,
-    "name": "end_crystal"
+    "name": "end_crystal",
+    "stackSize": 64
   },
   {
     "id": 427,
     "displayName": "Spruce Door",
-    "stackSize": 64,
-    "name": "spruce_door"
+    "name": "spruce_door",
+    "stackSize": 64
   },
   {
     "id": 428,
     "displayName": "Birch Door",
-    "stackSize": 64,
-    "name": "birch_door"
+    "name": "birch_door",
+    "stackSize": 64
   },
   {
     "id": 429,
     "displayName": "Jungle Door",
-    "stackSize": 64,
-    "name": "jungle_door"
+    "name": "jungle_door",
+    "stackSize": 64
   },
   {
     "id": 430,
     "displayName": "Acacia Door",
-    "stackSize": 64,
-    "name": "acacia_door"
+    "name": "acacia_door",
+    "stackSize": 64
   },
   {
     "id": 431,
     "displayName": "Dark Oak Door",
-    "stackSize": 64,
-    "name": "dark_oak_door"
+    "name": "dark_oak_door",
+    "stackSize": 64
   },
   {
     "id": 432,
     "displayName": "Chorus Fruit",
-    "stackSize": 64,
-    "name": "chorus_fruit"
+    "name": "chorus_fruit",
+    "stackSize": 64
   },
   {
     "id": 433,
     "displayName": "Popped Chorus Fruit",
-    "stackSize": 64,
-    "name": "chorus_fruit_popped"
+    "name": "chorus_fruit_popped",
+    "stackSize": 64
   },
   {
     "id": 434,
     "displayName": "Beetroot",
-    "stackSize": 64,
-    "name": "beetroot"
+    "name": "beetroot",
+    "stackSize": 64
   },
   {
     "id": 435,
     "displayName": "Beetroot Seeds",
-    "stackSize": 64,
-    "name": "beetroot_seeds"
+    "name": "beetroot_seeds",
+    "stackSize": 64
   },
   {
     "id": 436,
     "displayName": "Beetroot Soup",
-    "stackSize": 1,
-    "name": "beetroot_soup"
+    "name": "beetroot_soup",
+    "stackSize": 1
   },
   {
     "id": 437,
     "displayName": "Dragon's Breath",
-    "stackSize": 64,
-    "name": "dragon_breath"
+    "name": "dragon_breath",
+    "stackSize": 64
   },
   {
     "id": 438,
     "displayName": "Splash Potion",
-    "stackSize": 1,
-    "name": "splash_potion"
+    "name": "splash_potion",
+    "stackSize": 1
   },
   {
     "id": 439,
     "displayName": "Spectral Arrow",
-    "stackSize": 64,
-    "name": "spectral_arrow"
+    "name": "spectral_arrow",
+    "stackSize": 64
   },
   {
     "id": 440,
     "displayName": "Tipped Arrow",
-    "stackSize": 64,
-    "name": "tipped_arrow"
+    "name": "tipped_arrow",
+    "stackSize": 64
   },
   {
     "id": 441,
     "displayName": "Lingering Potion",
-    "stackSize": 1,
-    "name": "lingering_potion"
+    "name": "lingering_potion",
+    "stackSize": 1
   },
   {
     "id": 442,
     "displayName": "Shield",
-    "stackSize": 1,
     "name": "shield",
+    "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3104,14 +2923,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 443,
     "displayName": "Elytra",
-    "stackSize": 1,
     "name": "elytra",
+    "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -3119,127 +2938,120 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 444,
     "displayName": "Spruce Boat",
-    "stackSize": 1,
-    "name": "spruce_boat"
+    "name": "spruce_boat",
+    "stackSize": 1
   },
   {
     "id": 445,
     "displayName": "Birch Boat",
-    "stackSize": 1,
-    "name": "birch_boat"
+    "name": "birch_boat",
+    "stackSize": 1
   },
   {
     "id": 446,
     "displayName": "Jungle Boat",
-    "stackSize": 1,
-    "name": "jungle_boat"
+    "name": "jungle_boat",
+    "stackSize": 1
   },
   {
     "id": 447,
     "displayName": "Acacia Boat",
-    "stackSize": 1,
-    "name": "acacia_boat"
+    "name": "acacia_boat",
+    "stackSize": 1
   },
   {
     "id": 448,
     "displayName": "Dark Oak Boat",
-    "stackSize": 1,
-    "name": "dark_oak_boat"
+    "name": "dark_oak_boat",
+    "stackSize": 1
   },
   {
     "id": 449,
     "displayName": "Totem of Undying",
-    "stackSize": 1,
-    "name": "totem_of_undying"
+    "name": "totem",
+    "stackSize": 1
   },
   {
     "id": 450,
     "displayName": "Shulker Shell",
-    "stackSize": 64,
-    "name": "shulker_shell"
-  },
-  {
-    "id": 452,
-    "displayName": "Iron Nugget",
-    "stackSize": 64,
-    "name": "iron_nugget"
+    "name": "shulker_shell",
+    "stackSize": 64
   },
   {
     "id": 2256,
     "displayName": "13 Disc",
-    "stackSize": 1,
-    "name": "record_13"
+    "name": "record_13",
+    "stackSize": 64
   },
   {
     "id": 2257,
     "displayName": "Cat Disc",
-    "stackSize": 1,
-    "name": "record_cat"
+    "name": "record_cat",
+    "stackSize": 1
   },
   {
     "id": 2258,
     "displayName": "Blocks Disc",
-    "stackSize": 1,
-    "name": "record_blocks"
+    "name": "record_blocks",
+    "stackSize": 1
   },
   {
     "id": 2259,
     "displayName": "Chirp Disc",
-    "stackSize": 1,
-    "name": "record_chirp"
+    "name": "record_chirp",
+    "stackSize": 1
   },
   {
     "id": 2260,
     "displayName": "Far Disc",
-    "stackSize": 1,
-    "name": "record_far"
+    "name": "record_far",
+    "stackSize": 1
   },
   {
     "id": 2261,
     "displayName": "Mall Disc",
-    "stackSize": 1,
-    "name": "record_mall"
+    "name": "record_mall",
+    "stackSize": 1
   },
   {
     "id": 2262,
     "displayName": "Mellohi Disc",
-    "stackSize": 1,
-    "name": "record_mellohi"
+    "name": "record_mellohi",
+    "stackSize": 1
   },
   {
     "id": 2263,
     "displayName": "Stal Disc",
-    "stackSize": 1,
-    "name": "record_stal"
+    "name": "record_stal",
+    "stackSize": 1
   },
   {
     "id": 2264,
     "displayName": "Strad Disc",
-    "stackSize": 1,
-    "name": "record_strad"
+    "name": "record_strad",
+    "stackSize": 1
   },
   {
     "id": 2265,
     "displayName": "Ward Disc",
-    "stackSize": 1,
-    "name": "record_ward"
+    "name": "record_ward",
+    "stackSize": 1
   },
   {
     "id": 2266,
     "displayName": "11 Disc",
-    "stackSize": 1,
-    "name": "record_11"
+    "name": "record_11",
+    "stackSize": 1
   },
   {
     "id": 2267,
     "displayName": "Wait Disc",
-    "stackSize": 1,
-    "name": "record_wait"
+    "name": "record_wait",
+    "stackSize": 1
   }
 ]

--- a/data/pc/1.12/items.json
+++ b/data/pc/1.12/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 64
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -31,7 +25,7 @@
   },
   {
     "id": 5,
-    "displayName": "Wood Planks",
+    "displayName": "Wooden Planks",
     "name": "planks",
     "stackSize": 64
   },
@@ -45,30 +39,6 @@
     "id": 7,
     "displayName": "Bedrock",
     "name": "bedrock",
-    "stackSize": 64
-  },
-  {
-    "id": 8,
-    "displayName": "Water",
-    "name": "flowing_water",
-    "stackSize": 64
-  },
-  {
-    "id": 9,
-    "displayName": "Stationary Water",
-    "name": "water",
-    "stackSize": 64
-  },
-  {
-    "id": 10,
-    "displayName": "Lava",
-    "name": "flowing_lava",
-    "stackSize": 64
-  },
-  {
-    "id": 11,
-    "displayName": "Stationary Lava",
-    "name": "lava",
     "stackSize": 64
   },
   {
@@ -198,21 +168,9 @@
     "stackSize": 64
   },
   {
-    "id": 34,
-    "displayName": "Piston Head",
-    "name": "piston_head",
-    "stackSize": 64
-  },
-  {
     "id": 35,
     "displayName": "Wool",
     "name": "wool",
-    "stackSize": 64
-  },
-  {
-    "id": 36,
-    "displayName": "Block moved by Piston",
-    "name": "piston_extension",
     "stackSize": 64
   },
   {
@@ -252,12 +210,6 @@
     "stackSize": 64
   },
   {
-    "id": 43,
-    "displayName": "Double Stone Slab",
-    "name": "double_stone_slab",
-    "stackSize": 64
-  },
-  {
     "id": 44,
     "displayName": "Stone Slab",
     "name": "stone_slab",
@@ -265,7 +217,7 @@
   },
   {
     "id": 45,
-    "displayName": "Bricks",
+    "displayName": "Brick",
     "name": "brick_block",
     "stackSize": 64
   },
@@ -300,12 +252,6 @@
     "stackSize": 64
   },
   {
-    "id": 51,
-    "displayName": "Fire",
-    "name": "fire",
-    "stackSize": 64
-  },
-  {
     "id": 52,
     "displayName": "Monster Spawner",
     "name": "mob_spawner",
@@ -321,12 +267,6 @@
     "id": 54,
     "displayName": "Chest",
     "name": "chest",
-    "stackSize": 64
-  },
-  {
-    "id": 55,
-    "displayName": "Redstone Wire",
-    "name": "redstone_wire",
     "stackSize": 64
   },
   {
@@ -360,18 +300,6 @@
     "stackSize": 64
   },
   {
-    "id": 62,
-    "displayName": "Burning Furnace",
-    "name": "lit_furnace",
-    "stackSize": 64
-  },
-  {
-    "id": 63,
-    "displayName": "Standing Sign",
-    "name": "standing_sign",
-    "stackSize": 64
-  },
-  {
     "id": 65,
     "displayName": "Ladder",
     "name": "ladder",
@@ -387,12 +315,6 @@
     "id": 67,
     "displayName": "Cobblestone Stairs",
     "name": "stone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 68,
-    "displayName": "Wall Sign",
-    "name": "wall_sign",
     "stackSize": 64
   },
   {
@@ -420,20 +342,8 @@
     "stackSize": 64
   },
   {
-    "id": 74,
-    "displayName": "Glowing Redstone Ore",
-    "name": "lit_redstone_ore",
-    "stackSize": 64
-  },
-  {
-    "id": 75,
-    "displayName": "Redstone Torch (inactive)",
-    "name": "unlit_redstone_torch",
-    "stackSize": 64
-  },
-  {
     "id": 76,
-    "displayName": "Redstone Torch (active)",
+    "displayName": "Redstone Torch",
     "name": "redstone_torch",
     "stackSize": 64
   },
@@ -445,7 +355,7 @@
   },
   {
     "id": 78,
-    "displayName": "Snow (layer)",
+    "displayName": "Snow",
     "name": "snow_layer",
     "stackSize": 64
   },
@@ -510,27 +420,9 @@
     "stackSize": 64
   },
   {
-    "id": 90,
-    "displayName": "Nether Portal",
-    "name": "portal",
-    "stackSize": 64
-  },
-  {
     "id": 91,
     "displayName": "Jack o'Lantern",
     "name": "lit_pumpkin",
-    "stackSize": 64
-  },
-  {
-    "id": 93,
-    "displayName": "Redstone Repeater (inactive)",
-    "name": "unpowered_repeater",
-    "stackSize": 64
-  },
-  {
-    "id": 94,
-    "displayName": "Redstone Repeater (active)",
-    "name": "powered_repeater",
     "stackSize": 64
   },
   {
@@ -541,7 +433,7 @@
   },
   {
     "id": 96,
-    "displayName": "Trapdoor",
+    "displayName": "Wooden Trapdoor",
     "name": "trapdoor",
     "stackSize": 64
   },
@@ -559,13 +451,13 @@
   },
   {
     "id": 99,
-    "displayName": "Brown Mushroom (block)",
+    "displayName": "Brown Mushroom Block",
     "name": "brown_mushroom_block",
     "stackSize": 64
   },
   {
     "id": 100,
-    "displayName": "Red Mushroom (block)",
+    "displayName": "Red Mushroom Block",
     "name": "red_mushroom_block",
     "stackSize": 64
   },
@@ -588,18 +480,6 @@
     "stackSize": 64
   },
   {
-    "id": 104,
-    "displayName": "Pumpkin Stem",
-    "name": "pumpkin_stem",
-    "stackSize": 64
-  },
-  {
-    "id": 105,
-    "displayName": "Melon Stem",
-    "name": "melon_stem",
-    "stackSize": 64
-  },
-  {
     "id": 106,
     "displayName": "Vines",
     "name": "vine",
@@ -607,7 +487,7 @@
   },
   {
     "id": 107,
-    "displayName": "Fence Gate",
+    "displayName": "Oak Fence Gate",
     "name": "fence_gate",
     "stackSize": 64
   },
@@ -660,12 +540,6 @@
     "stackSize": 64
   },
   {
-    "id": 119,
-    "displayName": "End Portal",
-    "name": "end_portal",
-    "stackSize": 64
-  },
-  {
     "id": 120,
     "displayName": "End Portal Frame",
     "name": "end_portal_frame",
@@ -685,32 +559,14 @@
   },
   {
     "id": 123,
-    "displayName": "Redstone Lamp (inactive)",
+    "displayName": "Redstone Lamp",
     "name": "redstone_lamp",
     "stackSize": 64
   },
   {
-    "id": 124,
-    "displayName": "Redstone Lamp (active)",
-    "name": "lit_redstone_lamp",
-    "stackSize": 64
-  },
-  {
-    "id": 125,
-    "displayName": "Double Wooden Slab",
-    "name": "double_wooden_slab",
-    "stackSize": 64
-  },
-  {
     "id": 126,
-    "displayName": "Wooden Slab",
+    "displayName": "Wood Slab",
     "name": "wooden_slab",
-    "stackSize": 64
-  },
-  {
-    "id": 127,
-    "displayName": "Cocoa",
-    "name": "cocoa",
     "stackSize": 64
   },
   {
@@ -735,12 +591,6 @@
     "id": 131,
     "displayName": "Tripwire Hook",
     "name": "tripwire_hook",
-    "stackSize": 64
-  },
-  {
-    "id": 132,
-    "displayName": "Tripwire",
-    "name": "tripwire",
     "stackSize": 64
   },
   {
@@ -786,18 +636,6 @@
     "stackSize": 64
   },
   {
-    "id": 141,
-    "displayName": "Carrot",
-    "name": "carrots",
-    "stackSize": 64
-  },
-  {
-    "id": 142,
-    "displayName": "Potato",
-    "name": "potatoes",
-    "stackSize": 64
-  },
-  {
     "id": 143,
     "displayName": "Wooden Button",
     "name": "wooden_button",
@@ -828,20 +666,8 @@
     "stackSize": 64
   },
   {
-    "id": 149,
-    "displayName": "Redstone Comparator",
-    "name": "unpowered_comparator",
-    "stackSize": 64
-  },
-  {
-    "id": 150,
-    "displayName": "Redstone Comparator (deprecated)",
-    "name": "powered_comparator",
-    "stackSize": 64
-  },
-  {
     "id": 151,
-    "displayName": "Daylight Sensor",
+    "displayName": "Daylight Detector",
     "name": "daylight_detector",
     "stackSize": 64
   },
@@ -853,7 +679,7 @@
   },
   {
     "id": 153,
-    "displayName": "Nether Quartz Ore",
+    "displayName": "Nether Quartz",
     "name": "quartz_ore",
     "stackSize": 64
   },
@@ -889,7 +715,7 @@
   },
   {
     "id": 159,
-    "displayName": "Stained Clay",
+    "displayName": "Stained Terracotta",
     "name": "stained_hardened_clay",
     "stackSize": 64
   },
@@ -901,13 +727,13 @@
   },
   {
     "id": 161,
-    "displayName": "Leaves (Acacia/Dark Oak)",
+    "displayName": "Leaves",
     "name": "leaves2",
     "stackSize": 64
   },
   {
     "id": 162,
-    "displayName": "Wood (Acacia/Dark Oak)",
+    "displayName": "Wood",
     "name": "log2",
     "stackSize": 64
   },
@@ -967,7 +793,7 @@
   },
   {
     "id": 172,
-    "displayName": "Hardened Clay",
+    "displayName": "Terracotta",
     "name": "hardened_clay",
     "stackSize": 64
   },
@@ -990,24 +816,6 @@
     "stackSize": 64
   },
   {
-    "id": 176,
-    "displayName": "Standing Banner",
-    "name": "standing_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 177,
-    "displayName": "Wall Banner",
-    "name": "wall_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 178,
-    "displayName": "Inverted Daylight Sensor",
-    "name": "daylight_detector_inverted",
-    "stackSize": 64
-  },
-  {
     "id": 179,
     "displayName": "Red Sandstone",
     "name": "red_sandstone",
@@ -1017,12 +825,6 @@
     "id": 180,
     "displayName": "Red Sandstone Stairs",
     "name": "red_sandstone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 181,
-    "displayName": "Double Red Sandstone Slab",
-    "name": "double_stone_slab2",
     "stackSize": 64
   },
   {
@@ -1128,12 +930,6 @@
     "stackSize": 64
   },
   {
-    "id": 204,
-    "displayName": "Purpur Double Slab",
-    "name": "purpur_double_slab",
-    "stackSize": 64
-  },
-  {
     "id": 205,
     "displayName": "Purpur Slab",
     "name": "purpur_slab",
@@ -1146,21 +942,9 @@
     "stackSize": 64
   },
   {
-    "id": 207,
-    "displayName": "Beetroot Seeds",
-    "name": "beetroots",
-    "stackSize": 64
-  },
-  {
     "id": 208,
     "displayName": "Grass Path",
     "name": "grass_path",
-    "stackSize": 64
-  },
-  {
-    "id": 209,
-    "displayName": "End Gateway",
-    "name": "end_gateway",
     "stackSize": 64
   },
   {
@@ -1173,12 +957,6 @@
     "id": 211,
     "displayName": "Chain Command Block",
     "name": "chain_command_block",
-    "stackSize": 64
-  },
-  {
-    "id": 212,
-    "displayName": "Frosted Ice",
-    "name": "frosted_ice",
     "stackSize": 64
   },
   {
@@ -1268,7 +1046,7 @@
   {
     "id": 227,
     "displayName": "Light Gray Shulker Box",
-    "name": "light_gray_shulker_box",
+    "name": "silver_shulker_box",
     "stackSize": 64
   },
   {
@@ -1363,8 +1141,8 @@
   },
   {
     "id": 243,
-    "displayName": "Light Gray Glazed Terracotta",
-    "name": "light_gray_glazed_terracotta",
+    "displayName": "Silver Glazed Terracotta",
+    "name": "silver_glazed_terracotta",
     "stackSize": 64
   },
   {
@@ -1430,8 +1208,9 @@
   {
     "id": 256,
     "displayName": "Iron Shovel",
-    "stackSize": 1,
     "name": "iron_shovel",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1439,14 +1218,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 257,
     "displayName": "Iron Pickaxe",
-    "stackSize": 1,
     "name": "iron_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1454,14 +1233,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 258,
     "displayName": "Iron Axe",
-    "stackSize": 1,
     "name": "iron_axe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1469,49 +1248,48 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 259,
     "displayName": "Flint and Steel",
-    "stackSize": 1,
     "name": "flint_and_steel",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 260,
     "displayName": "Apple",
-    "stackSize": 64,
-    "name": "apple"
+    "name": "apple",
+    "stackSize": 64
   },
   {
     "id": 261,
     "displayName": "Bow",
-    "stackSize": 1,
     "name": "bow",
+    "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 262,
     "displayName": "Arrow",
-    "stackSize": 64,
-    "name": "arrow"
+    "name": "arrow",
+    "stackSize": 64
   },
   {
     "id": 263,
     "displayName": "Coal",
-    "stackSize": 64,
     "name": "coal",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -1526,26 +1304,27 @@
   {
     "id": 264,
     "displayName": "Diamond",
-    "stackSize": 64,
-    "name": "diamond"
+    "name": "diamond",
+    "stackSize": 64
   },
   {
     "id": 265,
     "displayName": "Iron Ingot",
-    "stackSize": 64,
-    "name": "iron_ingot"
+    "name": "iron_ingot",
+    "stackSize": 64
   },
   {
     "id": 266,
     "displayName": "Gold Ingot",
-    "stackSize": 64,
-    "name": "gold_ingot"
+    "name": "gold_ingot",
+    "stackSize": 64
   },
   {
     "id": 267,
     "displayName": "Iron Sword",
-    "stackSize": 1,
     "name": "iron_sword",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1553,14 +1332,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 268,
     "displayName": "Wooden Sword",
-    "stackSize": 1,
     "name": "wooden_sword",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1575,14 +1354,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 269,
     "displayName": "Wooden Shovel",
-    "stackSize": 1,
     "name": "wooden_shovel",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1597,14 +1376,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 270,
     "displayName": "Wooden Pickaxe",
-    "stackSize": 1,
     "name": "wooden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1619,14 +1398,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 271,
     "displayName": "Wooden Axe",
-    "stackSize": 1,
     "name": "wooden_axe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1641,14 +1420,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 272,
     "displayName": "Stone Sword",
-    "stackSize": 1,
     "name": "stone_sword",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1657,14 +1436,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 273,
     "displayName": "Stone Shovel",
-    "stackSize": 1,
     "name": "stone_shovel",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1673,14 +1452,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 274,
     "displayName": "Stone Pickaxe",
-    "stackSize": 1,
     "name": "stone_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1689,14 +1468,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 275,
     "displayName": "Stone Axe",
-    "stackSize": 1,
     "name": "stone_axe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1705,14 +1484,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 276,
     "displayName": "Diamond Sword",
-    "stackSize": 1,
     "name": "diamond_sword",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1720,14 +1499,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 277,
     "displayName": "Diamond Shovel",
-    "stackSize": 1,
     "name": "diamond_shovel",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1735,14 +1514,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 278,
     "displayName": "Diamond Pickaxe",
-    "stackSize": 1,
     "name": "diamond_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1750,14 +1529,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 279,
     "displayName": "Diamond Axe",
-    "stackSize": 1,
     "name": "diamond_axe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1765,32 +1544,32 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 280,
     "displayName": "Stick",
-    "stackSize": 64,
-    "name": "stick"
+    "name": "stick",
+    "stackSize": 64
   },
   {
     "id": 281,
     "displayName": "Bowl",
-    "stackSize": 64,
-    "name": "bowl"
+    "name": "bowl",
+    "stackSize": 64
   },
   {
     "id": 282,
     "displayName": "Mushroom Stew",
-    "stackSize": 1,
-    "name": "mushroom_stew"
+    "name": "mushroom_stew",
+    "stackSize": 1
   },
   {
     "id": 283,
     "displayName": "Golden Sword",
-    "stackSize": 1,
     "name": "golden_sword",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1798,14 +1577,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 284,
     "displayName": "Golden Shovel",
-    "stackSize": 1,
     "name": "golden_shovel",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1813,14 +1592,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 285,
     "displayName": "Golden Pickaxe",
-    "stackSize": 1,
     "name": "golden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1828,14 +1607,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 286,
     "displayName": "Golden Axe",
-    "stackSize": 1,
     "name": "golden_axe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1843,32 +1622,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 287,
     "displayName": "String",
-    "stackSize": 64,
-    "name": "string"
+    "name": "string",
+    "stackSize": 64
   },
   {
     "id": 288,
     "displayName": "Feather",
-    "stackSize": 64,
-    "name": "feather"
+    "name": "feather",
+    "stackSize": 64
   },
   {
     "id": 289,
     "displayName": "Gunpowder",
-    "stackSize": 64,
-    "name": "gunpowder"
+    "name": "gunpowder",
+    "stackSize": 64
   },
   {
     "id": 290,
     "displayName": "Wooden Hoe",
-    "stackSize": 1,
     "name": "wooden_hoe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1883,14 +1662,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 291,
     "displayName": "Stone Hoe",
-    "stackSize": 1,
     "name": "stone_hoe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1899,14 +1678,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 292,
     "displayName": "Iron Hoe",
-    "stackSize": 1,
     "name": "iron_hoe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1914,14 +1693,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 293,
     "displayName": "Diamond Hoe",
-    "stackSize": 1,
     "name": "diamond_hoe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1929,14 +1708,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 294,
     "displayName": "Golden Hoe",
-    "stackSize": 1,
     "name": "golden_hoe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1944,32 +1723,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 295,
     "displayName": "Seeds",
-    "stackSize": 64,
-    "name": "wheat_seeds"
+    "name": "wheat_seeds",
+    "stackSize": 64
   },
   {
     "id": 296,
     "displayName": "Wheat",
-    "stackSize": 64,
-    "name": "wheat"
+    "name": "wheat",
+    "stackSize": 64
   },
   {
     "id": 297,
     "displayName": "Bread",
-    "stackSize": 64,
-    "name": "bread"
+    "name": "bread",
+    "stackSize": 64
   },
   {
     "id": 298,
     "displayName": "Leather Cap",
-    "stackSize": 1,
     "name": "leather_helmet",
+    "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1979,14 +1758,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 299,
     "displayName": "Leather Tunic",
-    "stackSize": 1,
     "name": "leather_chestplate",
+    "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1996,14 +1775,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 300,
     "displayName": "Leather Pants",
-    "stackSize": 1,
     "name": "leather_leggings",
+    "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2012,14 +1791,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 301,
     "displayName": "Leather Boots",
-    "stackSize": 1,
     "name": "leather_boots",
+    "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2029,14 +1808,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 302,
     "displayName": "Chain Helmet",
-    "stackSize": 1,
     "name": "chainmail_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2046,14 +1825,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 303,
     "displayName": "Chain Chestplate",
-    "stackSize": 1,
     "name": "chainmail_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2063,14 +1842,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 304,
     "displayName": "Chain Leggings",
-    "stackSize": 1,
     "name": "chainmail_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2079,14 +1858,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 305,
     "displayName": "Chain Boots",
-    "stackSize": 1,
     "name": "chainmail_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2096,14 +1875,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 306,
     "displayName": "Iron Helmet",
-    "stackSize": 1,
     "name": "iron_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2113,14 +1892,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 307,
     "displayName": "Iron Chestplate",
-    "stackSize": 1,
     "name": "iron_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2130,14 +1909,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 308,
     "displayName": "Iron Leggings",
-    "stackSize": 1,
     "name": "iron_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2146,14 +1925,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 309,
     "displayName": "Iron Boots",
-    "stackSize": 1,
     "name": "iron_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2163,14 +1942,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 310,
     "displayName": "Diamond Helmet",
-    "stackSize": 1,
     "name": "diamond_helmet",
+    "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2180,14 +1959,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 311,
     "displayName": "Diamond Chestplate",
-    "stackSize": 1,
     "name": "diamond_chestplate",
+    "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2197,14 +1976,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 312,
     "displayName": "Diamond Leggings",
-    "stackSize": 1,
     "name": "diamond_leggings",
+    "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2213,14 +1992,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 313,
     "displayName": "Diamond Boots",
-    "stackSize": 1,
     "name": "diamond_boots",
+    "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2230,14 +2009,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 314,
     "displayName": "Golden Helmet",
-    "stackSize": 1,
     "name": "golden_helmet",
+    "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2247,14 +2026,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 315,
     "displayName": "Golden Chestplate",
-    "stackSize": 1,
     "name": "golden_chestplate",
+    "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2264,14 +2043,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 316,
     "displayName": "Golden Leggings",
-    "stackSize": 1,
     "name": "golden_leggings",
+    "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2280,14 +2059,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 317,
     "displayName": "Golden Boots",
-    "stackSize": 1,
     "name": "golden_boots",
+    "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2297,38 +2076,37 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 318,
     "displayName": "Flint",
-    "stackSize": 64,
-    "name": "flint"
+    "name": "flint",
+    "stackSize": 64
   },
   {
     "id": 319,
     "displayName": "Raw Porkchop",
-    "stackSize": 64,
-    "name": "porkchop"
+    "name": "porkchop",
+    "stackSize": 64
   },
   {
     "id": 320,
     "displayName": "Cooked Porkchop",
-    "stackSize": 64,
-    "name": "cooked_porkchop"
+    "name": "cooked_porkchop",
+    "stackSize": 64
   },
   {
     "id": 321,
     "displayName": "Painting",
-    "stackSize": 64,
-    "name": "painting"
+    "name": "painting",
+    "stackSize": 64
   },
   {
     "id": 322,
     "displayName": "Golden Apple",
-    "stackSize": 64,
     "name": "golden_apple",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2343,170 +2121,170 @@
   {
     "id": 323,
     "displayName": "Sign",
-    "stackSize": 16,
-    "name": "sign"
+    "name": "sign",
+    "stackSize": 16
   },
   {
     "id": 324,
     "displayName": "Oak Door",
-    "stackSize": 64,
-    "name": "wooden_door"
+    "name": "wooden_door",
+    "stackSize": 64
   },
   {
     "id": 325,
     "displayName": "Bucket",
-    "stackSize": 16,
-    "name": "bucket"
+    "name": "bucket",
+    "stackSize": 16
   },
   {
     "id": 326,
     "displayName": "Water Bucket",
-    "stackSize": 1,
-    "name": "water_bucket"
+    "name": "water_bucket",
+    "stackSize": 1
   },
   {
     "id": 327,
     "displayName": "Lava Bucket",
-    "stackSize": 1,
-    "name": "lava_bucket"
+    "name": "lava_bucket",
+    "stackSize": 1
   },
   {
     "id": 328,
     "displayName": "Minecart",
-    "stackSize": 1,
-    "name": "minecart"
+    "name": "minecart",
+    "stackSize": 1
   },
   {
     "id": 329,
     "displayName": "Saddle",
-    "stackSize": 1,
-    "name": "saddle"
+    "name": "saddle",
+    "stackSize": 1
   },
   {
     "id": 330,
     "displayName": "Iron Door",
-    "stackSize": 64,
-    "name": "iron_door"
+    "name": "iron_door",
+    "stackSize": 64
   },
   {
     "id": 331,
     "displayName": "Redstone",
-    "stackSize": 64,
-    "name": "redstone"
+    "name": "redstone",
+    "stackSize": 64
   },
   {
     "id": 332,
     "displayName": "Snowball",
-    "stackSize": 16,
-    "name": "snowball"
+    "name": "snowball",
+    "stackSize": 16
   },
   {
     "id": 333,
     "displayName": "Boat",
-    "stackSize": 1,
-    "name": "boat"
+    "name": "boat",
+    "stackSize": 1
   },
   {
     "id": 334,
     "displayName": "Leather",
-    "stackSize": 64,
-    "name": "leather"
+    "name": "leather",
+    "stackSize": 64
   },
   {
     "id": 335,
     "displayName": "Milk",
-    "stackSize": 1,
-    "name": "milk_bucket"
+    "name": "milk_bucket",
+    "stackSize": 1
   },
   {
     "id": 336,
     "displayName": "Brick",
-    "stackSize": 64,
-    "name": "brick"
+    "name": "brick",
+    "stackSize": 64
   },
   {
     "id": 337,
     "displayName": "Clay",
-    "stackSize": 64,
-    "name": "clay_ball"
+    "name": "clay_ball",
+    "stackSize": 64
   },
   {
     "id": 338,
-    "displayName": "Sugar Cane",
-    "stackSize": 64,
-    "name": "reeds"
+    "displayName": "Sugar Canes",
+    "name": "reeds",
+    "stackSize": 64
   },
   {
     "id": 339,
     "displayName": "Paper",
-    "stackSize": 64,
-    "name": "paper"
+    "name": "paper",
+    "stackSize": 64
   },
   {
     "id": 340,
     "displayName": "Book",
-    "stackSize": 64,
-    "name": "book"
+    "name": "book",
+    "stackSize": 64
   },
   {
     "id": 341,
     "displayName": "Slimeball",
-    "stackSize": 64,
-    "name": "slime_ball"
+    "name": "slime_ball",
+    "stackSize": 64
   },
   {
     "id": 342,
     "displayName": "Minecart with Chest",
-    "stackSize": 1,
-    "name": "chest_minecart"
+    "name": "chest_minecart",
+    "stackSize": 1
   },
   {
     "id": 343,
     "displayName": "Minecart with Furnace",
-    "stackSize": 1,
-    "name": "furnace_minecart"
+    "name": "furnace_minecart",
+    "stackSize": 1
   },
   {
     "id": 344,
     "displayName": "Egg",
-    "stackSize": 16,
-    "name": "egg"
+    "name": "egg",
+    "stackSize": 16
   },
   {
     "id": 345,
     "displayName": "Compass",
-    "stackSize": 64,
-    "name": "compass"
+    "name": "compass",
+    "stackSize": 64
   },
   {
     "id": 346,
     "displayName": "Fishing Rod",
-    "stackSize": 1,
     "name": "fishing_rod",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 347,
     "displayName": "Clock",
-    "stackSize": 64,
-    "name": "clock"
+    "name": "clock",
+    "stackSize": 64
   },
   {
     "id": 348,
     "displayName": "Glowstone Dust",
-    "stackSize": 64,
-    "name": "glowstone_dust"
+    "name": "glowstone_dust",
+    "stackSize": 64
   },
   {
     "id": 349,
-    "displayName": "Raw Fish",
-    "stackSize": 64,
+    "displayName": "Fish",
     "name": "fish",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2523,54 +2301,20 @@
       {
         "metadata": 3,
         "displayName": "Pufferfish"
-      },
-      {
-        "metadata": 4,
-        "displayName": "Cooked Fish"
-      },
-      {
-        "metadata": 5,
-        "displayName": "Cooked Salmon"
       }
     ]
   },
   {
     "id": 350,
     "displayName": "Cooked Fish",
-    "stackSize": 64,
     "name": "cooked_fish",
-    "variations": [
-      {
-        "metadata": 0,
-        "displayName": "Raw Fish"
-      },
-      {
-        "metadata": 1,
-        "displayName": "Raw Salmon"
-      },
-      {
-        "metadata": 2,
-        "displayName": "Clownfish"
-      },
-      {
-        "metadata": 3,
-        "displayName": "Pufferfish"
-      },
-      {
-        "metadata": 4,
-        "displayName": "Cooked Fish"
-      },
-      {
-        "metadata": 5,
-        "displayName": "Cooked Salmon"
-      }
-    ]
+    "stackSize": 64
   },
   {
     "id": 351,
     "displayName": "Dye",
-    "stackSize": 64,
     "name": "dye",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2641,283 +2385,341 @@
   {
     "id": 352,
     "displayName": "Bone",
-    "stackSize": 64,
-    "name": "bone"
+    "name": "bone",
+    "stackSize": 64
   },
   {
     "id": 353,
     "displayName": "Sugar",
-    "stackSize": 64,
-    "name": "sugar"
+    "name": "sugar",
+    "stackSize": 64
   },
   {
     "id": 354,
     "displayName": "Cake",
-    "stackSize": 1,
-    "name": "cake"
+    "name": "cake",
+    "stackSize": 1
   },
   {
     "id": 355,
     "displayName": "Bed",
-    "stackSize": 1,
-    "name": "bed"
+    "name": "bed",
+    "stackSize": 1
   },
   {
     "id": 356,
     "displayName": "Redstone Repeater",
-    "stackSize": 64,
-    "name": "repeater"
+    "name": "repeater",
+    "stackSize": 64
   },
   {
     "id": 357,
     "displayName": "Cookie",
-    "stackSize": 64,
-    "name": "cookie"
+    "name": "cookie",
+    "stackSize": 64
   },
   {
     "id": 358,
     "displayName": "Map",
-    "stackSize": 64,
-    "name": "filled_map"
+    "name": "filled_map",
+    "stackSize": 64
   },
   {
     "id": 359,
     "displayName": "Shears",
-    "stackSize": 1,
     "name": "shears",
+    "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 360,
     "displayName": "Melon",
-    "stackSize": 64,
-    "name": "melon"
+    "name": "melon",
+    "stackSize": 64
   },
   {
     "id": 361,
     "displayName": "Pumpkin Seeds",
-    "stackSize": 64,
-    "name": "pumpkin_seeds"
+    "name": "pumpkin_seeds",
+    "stackSize": 64
   },
   {
     "id": 362,
     "displayName": "Melon Seeds",
-    "stackSize": 64,
-    "name": "melon_seeds"
+    "name": "melon_seeds",
+    "stackSize": 64
   },
   {
     "id": 363,
     "displayName": "Raw Beef",
-    "stackSize": 64,
-    "name": "beef"
+    "name": "beef",
+    "stackSize": 64
   },
   {
     "id": 364,
     "displayName": "Steak",
-    "stackSize": 64,
-    "name": "cooked_beef"
+    "name": "cooked_beef",
+    "stackSize": 64
   },
   {
     "id": 365,
     "displayName": "Raw Chicken",
-    "stackSize": 64,
-    "name": "chicken"
+    "name": "chicken",
+    "stackSize": 64
   },
   {
     "id": 366,
     "displayName": "Cooked Chicken",
-    "stackSize": 64,
-    "name": "cooked_chicken"
+    "name": "cooked_chicken",
+    "stackSize": 64
   },
   {
     "id": 367,
     "displayName": "Rotten Flesh",
-    "stackSize": 64,
-    "name": "rotten_flesh"
+    "name": "rotten_flesh",
+    "stackSize": 64
   },
   {
     "id": 368,
     "displayName": "Ender Pearl",
-    "stackSize": 16,
-    "name": "ender_pearl"
+    "name": "ender_pearl",
+    "stackSize": 64
   },
   {
     "id": 369,
     "displayName": "Blaze Rod",
-    "stackSize": 64,
-    "name": "blaze_rod"
+    "name": "blaze_rod",
+    "stackSize": 64
   },
   {
     "id": 370,
     "displayName": "Ghast Tear",
-    "stackSize": 64,
-    "name": "ghast_tear"
+    "name": "ghast_tear",
+    "stackSize": 64
   },
   {
     "id": 371,
     "displayName": "Gold Nugget",
-    "stackSize": 64,
-    "name": "gold_nugget"
+    "name": "gold_nugget",
+    "stackSize": 64
   },
   {
     "id": 372,
     "displayName": "Nether Wart",
-    "stackSize": 64,
-    "name": "nether_wart"
+    "name": "nether_wart",
+    "stackSize": 64
   },
   {
     "id": 373,
     "displayName": "Potion",
-    "stackSize": 1,
-    "name": "potion"
+    "name": "potion",
+    "stackSize": 1
   },
   {
     "id": 374,
     "displayName": "Glass Bottle",
-    "stackSize": 64,
-    "name": "glass_bottle"
+    "name": "glass_bottle",
+    "stackSize": 64
   },
   {
     "id": 375,
     "displayName": "Spider Eye",
-    "stackSize": 64,
-    "name": "spider_eye"
+    "name": "spider_eye",
+    "stackSize": 64
   },
   {
     "id": 376,
     "displayName": "Fermented Spider Eye",
-    "stackSize": 64,
-    "name": "fermented_spider_eye"
+    "name": "fermented_spider_eye",
+    "stackSize": 64
   },
   {
     "id": 377,
     "displayName": "Blaze Powder",
-    "stackSize": 64,
-    "name": "blaze_powder"
+    "name": "blaze_powder",
+    "stackSize": 64
   },
   {
     "id": 378,
     "displayName": "Magma Cream",
-    "stackSize": 64,
-    "name": "magma_cream"
+    "name": "magma_cream",
+    "stackSize": 64
   },
   {
     "id": 379,
     "displayName": "Brewing Stand",
-    "stackSize": 64,
-    "name": "brewing_stand"
+    "name": "brewing_stand",
+    "stackSize": 64
   },
   {
     "id": 380,
     "displayName": "Cauldron",
-    "stackSize": 64,
-    "name": "cauldron"
+    "name": "cauldron",
+    "stackSize": 64
   },
   {
     "id": 381,
     "displayName": "Eye of Ender",
-    "stackSize": 64,
-    "name": "ender_eye"
+    "name": "ender_eye",
+    "stackSize": 64
   },
   {
     "id": 382,
     "displayName": "Glistering Melon",
-    "stackSize": 64,
-    "name": "speckled_melon"
+    "name": "speckled_melon",
+    "stackSize": 64
   },
   {
     "id": 383,
     "displayName": "Spawn Egg",
-    "stackSize": 64,
-    "name": "spawn_egg"
+    "name": "spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 384,
     "displayName": "Bottle o' Enchanting",
-    "stackSize": 64,
-    "name": "experience_bottle"
+    "name": "experience_bottle",
+    "stackSize": 64
   },
   {
     "id": 385,
     "displayName": "Fire Charge",
-    "stackSize": 64,
-    "name": "fire_charge"
+    "name": "fire_charge",
+    "stackSize": 64
   },
   {
     "id": 386,
     "displayName": "Book and Quill",
-    "stackSize": 1,
-    "name": "writable_book"
+    "name": "writable_book",
+    "stackSize": 1
   },
   {
     "id": 387,
     "displayName": "Written Book",
-    "stackSize": 16,
-    "name": "written_book"
+    "name": "written_book",
+    "stackSize": 16
   },
   {
     "id": 388,
     "displayName": "Emerald",
-    "stackSize": 64,
-    "name": "emerald"
+    "name": "emerald",
+    "stackSize": 64
   },
   {
     "id": 389,
     "displayName": "Item Frame",
-    "stackSize": 64,
-    "name": "item_frame"
+    "name": "item_frame",
+    "stackSize": 64
   },
   {
     "id": 390,
     "displayName": "Flower Pot",
+    "name": "flower_pot",
     "stackSize": 64,
-    "name": "flower_pot"
+    "variations": [
+      {
+        "metadata": 0,
+        "displayName": "Empty Flower Pot"
+      },
+      {
+        "metadata": 1,
+        "displayName": "Poppy Flower Pot"
+      },
+      {
+        "metadata": 2,
+        "displayName": "Dandelion Flower Pot"
+      },
+      {
+        "metadata": 3,
+        "displayName": "Oak sapling Flower Pot"
+      },
+      {
+        "metadata": 4,
+        "displayName": "Spruce sapling Flower Pot"
+      },
+      {
+        "metadata": 5,
+        "displayName": "Birch sapling Flower Pot"
+      },
+      {
+        "metadata": 6,
+        "displayName": "Jungle sapling Flower Pot"
+      },
+      {
+        "metadata": 7,
+        "displayName": "Red mushroom Flower Pot"
+      },
+      {
+        "metadata": 8,
+        "displayName": "Brown mushroom Flower Pot"
+      },
+      {
+        "metadata": 9,
+        "displayName": "Cactus Flower Pot"
+      },
+      {
+        "metadata": 10,
+        "displayName": "Dead bush Flower Pot"
+      },
+      {
+        "metadata": 11,
+        "displayName": "Fern Flower Pot"
+      },
+      {
+        "metadata": 12,
+        "displayName": "Acacia sapling Flower Pot"
+      },
+      {
+        "metadata": 13,
+        "displayName": "Dark oak sapling Flower Pot"
+      }
+    ]
   },
   {
     "id": 391,
     "displayName": "Carrot",
-    "stackSize": 64,
-    "name": "carrot"
+    "name": "carrot",
+    "stackSize": 64
   },
   {
     "id": 392,
     "displayName": "Potato",
-    "stackSize": 64,
-    "name": "potato"
+    "name": "potato",
+    "stackSize": 64
   },
   {
     "id": 393,
     "displayName": "Baked Potato",
-    "stackSize": 64,
-    "name": "baked_potato"
+    "name": "baked_potato",
+    "stackSize": 64
   },
   {
     "id": 394,
     "displayName": "Poisonous Potato",
-    "stackSize": 64,
-    "name": "poisonous_potato"
+    "name": "poisonous_potato",
+    "stackSize": 64
   },
   {
     "id": 395,
     "displayName": "Empty Map",
-    "stackSize": 64,
-    "name": "map"
+    "name": "map",
+    "stackSize": 64
   },
   {
     "id": 396,
     "displayName": "Golden Carrot",
-    "stackSize": 64,
-    "name": "golden_carrot"
+    "name": "golden_carrot",
+    "stackSize": 64
   },
   {
     "id": 397,
-    "displayName": "Mob head",
-    "stackSize": 64,
+    "displayName": "Skull",
     "name": "skull",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2944,277 +2746,278 @@
   {
     "id": 398,
     "displayName": "Carrot on a Stick",
-    "stackSize": 1,
     "name": "carrot_on_a_stick",
+    "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 399,
     "displayName": "Nether Star",
-    "stackSize": 64,
-    "name": "nether_star"
+    "name": "nether_star",
+    "stackSize": 64
   },
   {
     "id": 400,
     "displayName": "Pumpkin Pie",
-    "stackSize": 64,
-    "name": "pumpkin_pie"
+    "name": "pumpkin_pie",
+    "stackSize": 64
   },
   {
     "id": 401,
     "displayName": "Firework Rocket",
-    "stackSize": 64,
-    "name": "fireworks"
+    "name": "fireworks",
+    "stackSize": 64
   },
   {
     "id": 402,
     "displayName": "Firework Star",
-    "stackSize": 64,
-    "name": "firework_charge"
+    "name": "firework_charge",
+    "stackSize": 64
   },
   {
     "id": 403,
     "displayName": "Enchanted Book",
-    "stackSize": 1,
-    "name": "enchanted_book"
+    "name": "enchanted_book",
+    "stackSize": 1
   },
   {
     "id": 404,
     "displayName": "Redstone Comparator",
-    "stackSize": 64,
-    "name": "comparator"
+    "name": "comparator",
+    "stackSize": 64
   },
   {
     "id": 405,
     "displayName": "Nether Brick",
-    "stackSize": 64,
-    "name": "netherbrick"
+    "name": "netherbrick",
+    "stackSize": 64
   },
   {
     "id": 406,
     "displayName": "Nether Quartz",
-    "stackSize": 64,
-    "name": "quartz"
+    "name": "quartz",
+    "stackSize": 64
   },
   {
     "id": 407,
     "displayName": "Minecart with TNT",
-    "stackSize": 1,
-    "name": "tnt_minecart"
+    "name": "tnt_minecart",
+    "stackSize": 1
   },
   {
     "id": 408,
     "displayName": "Minecart with Hopper",
-    "stackSize": 1,
-    "name": "hopper_minecart"
+    "name": "hopper_minecart",
+    "stackSize": 1
   },
   {
     "id": 409,
     "displayName": "Prismarine Shard",
-    "stackSize": 64,
-    "name": "prismarine_shard"
+    "name": "prismarine_shard",
+    "stackSize": 64
   },
   {
     "id": 410,
     "displayName": "Prismarine Crystals",
-    "stackSize": 64,
-    "name": "prismarine_crystals"
+    "name": "prismarine_crystals",
+    "stackSize": 64
   },
   {
     "id": 411,
     "displayName": "Raw Rabbit",
-    "stackSize": 64,
-    "name": "rabbit"
+    "name": "rabbit",
+    "stackSize": 64
   },
   {
     "id": 412,
     "displayName": "Cooked Rabbit",
-    "stackSize": 64,
-    "name": "cooked_rabbit"
+    "name": "cooked_rabbit",
+    "stackSize": 64
   },
   {
     "id": 413,
     "displayName": "Rabbit Stew",
-    "stackSize": 1,
-    "name": "rabbit_stew"
+    "name": "rabbit_stew",
+    "stackSize": 1
   },
   {
     "id": 414,
     "displayName": "Rabbit's Foot",
-    "stackSize": 64,
-    "name": "rabbit_foot"
+    "name": "rabbit_foot",
+    "stackSize": 64
   },
   {
     "id": 415,
     "displayName": "Rabbit Hide",
-    "stackSize": 64,
-    "name": "rabbit_hide"
+    "name": "rabbit_hide",
+    "stackSize": 64
   },
   {
     "id": 416,
     "displayName": "Armor Stand",
-    "stackSize": 16,
-    "name": "armor_stand"
+    "name": "armor_stand",
+    "stackSize": 16
   },
   {
     "id": 417,
     "displayName": "Iron Horse Armor",
-    "stackSize": 1,
-    "name": "iron_horse_armor"
+    "name": "iron_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 418,
-    "displayName": "Golden Horse Armor",
-    "stackSize": 1,
-    "name": "golden_horse_armor"
+    "displayName": "Gold Horse Armor",
+    "name": "golden_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 419,
     "displayName": "Diamond Horse Armor",
-    "stackSize": 1,
-    "name": "diamond_horse_armor"
+    "name": "diamond_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 420,
     "displayName": "Lead",
-    "stackSize": 64,
-    "name": "lead"
+    "name": "lead",
+    "stackSize": 64
   },
   {
     "id": 421,
     "displayName": "Name Tag",
-    "stackSize": 64,
-    "name": "name_tag"
+    "name": "name_tag",
+    "stackSize": 64
   },
   {
     "id": 422,
     "displayName": "Minecart with Command Block",
-    "stackSize": 1,
-    "name": "command_block_minecart"
+    "name": "command_block_minecart",
+    "stackSize": 1
   },
   {
     "id": 423,
     "displayName": "Raw Mutton",
-    "stackSize": 64,
-    "name": "mutton"
+    "name": "mutton",
+    "stackSize": 64
   },
   {
     "id": 424,
     "displayName": "Cooked Mutton",
-    "stackSize": 64,
-    "name": "cooked_mutton"
+    "name": "cooked_mutton",
+    "stackSize": 64
   },
   {
     "id": 425,
     "displayName": "Banner",
-    "stackSize": 16,
-    "name": "banner"
+    "name": "banner",
+    "stackSize": 16
   },
   {
     "id": 426,
     "displayName": "End Crystal",
-    "stackSize": 64,
-    "name": "end_crystal"
+    "name": "end_crystal",
+    "stackSize": 64
   },
   {
     "id": 427,
     "displayName": "Spruce Door",
-    "stackSize": 64,
-    "name": "spruce_door"
+    "name": "spruce_door",
+    "stackSize": 64
   },
   {
     "id": 428,
     "displayName": "Birch Door",
-    "stackSize": 64,
-    "name": "birch_door"
+    "name": "birch_door",
+    "stackSize": 64
   },
   {
     "id": 429,
     "displayName": "Jungle Door",
-    "stackSize": 64,
-    "name": "jungle_door"
+    "name": "jungle_door",
+    "stackSize": 64
   },
   {
     "id": 430,
     "displayName": "Acacia Door",
-    "stackSize": 64,
-    "name": "acacia_door"
+    "name": "acacia_door",
+    "stackSize": 64
   },
   {
     "id": 431,
     "displayName": "Dark Oak Door",
-    "stackSize": 64,
-    "name": "dark_oak_door"
+    "name": "dark_oak_door",
+    "stackSize": 64
   },
   {
     "id": 432,
     "displayName": "Chorus Fruit",
-    "stackSize": 64,
-    "name": "chorus_fruit"
+    "name": "chorus_fruit",
+    "stackSize": 64
   },
   {
     "id": 433,
     "displayName": "Popped Chorus Fruit",
-    "stackSize": 64,
-    "name": "chorus_fruit_popped"
+    "name": "chorus_fruit_popped",
+    "stackSize": 64
   },
   {
     "id": 434,
     "displayName": "Beetroot",
-    "stackSize": 64,
-    "name": "beetroot"
+    "name": "beetroot",
+    "stackSize": 64
   },
   {
     "id": 435,
     "displayName": "Beetroot Seeds",
-    "stackSize": 64,
-    "name": "beetroot_seeds"
+    "name": "beetroot_seeds",
+    "stackSize": 64
   },
   {
     "id": 436,
     "displayName": "Beetroot Soup",
-    "stackSize": 1,
-    "name": "beetroot_soup"
+    "name": "beetroot_soup",
+    "stackSize": 1
   },
   {
     "id": 437,
     "displayName": "Dragon's Breath",
-    "stackSize": 64,
-    "name": "dragon_breath"
+    "name": "dragon_breath",
+    "stackSize": 64
   },
   {
     "id": 438,
     "displayName": "Splash Potion",
-    "stackSize": 1,
-    "name": "splash_potion"
+    "name": "splash_potion",
+    "stackSize": 1
   },
   {
     "id": 439,
     "displayName": "Spectral Arrow",
-    "stackSize": 64,
-    "name": "spectral_arrow"
+    "name": "spectral_arrow",
+    "stackSize": 64
   },
   {
     "id": 440,
     "displayName": "Tipped Arrow",
-    "stackSize": 64,
-    "name": "tipped_arrow"
+    "name": "tipped_arrow",
+    "stackSize": 64
   },
   {
     "id": 441,
     "displayName": "Lingering Potion",
-    "stackSize": 1,
-    "name": "lingering_potion"
+    "name": "lingering_potion",
+    "stackSize": 1
   },
   {
     "id": 442,
     "displayName": "Shield",
-    "stackSize": 1,
     "name": "shield",
+    "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3228,14 +3031,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 443,
     "displayName": "Elytra",
-    "stackSize": 1,
     "name": "elytra",
+    "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -3243,127 +3046,132 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 444,
     "displayName": "Spruce Boat",
-    "stackSize": 1,
-    "name": "spruce_boat"
+    "name": "spruce_boat",
+    "stackSize": 1
   },
   {
     "id": 445,
     "displayName": "Birch Boat",
-    "stackSize": 1,
-    "name": "birch_boat"
+    "name": "birch_boat",
+    "stackSize": 1
   },
   {
     "id": 446,
     "displayName": "Jungle Boat",
-    "stackSize": 1,
-    "name": "jungle_boat"
+    "name": "jungle_boat",
+    "stackSize": 1
   },
   {
     "id": 447,
     "displayName": "Acacia Boat",
-    "stackSize": 1,
-    "name": "acacia_boat"
+    "name": "acacia_boat",
+    "stackSize": 1
   },
   {
     "id": 448,
     "displayName": "Dark Oak Boat",
-    "stackSize": 1,
-    "name": "dark_oak_boat"
+    "name": "dark_oak_boat",
+    "stackSize": 1
   },
   {
     "id": 449,
     "displayName": "Totem of Undying",
-    "stackSize": 1,
-    "name": "totem_of_undying"
+    "name": "totem_of_undying",
+    "stackSize": 1
   },
   {
     "id": 450,
     "displayName": "Shulker Shell",
-    "stackSize": 64,
-    "name": "shulker_shell"
+    "name": "shulker_shell",
+    "stackSize": 64
   },
   {
     "id": 452,
     "displayName": "Iron Nugget",
-    "stackSize": 64,
-    "name": "iron_nugget"
+    "name": "iron_nugget",
+    "stackSize": 64
+  },
+  {
+    "id": 453,
+    "displayName": "Knowledge Book",
+    "name": "knowledge_book",
+    "stackSize": 64
   },
   {
     "id": 2256,
     "displayName": "13 Disc",
-    "stackSize": 1,
-    "name": "record_13"
+    "name": "record_13",
+    "stackSize": 64
   },
   {
     "id": 2257,
     "displayName": "Cat Disc",
-    "stackSize": 1,
-    "name": "record_cat"
+    "name": "record_cat",
+    "stackSize": 1
   },
   {
     "id": 2258,
     "displayName": "Blocks Disc",
-    "stackSize": 1,
-    "name": "record_blocks"
+    "name": "record_blocks",
+    "stackSize": 1
   },
   {
     "id": 2259,
     "displayName": "Chirp Disc",
-    "stackSize": 1,
-    "name": "record_chirp"
+    "name": "record_chirp",
+    "stackSize": 1
   },
   {
     "id": 2260,
     "displayName": "Far Disc",
-    "stackSize": 1,
-    "name": "record_far"
+    "name": "record_far",
+    "stackSize": 1
   },
   {
     "id": 2261,
     "displayName": "Mall Disc",
-    "stackSize": 1,
-    "name": "record_mall"
+    "name": "record_mall",
+    "stackSize": 1
   },
   {
     "id": 2262,
     "displayName": "Mellohi Disc",
-    "stackSize": 1,
-    "name": "record_mellohi"
+    "name": "record_mellohi",
+    "stackSize": 1
   },
   {
     "id": 2263,
     "displayName": "Stal Disc",
-    "stackSize": 1,
-    "name": "record_stal"
+    "name": "record_stal",
+    "stackSize": 1
   },
   {
     "id": 2264,
     "displayName": "Strad Disc",
-    "stackSize": 1,
-    "name": "record_strad"
+    "name": "record_strad",
+    "stackSize": 1
   },
   {
     "id": 2265,
     "displayName": "Ward Disc",
-    "stackSize": 1,
-    "name": "record_ward"
+    "name": "record_ward",
+    "stackSize": 1
   },
   {
     "id": 2266,
     "displayName": "11 Disc",
-    "stackSize": 1,
-    "name": "record_11"
+    "name": "record_11",
+    "stackSize": 1
   },
   {
     "id": 2267,
     "displayName": "Wait Disc",
-    "stackSize": 1,
-    "name": "record_wait"
+    "name": "record_wait",
+    "stackSize": 1
   }
 ]

--- a/data/pc/1.13.2/items.json
+++ b/data/pc/1.13.2/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 64
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -2828,6 +2822,7 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
+    "maxDurability": 275,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2837,8 +2832,7 @@
     ],
     "repairWith": [
       "scute"
-    ],
-    "maxDurability": 275
+    ]
   },
   {
     "id": 471,
@@ -2850,7 +2844,8 @@
     "id": 472,
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2858,14 +2853,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 473,
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2873,14 +2868,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 474,
     "displayName": "Iron Axe",
     "name": "iron_axe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2888,19 +2883,18 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 475,
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 476,
@@ -2912,13 +2906,13 @@
     "id": 477,
     "displayName": "Bow",
     "name": "bow",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 478,
@@ -2960,7 +2954,8 @@
     "id": 484,
     "displayName": "Iron Sword",
     "name": "iron_sword",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -2968,14 +2963,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 485,
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -2990,14 +2985,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 486,
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3012,14 +3007,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 487,
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3034,14 +3029,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 488,
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3056,14 +3051,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 489,
     "displayName": "Stone Sword",
     "name": "stone_sword",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3072,14 +3067,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 490,
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3088,14 +3083,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 491,
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3104,14 +3099,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 492,
     "displayName": "Stone Axe",
     "name": "stone_axe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3120,14 +3115,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 493,
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3135,14 +3130,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 494,
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3150,14 +3145,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 495,
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3165,14 +3160,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 496,
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3180,8 +3175,7 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 497,
@@ -3205,7 +3199,8 @@
     "id": 500,
     "displayName": "Golden Sword",
     "name": "golden_sword",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3213,14 +3208,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 501,
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3228,14 +3223,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 502,
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3243,14 +3238,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 503,
     "displayName": "Golden Axe",
     "name": "golden_axe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3258,8 +3253,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 504,
@@ -3283,7 +3277,8 @@
     "id": 507,
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3298,14 +3293,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 508,
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3314,14 +3309,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 509,
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3329,14 +3324,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 510,
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3344,14 +3339,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 511,
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3359,8 +3354,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 512,
@@ -3385,6 +3379,7 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3394,14 +3389,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 516,
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3411,14 +3406,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 517,
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3427,14 +3422,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 518,
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3444,14 +3439,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 519,
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3461,14 +3456,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 520,
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3478,14 +3473,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 521,
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3494,14 +3489,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 522,
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3511,14 +3506,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 523,
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3528,14 +3523,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 524,
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3545,14 +3540,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 525,
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3561,14 +3556,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 526,
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3578,14 +3573,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 527,
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3595,14 +3590,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 528,
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3612,14 +3607,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 529,
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3628,14 +3623,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 530,
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3645,14 +3640,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 531,
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3662,14 +3657,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 532,
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3679,14 +3674,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 533,
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3695,14 +3690,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 534,
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3712,8 +3707,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 535,
@@ -3917,13 +3911,13 @@
     "id": 568,
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 569,
@@ -4199,12 +4193,12 @@
     "id": 614,
     "displayName": "Shears",
     "name": "shears",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 615,
@@ -4790,12 +4784,12 @@
     "id": 709,
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 710,
@@ -5113,7 +5107,8 @@
     "id": 762,
     "displayName": "Shield",
     "name": "shield",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5127,14 +5122,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 763,
     "displayName": "Elytra",
     "name": "elytra",
-    "stackSize": 64,
+    "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -5142,8 +5137,7 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 764,
@@ -5282,12 +5276,12 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "trident"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 787,

--- a/data/pc/1.13/items.json
+++ b/data/pc/1.13/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 0
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -2798,6 +2792,7 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
+    "maxDurability": 275,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2807,8 +2802,7 @@
     ],
     "repairWith": [
       "scute"
-    ],
-    "maxDurability": 275
+    ]
   },
   {
     "id": 466,
@@ -2821,6 +2815,7 @@
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2828,14 +2823,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 468,
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2843,14 +2838,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 469,
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2858,19 +2853,18 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 470,
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 471,
@@ -2883,12 +2877,12 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 473,
@@ -2931,6 +2925,7 @@
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -2938,14 +2933,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 480,
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -2960,14 +2955,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 481,
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -2982,14 +2977,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 482,
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3004,14 +2999,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 483,
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3026,14 +3021,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 484,
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3042,14 +3037,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 485,
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3058,14 +3053,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 486,
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3074,14 +3069,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 487,
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3090,14 +3085,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 488,
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3105,14 +3100,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 489,
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3120,14 +3115,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 490,
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3135,14 +3130,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 491,
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3150,8 +3145,7 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 492,
@@ -3176,6 +3170,7 @@
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3183,14 +3178,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 496,
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3198,14 +3193,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 497,
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3213,14 +3208,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 498,
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3228,8 +3223,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 499,
@@ -3254,6 +3248,7 @@
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3268,14 +3263,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 503,
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3284,14 +3279,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 504,
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3299,14 +3294,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 505,
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3314,14 +3309,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 506,
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3329,8 +3324,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 507,
@@ -3355,6 +3349,7 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3364,14 +3359,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 511,
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3381,14 +3376,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 512,
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3397,14 +3392,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 513,
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3414,14 +3409,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 514,
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3431,14 +3426,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 515,
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3448,14 +3443,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 516,
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3464,14 +3459,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 517,
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3481,14 +3476,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 518,
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3498,14 +3493,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 519,
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3515,14 +3510,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 520,
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3531,14 +3526,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 521,
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3548,14 +3543,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 522,
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3565,14 +3560,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 523,
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3582,14 +3577,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 524,
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3598,14 +3593,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 525,
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3615,14 +3610,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 526,
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3632,14 +3627,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 527,
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3649,14 +3644,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 528,
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3665,14 +3660,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 529,
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3682,8 +3677,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 530,
@@ -3888,12 +3882,12 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 564,
@@ -4170,11 +4164,11 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 610,
@@ -4761,11 +4755,11 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 705,
@@ -5084,6 +5078,7 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5097,14 +5092,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 758,
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -5112,8 +5107,7 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 759,
@@ -5252,12 +5246,12 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "trident"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 782,

--- a/data/pc/1.14.4/items.json
+++ b/data/pc/1.14.4/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 0
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -3116,6 +3110,7 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
+    "maxDurability": 275,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3125,8 +3120,7 @@
     ],
     "repairWith": [
       "scute"
-    ],
-    "maxDurability": 275
+    ]
   },
   {
     "id": 519,
@@ -3139,6 +3133,7 @@
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3146,14 +3141,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 521,
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3161,14 +3156,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 522,
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3176,19 +3171,18 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 523,
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 524,
@@ -3201,12 +3195,12 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 526,
@@ -3249,6 +3243,7 @@
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3256,14 +3251,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 533,
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3278,14 +3273,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 534,
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3300,14 +3295,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 535,
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3322,14 +3317,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 536,
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3344,14 +3339,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 537,
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3360,14 +3355,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 538,
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3376,14 +3371,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 539,
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3392,14 +3387,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 540,
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3408,14 +3403,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 541,
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3423,14 +3418,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 542,
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3438,14 +3433,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 543,
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3453,14 +3448,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 544,
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3468,8 +3463,7 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 545,
@@ -3494,6 +3488,7 @@
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3501,14 +3496,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 549,
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3516,14 +3511,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 550,
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3531,14 +3526,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 551,
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3546,8 +3541,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 552,
@@ -3572,6 +3566,7 @@
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3586,14 +3581,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 556,
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3602,14 +3597,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 557,
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3617,14 +3612,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 558,
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3632,14 +3627,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 559,
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3647,8 +3642,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 560,
@@ -3673,6 +3667,7 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3682,14 +3677,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 564,
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3699,14 +3694,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 565,
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3715,14 +3710,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 566,
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3732,14 +3727,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 567,
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3749,14 +3744,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 568,
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3766,14 +3761,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 569,
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3782,14 +3777,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 570,
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3799,14 +3794,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 571,
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3816,14 +3811,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 572,
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3833,14 +3828,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 573,
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3849,14 +3844,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 574,
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3866,14 +3861,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 575,
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3883,14 +3878,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 576,
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3900,14 +3895,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 577,
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3916,14 +3911,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 578,
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3933,14 +3928,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 579,
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3950,14 +3945,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 580,
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3967,14 +3962,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 581,
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3983,14 +3978,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 582,
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -4000,8 +3995,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 583,
@@ -4242,12 +4236,12 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 623,
@@ -4548,11 +4542,11 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 673,
@@ -5181,11 +5175,11 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 775,
@@ -5510,6 +5504,7 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5523,14 +5518,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 829,
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -5538,8 +5533,7 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 830,
@@ -5678,12 +5672,12 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "trident"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 853,
@@ -5708,12 +5702,12 @@
     "displayName": "Crossbow",
     "name": "crossbow",
     "stackSize": 1,
+    "maxDurability": 326,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "crossbow"
-    ],
-    "maxDurability": 326
+    ]
   },
   {
     "id": 857,

--- a/data/pc/1.14/items.json
+++ b/data/pc/1.14/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 0
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",

--- a/data/pc/1.15.2/items.json
+++ b/data/pc/1.15.2/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 0
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -3116,6 +3110,7 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
+    "maxDurability": 275,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3125,8 +3120,7 @@
     ],
     "repairWith": [
       "scute"
-    ],
-    "maxDurability": 275
+    ]
   },
   {
     "id": 519,
@@ -3139,6 +3133,7 @@
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3146,14 +3141,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 521,
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3161,14 +3156,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 522,
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3176,19 +3171,18 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 523,
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 524,
@@ -3201,12 +3195,12 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 526,
@@ -3249,6 +3243,7 @@
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3256,14 +3251,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 533,
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3278,14 +3273,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 534,
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3300,14 +3295,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 535,
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3322,14 +3317,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 536,
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3344,14 +3339,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 537,
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3360,14 +3355,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 538,
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3376,14 +3371,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 539,
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3392,14 +3387,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 540,
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3408,14 +3403,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 541,
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3423,14 +3418,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 542,
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3438,14 +3433,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 543,
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3453,14 +3448,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 544,
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3468,8 +3463,7 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 545,
@@ -3494,6 +3488,7 @@
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3501,14 +3496,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 549,
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3516,14 +3511,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 550,
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3531,14 +3526,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 551,
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3546,8 +3541,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 552,
@@ -3572,6 +3566,7 @@
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3586,14 +3581,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 556,
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3602,14 +3597,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 557,
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3617,14 +3612,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 558,
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3632,14 +3627,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 559,
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3647,8 +3642,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 560,
@@ -3673,6 +3667,7 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3682,14 +3677,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 564,
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3699,14 +3694,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 565,
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3715,14 +3710,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 566,
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3732,14 +3727,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 567,
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3749,14 +3744,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 568,
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3766,14 +3761,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 569,
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3782,14 +3777,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 570,
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3799,14 +3794,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 571,
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3816,14 +3811,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 572,
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3833,14 +3828,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 573,
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3849,14 +3844,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 574,
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3866,14 +3861,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 575,
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3883,14 +3878,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 576,
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3900,14 +3895,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 577,
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3916,14 +3911,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 578,
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -3933,14 +3928,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 579,
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3950,14 +3945,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 580,
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -3967,14 +3962,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 581,
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -3983,14 +3978,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 582,
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -4000,8 +3995,7 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 583,
@@ -4242,12 +4236,12 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 623,
@@ -4548,11 +4542,11 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 673,
@@ -5187,11 +5181,11 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 776,
@@ -5516,6 +5510,7 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -5529,14 +5524,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 830,
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -5544,8 +5539,7 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 831,
@@ -5684,12 +5678,12 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "trident"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 854,
@@ -5714,12 +5708,12 @@
     "displayName": "Crossbow",
     "name": "crossbow",
     "stackSize": 1,
+    "maxDurability": 326,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "crossbow"
-    ],
-    "maxDurability": 326
+    ]
   },
   {
     "id": 858,

--- a/data/pc/1.16.1/items.json
+++ b/data/pc/1.16.1/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 0
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -3428,6 +3422,7 @@
     "displayName": "Turtle Shell",
     "name": "turtle_helmet",
     "stackSize": 1,
+    "maxDurability": 275,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -3437,8 +3432,7 @@
     ],
     "repairWith": [
       "scute"
-    ],
-    "maxDurability": 275
+    ]
   },
   {
     "id": 571,
@@ -3451,6 +3445,7 @@
     "displayName": "Iron Shovel",
     "name": "iron_shovel",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3458,14 +3453,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 573,
     "displayName": "Iron Pickaxe",
     "name": "iron_pickaxe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3473,14 +3468,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 574,
     "displayName": "Iron Axe",
     "name": "iron_axe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3488,19 +3483,18 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 575,
     "displayName": "Flint and Steel",
     "name": "flint_and_steel",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 576,
@@ -3513,12 +3507,12 @@
     "displayName": "Bow",
     "name": "bow",
     "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 578,
@@ -3573,6 +3567,7 @@
     "displayName": "Iron Sword",
     "name": "iron_sword",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3580,14 +3575,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 587,
     "displayName": "Wooden Sword",
     "name": "wooden_sword",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3602,14 +3597,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 588,
     "displayName": "Wooden Shovel",
     "name": "wooden_shovel",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3624,14 +3619,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 589,
     "displayName": "Wooden Pickaxe",
     "name": "wooden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3646,14 +3641,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 590,
     "displayName": "Wooden Axe",
     "name": "wooden_axe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3668,14 +3663,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 591,
     "displayName": "Stone Sword",
     "name": "stone_sword",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3684,14 +3679,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 592,
     "displayName": "Stone Shovel",
     "name": "stone_shovel",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3700,14 +3695,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 593,
     "displayName": "Stone Pickaxe",
     "name": "stone_pickaxe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3716,14 +3711,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 594,
     "displayName": "Stone Axe",
     "name": "stone_axe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3732,14 +3727,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 595,
     "displayName": "Diamond Sword",
     "name": "diamond_sword",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3747,14 +3742,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 596,
     "displayName": "Diamond Shovel",
     "name": "diamond_shovel",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3762,14 +3757,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 597,
     "displayName": "Diamond Pickaxe",
     "name": "diamond_pickaxe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3777,14 +3772,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 598,
     "displayName": "Diamond Axe",
     "name": "diamond_axe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3792,8 +3787,7 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 599,
@@ -3818,6 +3812,7 @@
     "displayName": "Golden Sword",
     "name": "golden_sword",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3825,14 +3820,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 603,
     "displayName": "Golden Shovel",
     "name": "golden_shovel",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3840,14 +3835,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 604,
     "displayName": "Golden Pickaxe",
     "name": "golden_pickaxe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3855,14 +3850,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 605,
     "displayName": "Golden Axe",
     "name": "golden_axe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3870,14 +3865,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 606,
     "displayName": "Netherite Sword",
     "name": "netherite_sword",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -3885,14 +3880,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 607,
     "displayName": "Netherite Shovel",
     "name": "netherite_shovel",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3900,14 +3895,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 608,
     "displayName": "Netherite Pickaxe",
     "name": "netherite_pickaxe",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3915,14 +3910,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 609,
     "displayName": "Netherite Axe",
     "name": "netherite_axe",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3930,8 +3925,7 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 610,
@@ -3956,6 +3950,7 @@
     "displayName": "Wooden Hoe",
     "name": "wooden_hoe",
     "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3970,14 +3965,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 614,
     "displayName": "Stone Hoe",
     "name": "stone_hoe",
     "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -3986,14 +3981,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 615,
     "displayName": "Iron Hoe",
     "name": "iron_hoe",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4001,14 +3996,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 616,
     "displayName": "Diamond Hoe",
     "name": "diamond_hoe",
     "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4016,14 +4011,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 617,
     "displayName": "Golden Hoe",
     "name": "golden_hoe",
     "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4031,14 +4026,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 618,
     "displayName": "Netherite Hoe",
     "name": "netherite_hoe",
     "stackSize": 1,
+    "maxDurability": 2031,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -4046,8 +4041,7 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 2031
+    ]
   },
   {
     "id": 619,
@@ -4072,6 +4066,7 @@
     "displayName": "Leather Cap",
     "name": "leather_helmet",
     "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -4081,14 +4076,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 623,
     "displayName": "Leather Tunic",
     "name": "leather_chestplate",
     "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4098,14 +4093,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 624,
     "displayName": "Leather Pants",
     "name": "leather_leggings",
     "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -4114,14 +4109,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 625,
     "displayName": "Leather Boots",
     "name": "leather_boots",
     "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -4131,14 +4126,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 626,
     "displayName": "Chainmail Helmet",
     "name": "chainmail_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -4148,14 +4143,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 627,
     "displayName": "Chainmail Chestplate",
     "name": "chainmail_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4165,14 +4160,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 628,
     "displayName": "Chainmail Leggings",
     "name": "chainmail_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -4181,14 +4176,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 629,
     "displayName": "Chainmail Boots",
     "name": "chainmail_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -4198,14 +4193,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 630,
     "displayName": "Iron Helmet",
     "name": "iron_helmet",
     "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -4215,14 +4210,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 631,
     "displayName": "Iron Chestplate",
     "name": "iron_chestplate",
     "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4232,14 +4227,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 632,
     "displayName": "Iron Leggings",
     "name": "iron_leggings",
     "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -4248,14 +4243,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 633,
     "displayName": "Iron Boots",
     "name": "iron_boots",
     "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -4265,14 +4260,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 634,
     "displayName": "Diamond Helmet",
     "name": "diamond_helmet",
     "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -4282,14 +4277,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 635,
     "displayName": "Diamond Chestplate",
     "name": "diamond_chestplate",
     "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4299,14 +4294,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 636,
     "displayName": "Diamond Leggings",
     "name": "diamond_leggings",
     "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -4315,14 +4310,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 637,
     "displayName": "Diamond Boots",
     "name": "diamond_boots",
     "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -4332,14 +4327,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 638,
     "displayName": "Golden Helmet",
     "name": "golden_helmet",
     "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -4349,14 +4344,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 639,
     "displayName": "Golden Chestplate",
     "name": "golden_chestplate",
     "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4366,14 +4361,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 640,
     "displayName": "Golden Leggings",
     "name": "golden_leggings",
     "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -4382,14 +4377,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 641,
     "displayName": "Golden Boots",
     "name": "golden_boots",
     "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -4399,14 +4394,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 642,
     "displayName": "Netherite Helmet",
     "name": "netherite_helmet",
     "stackSize": 1,
+    "maxDurability": 407,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -4416,14 +4411,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 407
+    ]
   },
   {
     "id": 643,
     "displayName": "Netherite Chestplate",
     "name": "netherite_chestplate",
     "stackSize": 1,
+    "maxDurability": 592,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -4433,14 +4428,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 592
+    ]
   },
   {
     "id": 644,
     "displayName": "Netherite Leggings",
     "name": "netherite_leggings",
     "stackSize": 1,
+    "maxDurability": 555,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -4449,14 +4444,14 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 555
+    ]
   },
   {
     "id": 645,
     "displayName": "Netherite Boots",
     "name": "netherite_boots",
     "stackSize": 1,
+    "maxDurability": 481,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -4466,8 +4461,7 @@
     ],
     "repairWith": [
       "netherite_ingot"
-    ],
-    "maxDurability": 481
+    ]
   },
   {
     "id": 646,
@@ -4702,12 +4696,12 @@
     "displayName": "Fishing Rod",
     "name": "fishing_rod",
     "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 685,
@@ -5008,11 +5002,11 @@
     "displayName": "Shears",
     "name": "shears",
     "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 735,
@@ -5671,22 +5665,22 @@
     "displayName": "Carrot on a Stick",
     "name": "carrot_on_a_stick",
     "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 842,
     "displayName": "Warped Fungus on a Stick",
     "name": "warped_fungus_on_a_stick",
     "stackSize": 64,
+    "maxDurability": 100,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 100
+    ]
   },
   {
     "id": 843,
@@ -6011,6 +6005,7 @@
     "displayName": "Shield",
     "name": "shield",
     "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -6024,14 +6019,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 897,
     "displayName": "Elytra",
     "name": "elytra",
     "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -6039,8 +6034,7 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 898,
@@ -6185,12 +6179,12 @@
     "displayName": "Trident",
     "name": "trident",
     "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "trident"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 922,
@@ -6215,12 +6209,12 @@
     "displayName": "Crossbow",
     "name": "crossbow",
     "stackSize": 1,
+    "maxDurability": 326,
     "enchantCategories": [
       "breakable",
       "vanishable",
       "crossbow"
-    ],
-    "maxDurability": 326
+    ]
   },
   {
     "id": 926,

--- a/data/pc/1.16.2/items.json
+++ b/data/pc/1.16.2/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 0
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",

--- a/data/pc/1.17/items.json
+++ b/data/pc/1.17/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 0
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",

--- a/data/pc/1.7/items.json
+++ b/data/pc/1.7/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 64
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -31,8 +25,8 @@
   },
   {
     "id": 5,
-    "displayName": "Wood Planks",
-    "name": "wood_planks",
+    "displayName": "Wooden Planks",
+    "name": "planks",
     "stackSize": 64
   },
   {
@@ -45,30 +39,6 @@
     "id": 7,
     "displayName": "Bedrock",
     "name": "bedrock",
-    "stackSize": 64
-  },
-  {
-    "id": 8,
-    "displayName": "Water",
-    "name": "flowing_water",
-    "stackSize": 64
-  },
-  {
-    "id": 9,
-    "displayName": "Stationary Water",
-    "name": "water",
-    "stackSize": 64
-  },
-  {
-    "id": 10,
-    "displayName": "Lava",
-    "name": "flowing_lava",
-    "stackSize": 64
-  },
-  {
-    "id": 11,
-    "displayName": "Stationary Lava",
-    "name": "lava",
     "stackSize": 64
   },
   {
@@ -198,21 +168,9 @@
     "stackSize": 64
   },
   {
-    "id": 34,
-    "displayName": "Piston Extension",
-    "name": "piston_head",
-    "stackSize": 64
-  },
-  {
     "id": 35,
     "displayName": "Wool",
     "name": "wool",
-    "stackSize": 64
-  },
-  {
-    "id": 36,
-    "displayName": "Block moved by Piston",
-    "name": "piston_extension",
     "stackSize": 64
   },
   {
@@ -252,12 +210,6 @@
     "stackSize": 64
   },
   {
-    "id": 43,
-    "displayName": "Double Stone Slab",
-    "name": "double_stone_slab",
-    "stackSize": 64
-  },
-  {
     "id": 44,
     "displayName": "Stone Slab",
     "name": "stone_slab",
@@ -265,7 +217,7 @@
   },
   {
     "id": 45,
-    "displayName": "Bricks",
+    "displayName": "Brick",
     "name": "brick_block",
     "stackSize": 64
   },
@@ -300,12 +252,6 @@
     "stackSize": 64
   },
   {
-    "id": 51,
-    "displayName": "Fire",
-    "name": "fire",
-    "stackSize": 64
-  },
-  {
     "id": 52,
     "displayName": "Monster Spawner",
     "name": "mob_spawner",
@@ -321,12 +267,6 @@
     "id": 54,
     "displayName": "Chest",
     "name": "chest",
-    "stackSize": 64
-  },
-  {
-    "id": 55,
-    "displayName": "Redstone Wire",
-    "name": "redstone_wire",
     "stackSize": 64
   },
   {
@@ -360,18 +300,6 @@
     "stackSize": 64
   },
   {
-    "id": 62,
-    "displayName": "Burning Furnace",
-    "name": "lit_furnace",
-    "stackSize": 64
-  },
-  {
-    "id": 63,
-    "displayName": "Standing Sign",
-    "name": "standing_sign",
-    "stackSize": 64
-  },
-  {
     "id": 65,
     "displayName": "Ladder",
     "name": "ladder",
@@ -387,12 +315,6 @@
     "id": 67,
     "displayName": "Cobblestone Stairs",
     "name": "stone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 68,
-    "displayName": "Wall Sign",
-    "name": "wall_sign",
     "stackSize": 64
   },
   {
@@ -417,18 +339,6 @@
     "id": 73,
     "displayName": "Redstone Ore",
     "name": "redstone_ore",
-    "stackSize": 64
-  },
-  {
-    "id": 74,
-    "displayName": "Glowing Redstone Ore",
-    "name": "lit_redstone_ore",
-    "stackSize": 64
-  },
-  {
-    "id": 75,
-    "displayName": "Redstone Torch",
-    "name": "unlit_redstone_torch",
     "stackSize": 64
   },
   {
@@ -481,7 +391,7 @@
   },
   {
     "id": 85,
-    "displayName": "Fence",
+    "displayName": "Oak Fence",
     "name": "fence",
     "stackSize": 64
   },
@@ -510,27 +420,9 @@
     "stackSize": 64
   },
   {
-    "id": 90,
-    "displayName": "Nether Portal",
-    "name": "portal",
-    "stackSize": 64
-  },
-  {
     "id": 91,
     "displayName": "Jack o'Lantern",
     "name": "lit_pumpkin",
-    "stackSize": 64
-  },
-  {
-    "id": 93,
-    "displayName": "Redstone Repeater",
-    "name": "unpowered_repeater",
-    "stackSize": 64
-  },
-  {
-    "id": 94,
-    "displayName": "Redstone Repeater",
-    "name": "powered_repeater",
     "stackSize": 64
   },
   {
@@ -541,7 +433,7 @@
   },
   {
     "id": 96,
-    "displayName": "Trapdoor",
+    "displayName": "Wooden Trapdoor",
     "name": "trapdoor",
     "stackSize": 64
   },
@@ -559,13 +451,13 @@
   },
   {
     "id": 99,
-    "displayName": "Huge Brown Mushroom",
+    "displayName": "Brown Mushroom Block",
     "name": "brown_mushroom_block",
     "stackSize": 64
   },
   {
     "id": 100,
-    "displayName": "Huge Red Mushroom",
+    "displayName": "Red Mushroom Block",
     "name": "red_mushroom_block",
     "stackSize": 64
   },
@@ -588,18 +480,6 @@
     "stackSize": 64
   },
   {
-    "id": 104,
-    "displayName": "Pumpkin Stem",
-    "name": "pumpkin_stem",
-    "stackSize": 64
-  },
-  {
-    "id": 105,
-    "displayName": "Melon Stem",
-    "name": "melon_stem",
-    "stackSize": 64
-  },
-  {
     "id": 106,
     "displayName": "Vines",
     "name": "vine",
@@ -607,7 +487,7 @@
   },
   {
     "id": 107,
-    "displayName": "Fence Gate",
+    "displayName": "Oak Fence Gate",
     "name": "fence_gate",
     "stackSize": 64
   },
@@ -660,14 +540,8 @@
     "stackSize": 64
   },
   {
-    "id": 119,
-    "displayName": "End Portal",
-    "name": "end_portal",
-    "stackSize": 64
-  },
-  {
     "id": 120,
-    "displayName": "End Portal Block",
+    "displayName": "End Portal Frame",
     "name": "end_portal_frame",
     "stackSize": 64
   },
@@ -690,27 +564,9 @@
     "stackSize": 64
   },
   {
-    "id": 124,
-    "displayName": "Redstone Lamp",
-    "name": "lit_redstone_lamp",
-    "stackSize": 64
-  },
-  {
-    "id": 125,
-    "displayName": "Double Wooden Slab",
-    "name": "double_wooden_slab",
-    "stackSize": 64
-  },
-  {
     "id": 126,
-    "displayName": "Wooden Slab",
+    "displayName": "Wood Slab",
     "name": "wooden_slab",
-    "stackSize": 64
-  },
-  {
-    "id": 127,
-    "displayName": "Cocoa",
-    "name": "cocoa",
     "stackSize": 64
   },
   {
@@ -735,12 +591,6 @@
     "id": 131,
     "displayName": "Tripwire Hook",
     "name": "tripwire_hook",
-    "stackSize": 64
-  },
-  {
-    "id": 132,
-    "displayName": "Tripwire",
-    "name": "tripwire",
     "stackSize": 64
   },
   {
@@ -786,18 +636,6 @@
     "stackSize": 64
   },
   {
-    "id": 141,
-    "displayName": "Carrot",
-    "name": "carrots",
-    "stackSize": 64
-  },
-  {
-    "id": 142,
-    "displayName": "Potato",
-    "name": "potatoes",
-    "stackSize": 64
-  },
-  {
     "id": 143,
     "displayName": "Wooden Button",
     "name": "wooden_button",
@@ -817,31 +655,19 @@
   },
   {
     "id": 147,
-    "displayName": "Light Weighted Pressure Plate",
+    "displayName": "Weighted Pressure Plate (Light)",
     "name": "light_weighted_pressure_plate",
     "stackSize": 64
   },
   {
     "id": 148,
-    "displayName": "Heavy Weighted Pressure Plate",
+    "displayName": "Weighted Pressure Plate (Heavy)",
     "name": "heavy_weighted_pressure_plate",
     "stackSize": 64
   },
   {
-    "id": 149,
-    "displayName": "Redstone Comparator",
-    "name": "unpowered_comparator",
-    "stackSize": 64
-  },
-  {
-    "id": 150,
-    "displayName": "Redstone Comparator",
-    "name": "powered_comparator",
-    "stackSize": 64
-  },
-  {
     "id": 151,
-    "displayName": "Daylight Sensor",
+    "displayName": "Daylight Detector",
     "name": "daylight_detector",
     "stackSize": 64
   },
@@ -853,7 +679,7 @@
   },
   {
     "id": 153,
-    "displayName": "Nether Quartz Ore",
+    "displayName": "Nether Quartz",
     "name": "quartz_ore",
     "stackSize": 64
   },
@@ -924,38 +750,8 @@
     "stackSize": 64
   },
   {
-    "id": 165,
-    "displayName": "Slime Block",
-    "name": "slime",
-    "stackSize": 64
-  },
-  {
-    "id": 166,
-    "displayName": "Barrier",
-    "name": "barrier",
-    "stackSize": 64
-  },
-  {
-    "id": 167,
-    "displayName": "Iron Trapdoor",
-    "name": "iron_trapdoor",
-    "stackSize": 64
-  },
-  {
-    "id": 168,
-    "displayName": "Prismarine",
-    "name": "prismarine",
-    "stackSize": 64
-  },
-  {
-    "id": 169,
-    "displayName": "Sea Lantern",
-    "name": "sea_lantern",
-    "stackSize": 64
-  },
-  {
     "id": 170,
-    "displayName": "Hay Block",
+    "displayName": "Hay Bale",
     "name": "hay_block",
     "stackSize": 64
   },
@@ -986,14 +782,15 @@
   {
     "id": 175,
     "displayName": "Large Flowers",
-    "name": "large_flowers",
+    "name": "double_plant",
     "stackSize": 64
   },
   {
     "id": 256,
     "displayName": "Iron Shovel",
-    "stackSize": 1,
     "name": "iron_shovel",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1001,14 +798,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 257,
     "displayName": "Iron Pickaxe",
-    "stackSize": 1,
     "name": "iron_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1016,14 +813,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 258,
     "displayName": "Iron Axe",
-    "stackSize": 1,
     "name": "iron_axe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1031,49 +828,48 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 259,
     "displayName": "Flint and Steel",
-    "stackSize": 1,
     "name": "flint_and_steel",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 260,
     "displayName": "Apple",
-    "stackSize": 64,
-    "name": "apple"
+    "name": "apple",
+    "stackSize": 64
   },
   {
     "id": 261,
     "displayName": "Bow",
-    "stackSize": 1,
     "name": "bow",
+    "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 262,
     "displayName": "Arrow",
-    "stackSize": 64,
-    "name": "arrow"
+    "name": "arrow",
+    "stackSize": 64
   },
   {
     "id": 263,
     "displayName": "Coal",
-    "stackSize": 64,
     "name": "coal",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -1088,26 +884,27 @@
   {
     "id": 264,
     "displayName": "Diamond",
-    "stackSize": 64,
-    "name": "diamond"
+    "name": "diamond",
+    "stackSize": 64
   },
   {
     "id": 265,
     "displayName": "Iron Ingot",
-    "stackSize": 64,
-    "name": "iron_ingot"
+    "name": "iron_ingot",
+    "stackSize": 64
   },
   {
     "id": 266,
     "displayName": "Gold Ingot",
-    "stackSize": 64,
-    "name": "gold_ingot"
+    "name": "gold_ingot",
+    "stackSize": 64
   },
   {
     "id": 267,
     "displayName": "Iron Sword",
-    "stackSize": 1,
     "name": "iron_sword",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1115,14 +912,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 268,
     "displayName": "Wooden Sword",
-    "stackSize": 1,
     "name": "wooden_sword",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1137,14 +934,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 269,
     "displayName": "Wooden Shovel",
-    "stackSize": 1,
     "name": "wooden_shovel",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1159,14 +956,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 270,
     "displayName": "Wooden Pickaxe",
-    "stackSize": 1,
     "name": "wooden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1181,14 +978,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 271,
     "displayName": "Wooden Axe",
-    "stackSize": 1,
     "name": "wooden_axe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1203,14 +1000,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 272,
     "displayName": "Stone Sword",
-    "stackSize": 1,
     "name": "stone_sword",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1219,14 +1016,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 273,
     "displayName": "Stone Shovel",
-    "stackSize": 1,
     "name": "stone_shovel",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1235,14 +1032,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 274,
     "displayName": "Stone Pickaxe",
-    "stackSize": 1,
     "name": "stone_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1251,14 +1048,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 275,
     "displayName": "Stone Axe",
-    "stackSize": 1,
     "name": "stone_axe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1267,14 +1064,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 276,
     "displayName": "Diamond Sword",
-    "stackSize": 1,
     "name": "diamond_sword",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1282,14 +1079,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 277,
     "displayName": "Diamond Shovel",
-    "stackSize": 1,
     "name": "diamond_shovel",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1297,14 +1094,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 278,
     "displayName": "Diamond Pickaxe",
-    "stackSize": 1,
     "name": "diamond_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1312,14 +1109,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 279,
     "displayName": "Diamond Axe",
-    "stackSize": 1,
     "name": "diamond_axe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1327,32 +1124,32 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 280,
     "displayName": "Stick",
-    "stackSize": 64,
-    "name": "stick"
+    "name": "stick",
+    "stackSize": 64
   },
   {
     "id": 281,
     "displayName": "Bowl",
-    "stackSize": 64,
-    "name": "bowl"
+    "name": "bowl",
+    "stackSize": 64
   },
   {
     "id": 282,
     "displayName": "Mushroom Stew",
-    "stackSize": 1,
-    "name": "mushroom_stew"
+    "name": "mushroom_stew",
+    "stackSize": 1
   },
   {
     "id": 283,
     "displayName": "Golden Sword",
-    "stackSize": 1,
     "name": "golden_sword",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1360,14 +1157,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 284,
     "displayName": "Golden Shovel",
-    "stackSize": 1,
     "name": "golden_shovel",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1375,14 +1172,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 285,
     "displayName": "Golden Pickaxe",
-    "stackSize": 1,
     "name": "golden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1390,14 +1187,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 286,
     "displayName": "Golden Axe",
-    "stackSize": 1,
     "name": "golden_axe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1405,32 +1202,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 287,
     "displayName": "String",
-    "stackSize": 64,
-    "name": "string"
+    "name": "string",
+    "stackSize": 64
   },
   {
     "id": 288,
     "displayName": "Feather",
-    "stackSize": 64,
-    "name": "feather"
+    "name": "feather",
+    "stackSize": 64
   },
   {
     "id": 289,
     "displayName": "Gunpowder",
-    "stackSize": 64,
-    "name": "gunpowder"
+    "name": "gunpowder",
+    "stackSize": 64
   },
   {
     "id": 290,
     "displayName": "Wooden Hoe",
-    "stackSize": 1,
     "name": "wooden_hoe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1445,14 +1242,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 291,
     "displayName": "Stone Hoe",
-    "stackSize": 1,
     "name": "stone_hoe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1461,14 +1258,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 292,
     "displayName": "Iron Hoe",
-    "stackSize": 1,
     "name": "iron_hoe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1476,14 +1273,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 293,
     "displayName": "Diamond Hoe",
-    "stackSize": 1,
     "name": "diamond_hoe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1491,14 +1288,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 294,
     "displayName": "Golden Hoe",
-    "stackSize": 1,
     "name": "golden_hoe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1506,32 +1303,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 295,
     "displayName": "Seeds",
-    "stackSize": 64,
-    "name": "wheat_seeds"
+    "name": "wheat_seeds",
+    "stackSize": 64
   },
   {
     "id": 296,
     "displayName": "Wheat",
-    "stackSize": 64,
-    "name": "wheat"
+    "name": "wheat",
+    "stackSize": 64
   },
   {
     "id": 297,
     "displayName": "Bread",
-    "stackSize": 64,
-    "name": "bread"
+    "name": "bread",
+    "stackSize": 64
   },
   {
     "id": 298,
     "displayName": "Leather Cap",
-    "stackSize": 1,
     "name": "leather_helmet",
+    "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1541,14 +1338,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 299,
     "displayName": "Leather Tunic",
-    "stackSize": 1,
     "name": "leather_chestplate",
+    "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1558,14 +1355,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 300,
     "displayName": "Leather Pants",
-    "stackSize": 1,
     "name": "leather_leggings",
+    "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1574,14 +1371,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 301,
     "displayName": "Leather Boots",
-    "stackSize": 1,
     "name": "leather_boots",
+    "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1591,14 +1388,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 302,
     "displayName": "Chain Helmet",
-    "stackSize": 1,
     "name": "chainmail_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1608,14 +1405,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 303,
-    "displayName": "Chain Tunic",
-    "stackSize": 1,
+    "displayName": "Chain Chestplate",
     "name": "chainmail_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1625,14 +1422,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 304,
     "displayName": "Chain Leggings",
-    "stackSize": 1,
     "name": "chainmail_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1641,14 +1438,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 305,
     "displayName": "Chain Boots",
-    "stackSize": 1,
     "name": "chainmail_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1658,14 +1455,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 306,
     "displayName": "Iron Helmet",
-    "stackSize": 1,
     "name": "iron_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1675,14 +1472,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 307,
     "displayName": "Iron Chestplate",
-    "stackSize": 1,
     "name": "iron_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1692,14 +1489,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 308,
     "displayName": "Iron Leggings",
-    "stackSize": 1,
     "name": "iron_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1708,14 +1505,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 309,
     "displayName": "Iron Boots",
-    "stackSize": 1,
     "name": "iron_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1725,14 +1522,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 310,
     "displayName": "Diamond Helmet",
-    "stackSize": 1,
     "name": "diamond_helmet",
+    "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1742,14 +1539,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 311,
     "displayName": "Diamond Chestplate",
-    "stackSize": 1,
     "name": "diamond_chestplate",
+    "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1759,14 +1556,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 312,
     "displayName": "Diamond Leggings",
-    "stackSize": 1,
     "name": "diamond_leggings",
+    "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1775,14 +1572,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 313,
     "displayName": "Diamond Boots",
-    "stackSize": 1,
     "name": "diamond_boots",
+    "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1792,14 +1589,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 314,
     "displayName": "Golden Helmet",
-    "stackSize": 1,
     "name": "golden_helmet",
+    "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1809,14 +1606,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 315,
     "displayName": "Golden Chestplate",
-    "stackSize": 1,
     "name": "golden_chestplate",
+    "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1826,14 +1623,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 316,
     "displayName": "Golden Leggings",
-    "stackSize": 1,
     "name": "golden_leggings",
+    "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1842,14 +1639,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 317,
     "displayName": "Golden Boots",
-    "stackSize": 1,
     "name": "golden_boots",
+    "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1859,38 +1656,37 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 318,
     "displayName": "Flint",
-    "stackSize": 64,
-    "name": "flint"
+    "name": "flint",
+    "stackSize": 64
   },
   {
     "id": 319,
     "displayName": "Raw Porkchop",
-    "stackSize": 64,
-    "name": "porkchop"
+    "name": "porkchop",
+    "stackSize": 64
   },
   {
     "id": 320,
     "displayName": "Cooked Porkchop",
-    "stackSize": 64,
-    "name": "cooked_porkchop"
+    "name": "cooked_porkchop",
+    "stackSize": 64
   },
   {
     "id": 321,
     "displayName": "Painting",
-    "stackSize": 64,
-    "name": "painting"
+    "name": "painting",
+    "stackSize": 64
   },
   {
     "id": 322,
     "displayName": "Golden Apple",
-    "stackSize": 64,
     "name": "golden_apple",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -1905,182 +1701,200 @@
   {
     "id": 323,
     "displayName": "Sign",
-    "stackSize": 16,
-    "name": "sign"
+    "name": "sign",
+    "stackSize": 16
   },
   {
     "id": 324,
-    "displayName": "Wooden Door",
-    "stackSize": 1,
-    "name": "wooden_door"
+    "displayName": "Oak Door",
+    "name": "wooden_door",
+    "stackSize": 64
   },
   {
     "id": 325,
     "displayName": "Bucket",
-    "stackSize": 16,
-    "name": "bucket"
+    "name": "bucket",
+    "stackSize": 16
   },
   {
     "id": 326,
     "displayName": "Water Bucket",
-    "stackSize": 64,
-    "name": "water_bucket"
+    "name": "water_bucket",
+    "stackSize": 1
   },
   {
     "id": 327,
     "displayName": "Lava Bucket",
-    "stackSize": 64,
-    "name": "lava_bucket"
+    "name": "lava_bucket",
+    "stackSize": 1
   },
   {
     "id": 328,
     "displayName": "Minecart",
-    "stackSize": 1,
-    "name": "minecart"
+    "name": "minecart",
+    "stackSize": 1
   },
   {
     "id": 329,
     "displayName": "Saddle",
-    "stackSize": 1,
-    "name": "saddle"
+    "name": "saddle",
+    "stackSize": 1
   },
   {
     "id": 330,
     "displayName": "Iron Door",
-    "stackSize": 1,
-    "name": "iron_door"
+    "name": "iron_door",
+    "stackSize": 64
   },
   {
     "id": 331,
     "displayName": "Redstone",
-    "stackSize": 64,
-    "name": "redstone"
+    "name": "redstone",
+    "stackSize": 64
   },
   {
     "id": 332,
     "displayName": "Snowball",
-    "stackSize": 16,
-    "name": "snowball"
+    "name": "snowball",
+    "stackSize": 16
   },
   {
     "id": 333,
     "displayName": "Boat",
-    "stackSize": 1,
-    "name": "boat"
+    "name": "boat",
+    "stackSize": 1
   },
   {
     "id": 334,
     "displayName": "Leather",
-    "stackSize": 64,
-    "name": "leather"
+    "name": "leather",
+    "stackSize": 64
   },
   {
     "id": 335,
     "displayName": "Milk",
-    "stackSize": 1,
-    "name": "milk_bucket"
+    "name": "milk_bucket",
+    "stackSize": 1
   },
   {
     "id": 336,
     "displayName": "Brick",
-    "stackSize": 64,
-    "name": "brick"
+    "name": "brick",
+    "stackSize": 64
   },
   {
     "id": 337,
     "displayName": "Clay",
-    "stackSize": 64,
-    "name": "clay_ball"
+    "name": "clay_ball",
+    "stackSize": 64
   },
   {
     "id": 338,
-    "displayName": "Sugar Cane",
-    "stackSize": 64,
-    "name": "reeds"
+    "displayName": "Sugar Canes",
+    "name": "reeds",
+    "stackSize": 64
   },
   {
     "id": 339,
     "displayName": "Paper",
-    "stackSize": 64,
-    "name": "paper"
+    "name": "paper",
+    "stackSize": 64
   },
   {
     "id": 340,
     "displayName": "Book",
-    "stackSize": 64,
-    "name": "book"
+    "name": "book",
+    "stackSize": 64
   },
   {
     "id": 341,
     "displayName": "Slimeball",
-    "stackSize": 64,
-    "name": "slime_ball"
+    "name": "slime_ball",
+    "stackSize": 64
   },
   {
     "id": 342,
     "displayName": "Minecart with Chest",
-    "stackSize": 1,
-    "name": "chest_minecart"
+    "name": "chest_minecart",
+    "stackSize": 1
   },
   {
     "id": 343,
     "displayName": "Minecart with Furnace",
-    "stackSize": 1,
-    "name": "furnace_minecart"
+    "name": "furnace_minecart",
+    "stackSize": 1
   },
   {
     "id": 344,
     "displayName": "Egg",
-    "stackSize": 16,
-    "name": "egg"
+    "name": "egg",
+    "stackSize": 16
   },
   {
     "id": 345,
     "displayName": "Compass",
-    "stackSize": 64,
-    "name": "compass"
+    "name": "compass",
+    "stackSize": 64
   },
   {
     "id": 346,
     "displayName": "Fishing Rod",
-    "stackSize": 1,
     "name": "fishing_rod",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 347,
     "displayName": "Clock",
-    "stackSize": 64,
-    "name": "clock"
+    "name": "clock",
+    "stackSize": 64
   },
   {
     "id": 348,
     "displayName": "Glowstone Dust",
-    "stackSize": 64,
-    "name": "glowstone_dust"
+    "name": "glowstone_dust",
+    "stackSize": 64
   },
   {
     "id": 349,
-    "displayName": "Raw Fish",
+    "displayName": "Fish",
+    "name": "fish",
     "stackSize": 64,
-    "name": "fish"
+    "variations": [
+      {
+        "metadata": 0,
+        "displayName": "Raw Fish"
+      },
+      {
+        "metadata": 1,
+        "displayName": "Raw Salmon"
+      },
+      {
+        "metadata": 2,
+        "displayName": "Clownfish"
+      },
+      {
+        "metadata": 3,
+        "displayName": "Pufferfish"
+      }
+    ]
   },
   {
     "id": 350,
     "displayName": "Cooked Fish",
-    "stackSize": 64,
-    "name": "cooked_fish"
+    "name": "cooked_fish",
+    "stackSize": 64
   },
   {
     "id": 351,
     "displayName": "Dye",
-    "stackSize": 64,
     "name": "dye",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2151,283 +1965,341 @@
   {
     "id": 352,
     "displayName": "Bone",
-    "stackSize": 64,
-    "name": "bone"
+    "name": "bone",
+    "stackSize": 64
   },
   {
     "id": 353,
     "displayName": "Sugar",
-    "stackSize": 64,
-    "name": "sugar"
+    "name": "sugar",
+    "stackSize": 64
   },
   {
     "id": 354,
     "displayName": "Cake",
-    "stackSize": 1,
-    "name": "cake"
+    "name": "cake",
+    "stackSize": 1
   },
   {
     "id": 355,
     "displayName": "Bed",
-    "stackSize": 1,
-    "name": "bed"
+    "name": "bed",
+    "stackSize": 1
   },
   {
     "id": 356,
     "displayName": "Redstone Repeater",
-    "stackSize": 64,
-    "name": "repeater"
+    "name": "repeater",
+    "stackSize": 64
   },
   {
     "id": 357,
     "displayName": "Cookie",
-    "stackSize": 64,
-    "name": "cookie"
+    "name": "cookie",
+    "stackSize": 64
   },
   {
     "id": 358,
     "displayName": "Map",
-    "stackSize": 64,
-    "name": "filled_map"
+    "name": "filled_map",
+    "stackSize": 64
   },
   {
     "id": 359,
     "displayName": "Shears",
-    "stackSize": 1,
     "name": "shears",
+    "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 360,
     "displayName": "Melon",
-    "stackSize": 64,
-    "name": "melon"
+    "name": "melon",
+    "stackSize": 64
   },
   {
     "id": 361,
     "displayName": "Pumpkin Seeds",
-    "stackSize": 64,
-    "name": "pumpkin_seeds"
+    "name": "pumpkin_seeds",
+    "stackSize": 64
   },
   {
     "id": 362,
     "displayName": "Melon Seeds",
-    "stackSize": 64,
-    "name": "melon_seeds"
+    "name": "melon_seeds",
+    "stackSize": 64
   },
   {
     "id": 363,
     "displayName": "Raw Beef",
-    "stackSize": 64,
-    "name": "beef"
+    "name": "beef",
+    "stackSize": 64
   },
   {
     "id": 364,
     "displayName": "Steak",
-    "stackSize": 64,
-    "name": "cooked_beef"
+    "name": "cooked_beef",
+    "stackSize": 64
   },
   {
     "id": 365,
     "displayName": "Raw Chicken",
-    "stackSize": 64,
-    "name": "chicken"
+    "name": "chicken",
+    "stackSize": 64
   },
   {
     "id": 366,
     "displayName": "Cooked Chicken",
-    "stackSize": 64,
-    "name": "cooked_chicken"
+    "name": "cooked_chicken",
+    "stackSize": 64
   },
   {
     "id": 367,
     "displayName": "Rotten Flesh",
-    "stackSize": 64,
-    "name": "rotten_flesh"
+    "name": "rotten_flesh",
+    "stackSize": 64
   },
   {
     "id": 368,
     "displayName": "Ender Pearl",
-    "stackSize": 16,
-    "name": "ender_pearl"
+    "name": "ender_pearl",
+    "stackSize": 16
   },
   {
     "id": 369,
     "displayName": "Blaze Rod",
-    "stackSize": 64,
-    "name": "blaze_rod"
+    "name": "blaze_rod",
+    "stackSize": 64
   },
   {
     "id": 370,
     "displayName": "Ghast Tear",
-    "stackSize": 64,
-    "name": "ghast_tear"
+    "name": "ghast_tear",
+    "stackSize": 64
   },
   {
     "id": 371,
     "displayName": "Gold Nugget",
-    "stackSize": 64,
-    "name": "gold_nugget"
+    "name": "gold_nugget",
+    "stackSize": 64
   },
   {
     "id": 372,
     "displayName": "Nether Wart",
-    "stackSize": 64,
-    "name": "nether_wart"
+    "name": "nether_wart",
+    "stackSize": 64
   },
   {
     "id": 373,
     "displayName": "Potion",
-    "stackSize": 1,
-    "name": "potion"
+    "name": "potion",
+    "stackSize": 1
   },
   {
     "id": 374,
     "displayName": "Glass Bottle",
-    "stackSize": 64,
-    "name": "glass_bottle"
+    "name": "glass_bottle",
+    "stackSize": 64
   },
   {
     "id": 375,
     "displayName": "Spider Eye",
-    "stackSize": 64,
-    "name": "spider_eye"
+    "name": "spider_eye",
+    "stackSize": 64
   },
   {
     "id": 376,
     "displayName": "Fermented Spider Eye",
-    "stackSize": 64,
-    "name": "fermented_spider_eye"
+    "name": "fermented_spider_eye",
+    "stackSize": 64
   },
   {
     "id": 377,
     "displayName": "Blaze Powder",
-    "stackSize": 64,
-    "name": "blaze_powder"
+    "name": "blaze_powder",
+    "stackSize": 64
   },
   {
     "id": 378,
     "displayName": "Magma Cream",
-    "stackSize": 64,
-    "name": "magma_cream"
+    "name": "magma_cream",
+    "stackSize": 64
   },
   {
     "id": 379,
     "displayName": "Brewing Stand",
-    "stackSize": 64,
-    "name": "brewing_stand"
+    "name": "brewing_stand",
+    "stackSize": 64
   },
   {
     "id": 380,
     "displayName": "Cauldron",
-    "stackSize": 64,
-    "name": "cauldron"
+    "name": "cauldron",
+    "stackSize": 64
   },
   {
     "id": 381,
     "displayName": "Eye of Ender",
-    "stackSize": 64,
-    "name": "eye_of_ender"
+    "name": "ender_eye",
+    "stackSize": 64
   },
   {
     "id": 382,
     "displayName": "Glistering Melon",
-    "stackSize": 64,
-    "name": "speckled_melon"
+    "name": "speckled_melon",
+    "stackSize": 64
   },
   {
     "id": 383,
     "displayName": "Spawn Egg",
-    "stackSize": 64,
-    "name": "spawn_egg"
+    "name": "spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 384,
     "displayName": "Bottle o' Enchanting",
-    "stackSize": 64,
-    "name": "experience_bottle"
+    "name": "experience_bottle",
+    "stackSize": 64
   },
   {
     "id": 385,
     "displayName": "Fire Charge",
-    "stackSize": 64,
-    "name": "fire_charge"
+    "name": "fire_charge",
+    "stackSize": 64
   },
   {
     "id": 386,
     "displayName": "Book and Quill",
-    "stackSize": 1,
-    "name": "writable_book"
+    "name": "writable_book",
+    "stackSize": 1
   },
   {
     "id": 387,
     "displayName": "Written Book",
-    "stackSize": 16,
-    "name": "written_book"
+    "name": "written_book",
+    "stackSize": 16
   },
   {
     "id": 388,
     "displayName": "Emerald",
-    "stackSize": 64,
-    "name": "emerald"
+    "name": "emerald",
+    "stackSize": 64
   },
   {
     "id": 389,
     "displayName": "Item Frame",
-    "stackSize": 64,
-    "name": "item_frame"
+    "name": "item_frame",
+    "stackSize": 64
   },
   {
     "id": 390,
     "displayName": "Flower Pot",
+    "name": "flower_pot",
     "stackSize": 64,
-    "name": "flower_pot"
+    "variations": [
+      {
+        "metadata": 0,
+        "displayName": "Empty Flower Pot"
+      },
+      {
+        "metadata": 1,
+        "displayName": "Poppy Flower Pot"
+      },
+      {
+        "metadata": 2,
+        "displayName": "Dandelion Flower Pot"
+      },
+      {
+        "metadata": 3,
+        "displayName": "Oak sapling Flower Pot"
+      },
+      {
+        "metadata": 4,
+        "displayName": "Spruce sapling Flower Pot"
+      },
+      {
+        "metadata": 5,
+        "displayName": "Birch sapling Flower Pot"
+      },
+      {
+        "metadata": 6,
+        "displayName": "Jungle sapling Flower Pot"
+      },
+      {
+        "metadata": 7,
+        "displayName": "Red mushroom Flower Pot"
+      },
+      {
+        "metadata": 8,
+        "displayName": "Brown mushroom Flower Pot"
+      },
+      {
+        "metadata": 9,
+        "displayName": "Cactus Flower Pot"
+      },
+      {
+        "metadata": 10,
+        "displayName": "Dead bush Flower Pot"
+      },
+      {
+        "metadata": 11,
+        "displayName": "Fern Flower Pot"
+      },
+      {
+        "metadata": 12,
+        "displayName": "Acacia sapling Flower Pot"
+      },
+      {
+        "metadata": 13,
+        "displayName": "Dark oak sapling Flower Pot"
+      }
+    ]
   },
   {
     "id": 391,
     "displayName": "Carrot",
-    "stackSize": 64,
-    "name": "carrot"
+    "name": "carrot",
+    "stackSize": 64
   },
   {
     "id": 392,
     "displayName": "Potato",
-    "stackSize": 64,
-    "name": "potato"
+    "name": "potato",
+    "stackSize": 64
   },
   {
     "id": 393,
     "displayName": "Baked Potato",
-    "stackSize": 64,
-    "name": "baked_potato"
+    "name": "baked_potato",
+    "stackSize": 64
   },
   {
     "id": 394,
     "displayName": "Poisonous Potato",
-    "stackSize": 64,
-    "name": "poisonous_potato"
+    "name": "poisonous_potato",
+    "stackSize": 64
   },
   {
     "id": 395,
     "displayName": "Empty Map",
-    "stackSize": 64,
-    "name": "map"
+    "name": "map",
+    "stackSize": 64
   },
   {
     "id": 396,
     "displayName": "Golden Carrot",
-    "stackSize": 64,
-    "name": "golden_carrot"
+    "name": "golden_carrot",
+    "stackSize": 64
   },
   {
     "id": 397,
-    "displayName": "Mob head",
-    "stackSize": 64,
+    "displayName": "Skull",
     "name": "skull",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2454,240 +2326,186 @@
   {
     "id": 398,
     "displayName": "Carrot on a Stick",
-    "stackSize": 1,
     "name": "carrot_on_a_stick",
+    "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 399,
     "displayName": "Nether Star",
-    "stackSize": 64,
-    "name": "nether_star"
+    "name": "nether_star",
+    "stackSize": 64
   },
   {
     "id": 400,
     "displayName": "Pumpkin Pie",
-    "stackSize": 64,
-    "name": "pumpkin_pie"
+    "name": "pumpkin_pie",
+    "stackSize": 64
   },
   {
     "id": 401,
     "displayName": "Firework Rocket",
-    "stackSize": 64,
-    "name": "fireworks"
+    "name": "fireworks",
+    "stackSize": 64
   },
   {
     "id": 402,
     "displayName": "Firework Star",
-    "stackSize": 64,
-    "name": "firework_charge"
+    "name": "firework_charge",
+    "stackSize": 64
   },
   {
     "id": 403,
     "displayName": "Enchanted Book",
-    "stackSize": 1,
-    "name": "enchanted_book"
+    "name": "enchanted_book",
+    "stackSize": 1
   },
   {
     "id": 404,
     "displayName": "Redstone Comparator",
-    "stackSize": 64,
-    "name": "comparator"
+    "name": "comparator",
+    "stackSize": 64
   },
   {
     "id": 405,
     "displayName": "Nether Brick",
-    "stackSize": 64,
-    "name": "netherbrick"
+    "name": "netherbrick",
+    "stackSize": 64
   },
   {
     "id": 406,
     "displayName": "Nether Quartz",
-    "stackSize": 64,
-    "name": "quartz"
+    "name": "quartz",
+    "stackSize": 64
   },
   {
     "id": 407,
     "displayName": "Minecart with TNT",
-    "stackSize": 1,
-    "name": "tnt_minecart"
+    "name": "tnt_minecart",
+    "stackSize": 1
   },
   {
     "id": 408,
     "displayName": "Minecart with Hopper",
-    "stackSize": 1,
-    "name": "hopper_minecart"
-  },
-  {
-    "id": 409,
-    "displayName": "Prismarine Shard",
-    "stackSize": 64,
-    "name": "prismarine_shard"
-  },
-  {
-    "id": 410,
-    "displayName": "Prismarine Crystals",
-    "stackSize": 64,
-    "name": "prismarine_crystals"
-  },
-  {
-    "id": 411,
-    "displayName": "Raw Rabbit",
-    "stackSize": 64,
-    "name": "rabbit"
-  },
-  {
-    "id": 412,
-    "displayName": "Cooked Rabbit",
-    "stackSize": 64,
-    "name": "cooked_rabbit"
-  },
-  {
-    "id": 413,
-    "displayName": "Rabbit Stew",
-    "stackSize": 1,
-    "name": "rabbit_stew"
-  },
-  {
-    "id": 414,
-    "displayName": "Rabbit's Foot",
-    "stackSize": 64,
-    "name": "rabbit_foot"
-  },
-  {
-    "id": 415,
-    "displayName": "Rabbit Hide",
-    "stackSize": 64,
-    "name": "rabbit_hide"
+    "name": "hopper_minecart",
+    "stackSize": 1
   },
   {
     "id": 417,
     "displayName": "Iron Horse Armor",
-    "stackSize": 1,
-    "name": "iron_horse_armor"
+    "name": "iron_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 418,
-    "displayName": "Golden Horse Armor",
-    "stackSize": 1,
-    "name": "golden_horse_armor"
+    "displayName": "Gold Horse Armor",
+    "name": "golden_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 419,
     "displayName": "Diamond Horse Armor",
-    "stackSize": 1,
-    "name": "diamond_horse_armor"
+    "name": "diamond_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 420,
     "displayName": "Lead",
-    "stackSize": 64,
-    "name": "lead"
+    "name": "lead",
+    "stackSize": 64
   },
   {
     "id": 421,
     "displayName": "Name Tag",
-    "stackSize": 64,
-    "name": "name_tag"
+    "name": "name_tag",
+    "stackSize": 64
   },
   {
     "id": 422,
     "displayName": "Minecart with Command Block",
-    "stackSize": 1,
-    "name": "command_block_minecart"
-  },
-  {
-    "id": 423,
-    "displayName": "Raw Mutton",
-    "stackSize": 64,
-    "name": "mutton"
-  },
-  {
-    "id": 424,
-    "displayName": "Cooked Mutton",
-    "stackSize": 64,
-    "name": "cooked_mutton"
+    "name": "command_block_minecart",
+    "stackSize": 1
   },
   {
     "id": 425,
     "displayName": "Banner",
-    "stackSize": 16,
-    "name": "banner"
+    "name": "banner",
+    "stackSize": 16
   },
   {
     "id": 2256,
     "displayName": "13 Disc",
-    "stackSize": 1,
-    "name": "record_13"
+    "name": "record_13",
+    "stackSize": 1
   },
   {
     "id": 2257,
-    "displayName": "cat Disc",
-    "stackSize": 1,
-    "name": "record_cat"
+    "displayName": "Cat Disc",
+    "name": "record_cat",
+    "stackSize": 1
   },
   {
     "id": 2258,
-    "displayName": "blocks Disc",
-    "stackSize": 1,
-    "name": "record_blocks"
+    "displayName": "Blocks Disc",
+    "name": "record_blocks",
+    "stackSize": 1
   },
   {
     "id": 2259,
-    "displayName": "chirp Disc",
-    "stackSize": 1,
-    "name": "record_chirp"
+    "displayName": "Chirp Disc",
+    "name": "record_chirp",
+    "stackSize": 1
   },
   {
     "id": 2260,
-    "displayName": "far Disc",
-    "stackSize": 1,
-    "name": "record_far"
+    "displayName": "Far Disc",
+    "name": "record_far",
+    "stackSize": 1
   },
   {
     "id": 2261,
-    "displayName": "mall Disc",
-    "stackSize": 1,
-    "name": "record_mall"
+    "displayName": "Mall Disc",
+    "name": "record_mall",
+    "stackSize": 1
   },
   {
     "id": 2262,
-    "displayName": "mellohi Disc",
-    "stackSize": 1,
-    "name": "record_mellohi"
+    "displayName": "Mellohi Disc",
+    "name": "record_mellohi",
+    "stackSize": 1
   },
   {
     "id": 2263,
-    "displayName": "stal Disc",
-    "stackSize": 1,
-    "name": "record_stal"
+    "displayName": "Stal Disc",
+    "name": "record_stal",
+    "stackSize": 1
   },
   {
     "id": 2264,
-    "displayName": "strad Disc",
-    "stackSize": 1,
-    "name": "record_strad"
+    "displayName": "Strad Disc",
+    "name": "record_strad",
+    "stackSize": 1
   },
   {
     "id": 2265,
-    "displayName": "ward Disc",
-    "stackSize": 1,
-    "name": "record_ward"
+    "displayName": "Ward Disc",
+    "name": "record_ward",
+    "stackSize": 1
   },
   {
     "id": 2266,
     "displayName": "11 Disc",
-    "stackSize": 1,
-    "name": "record_11"
+    "name": "record_11",
+    "stackSize": 1
   },
   {
     "id": 2267,
-    "displayName": "wait Disc",
-    "stackSize": 1,
-    "name": "record_wait"
+    "displayName": "Wait Disc",
+    "name": "record_wait",
+    "stackSize": 1
   }
 ]

--- a/data/pc/1.8/items.json
+++ b/data/pc/1.8/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 64
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -31,7 +25,7 @@
   },
   {
     "id": 5,
-    "displayName": "Wood Planks",
+    "displayName": "Wooden Planks",
     "name": "planks",
     "stackSize": 64
   },
@@ -45,30 +39,6 @@
     "id": 7,
     "displayName": "Bedrock",
     "name": "bedrock",
-    "stackSize": 64
-  },
-  {
-    "id": 8,
-    "displayName": "Water",
-    "name": "flowing_water",
-    "stackSize": 64
-  },
-  {
-    "id": 9,
-    "displayName": "Stationary Water",
-    "name": "water",
-    "stackSize": 64
-  },
-  {
-    "id": 10,
-    "displayName": "Lava",
-    "name": "flowing_lava",
-    "stackSize": 64
-  },
-  {
-    "id": 11,
-    "displayName": "Stationary Lava",
-    "name": "lava",
     "stackSize": 64
   },
   {
@@ -198,21 +168,9 @@
     "stackSize": 64
   },
   {
-    "id": 34,
-    "displayName": "Piston Head",
-    "name": "piston_head",
-    "stackSize": 64
-  },
-  {
     "id": 35,
     "displayName": "Wool",
     "name": "wool",
-    "stackSize": 64
-  },
-  {
-    "id": 36,
-    "displayName": "Block moved by Piston",
-    "name": "piston_extension",
     "stackSize": 64
   },
   {
@@ -252,12 +210,6 @@
     "stackSize": 64
   },
   {
-    "id": 43,
-    "displayName": "Double Stone Slab",
-    "name": "double_stone_slab",
-    "stackSize": 64
-  },
-  {
     "id": 44,
     "displayName": "Stone Slab",
     "name": "stone_slab",
@@ -265,7 +217,7 @@
   },
   {
     "id": 45,
-    "displayName": "Bricks",
+    "displayName": "Brick",
     "name": "brick_block",
     "stackSize": 64
   },
@@ -300,12 +252,6 @@
     "stackSize": 64
   },
   {
-    "id": 51,
-    "displayName": "Fire",
-    "name": "fire",
-    "stackSize": 64
-  },
-  {
     "id": 52,
     "displayName": "Monster Spawner",
     "name": "mob_spawner",
@@ -321,12 +267,6 @@
     "id": 54,
     "displayName": "Chest",
     "name": "chest",
-    "stackSize": 64
-  },
-  {
-    "id": 55,
-    "displayName": "Redstone Wire",
-    "name": "redstone_wire",
     "stackSize": 64
   },
   {
@@ -360,18 +300,6 @@
     "stackSize": 64
   },
   {
-    "id": 62,
-    "displayName": "Burning Furnace",
-    "name": "lit_furnace",
-    "stackSize": 64
-  },
-  {
-    "id": 63,
-    "displayName": "Standing Sign",
-    "name": "standing_sign",
-    "stackSize": 64
-  },
-  {
     "id": 65,
     "displayName": "Ladder",
     "name": "ladder",
@@ -387,12 +315,6 @@
     "id": 67,
     "displayName": "Cobblestone Stairs",
     "name": "stone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 68,
-    "displayName": "Wall Sign",
-    "name": "wall_sign",
     "stackSize": 64
   },
   {
@@ -420,20 +342,8 @@
     "stackSize": 64
   },
   {
-    "id": 74,
-    "displayName": "Glowing Redstone Ore",
-    "name": "lit_redstone_ore",
-    "stackSize": 64
-  },
-  {
-    "id": 75,
-    "displayName": "Redstone Torch (inactive)",
-    "name": "unlit_redstone_torch",
-    "stackSize": 64
-  },
-  {
     "id": 76,
-    "displayName": "Redstone Torch (active)",
+    "displayName": "Redstone Torch",
     "name": "redstone_torch",
     "stackSize": 64
   },
@@ -445,7 +355,7 @@
   },
   {
     "id": 78,
-    "displayName": "Snow (layer)",
+    "displayName": "Snow",
     "name": "snow_layer",
     "stackSize": 64
   },
@@ -481,7 +391,7 @@
   },
   {
     "id": 85,
-    "displayName": "Fence",
+    "displayName": "Oak Fence",
     "name": "fence",
     "stackSize": 64
   },
@@ -510,27 +420,9 @@
     "stackSize": 64
   },
   {
-    "id": 90,
-    "displayName": "Nether Portal",
-    "name": "portal",
-    "stackSize": 64
-  },
-  {
     "id": 91,
     "displayName": "Jack o'Lantern",
     "name": "lit_pumpkin",
-    "stackSize": 64
-  },
-  {
-    "id": 93,
-    "displayName": "Redstone Repeater (inactive)",
-    "name": "unpowered_repeater",
-    "stackSize": 64
-  },
-  {
-    "id": 94,
-    "displayName": "Redstone Repeater (active)",
-    "name": "powered_repeater",
     "stackSize": 64
   },
   {
@@ -541,7 +433,7 @@
   },
   {
     "id": 96,
-    "displayName": "Trapdoor",
+    "displayName": "Wooden Trapdoor",
     "name": "trapdoor",
     "stackSize": 64
   },
@@ -559,13 +451,13 @@
   },
   {
     "id": 99,
-    "displayName": "Brown Mushroom (block)",
+    "displayName": "Brown Mushroom Block",
     "name": "brown_mushroom_block",
     "stackSize": 64
   },
   {
     "id": 100,
-    "displayName": "Red Mushroom (block)",
+    "displayName": "Red Mushroom Block",
     "name": "red_mushroom_block",
     "stackSize": 64
   },
@@ -588,18 +480,6 @@
     "stackSize": 64
   },
   {
-    "id": 104,
-    "displayName": "Pumpkin Stem",
-    "name": "pumpkin_stem",
-    "stackSize": 64
-  },
-  {
-    "id": 105,
-    "displayName": "Melon Stem",
-    "name": "melon_stem",
-    "stackSize": 64
-  },
-  {
     "id": 106,
     "displayName": "Vines",
     "name": "vine",
@@ -607,7 +487,7 @@
   },
   {
     "id": 107,
-    "displayName": "Fence Gate",
+    "displayName": "Oak Fence Gate",
     "name": "fence_gate",
     "stackSize": 64
   },
@@ -660,14 +540,8 @@
     "stackSize": 64
   },
   {
-    "id": 119,
-    "displayName": "End Portal",
-    "name": "end_portal",
-    "stackSize": 64
-  },
-  {
     "id": 120,
-    "displayName": "End Portal Block",
+    "displayName": "End Portal Frame",
     "name": "end_portal_frame",
     "stackSize": 64
   },
@@ -685,32 +559,14 @@
   },
   {
     "id": 123,
-    "displayName": "Redstone Lamp (inactive)",
+    "displayName": "Redstone Lamp",
     "name": "redstone_lamp",
     "stackSize": 64
   },
   {
-    "id": 124,
-    "displayName": "Redstone Lamp (active)",
-    "name": "lit_redstone_lamp",
-    "stackSize": 64
-  },
-  {
-    "id": 125,
-    "displayName": "Double Wooden Slab",
-    "name": "double_wooden_slab",
-    "stackSize": 64
-  },
-  {
     "id": 126,
-    "displayName": "Wooden Slab",
+    "displayName": "Wood Slab",
     "name": "wooden_slab",
-    "stackSize": 64
-  },
-  {
-    "id": 127,
-    "displayName": "Cocoa",
-    "name": "cocoa",
     "stackSize": 64
   },
   {
@@ -735,12 +591,6 @@
     "id": 131,
     "displayName": "Tripwire Hook",
     "name": "tripwire_hook",
-    "stackSize": 64
-  },
-  {
-    "id": 132,
-    "displayName": "Tripwire",
-    "name": "tripwire",
     "stackSize": 64
   },
   {
@@ -786,18 +636,6 @@
     "stackSize": 64
   },
   {
-    "id": 141,
-    "displayName": "Carrot",
-    "name": "carrots",
-    "stackSize": 64
-  },
-  {
-    "id": 142,
-    "displayName": "Potato",
-    "name": "potatoes",
-    "stackSize": 64
-  },
-  {
     "id": 143,
     "displayName": "Wooden Button",
     "name": "wooden_button",
@@ -828,20 +666,8 @@
     "stackSize": 64
   },
   {
-    "id": 149,
-    "displayName": "Redstone Comparator",
-    "name": "unpowered_comparator",
-    "stackSize": 64
-  },
-  {
-    "id": 150,
-    "displayName": "Redstone Comparator (deprecated)",
-    "name": "powered_comparator",
-    "stackSize": 64
-  },
-  {
     "id": 151,
-    "displayName": "Daylight Sensor",
+    "displayName": "Daylight Detector",
     "name": "daylight_detector",
     "stackSize": 64
   },
@@ -853,7 +679,7 @@
   },
   {
     "id": 153,
-    "displayName": "Nether Quartz Ore",
+    "displayName": "Nether Quartz",
     "name": "quartz_ore",
     "stackSize": 64
   },
@@ -901,13 +727,13 @@
   },
   {
     "id": 161,
-    "displayName": "Leaves (Acacia/Dark Oak)",
+    "displayName": "Leaves",
     "name": "leaves2",
     "stackSize": 64
   },
   {
     "id": 162,
-    "displayName": "Wood (Acacia/Dark Oak)",
+    "displayName": "Wood",
     "name": "log2",
     "stackSize": 64
   },
@@ -990,24 +816,6 @@
     "stackSize": 64
   },
   {
-    "id": 176,
-    "displayName": "Standing Banner",
-    "name": "standing_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 177,
-    "displayName": "Wall Banner",
-    "name": "wall_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 178,
-    "displayName": "Inverted Daylight Sensor",
-    "name": "daylight_detector_inverted",
-    "stackSize": 64
-  },
-  {
     "id": 179,
     "displayName": "Red Sandstone",
     "name": "red_sandstone",
@@ -1017,12 +825,6 @@
     "id": 180,
     "displayName": "Red Sandstone Stairs",
     "name": "red_sandstone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 181,
-    "displayName": "Double Red Sandstone Slab",
-    "name": "double_stone_slab2",
     "stackSize": 64
   },
   {
@@ -1094,8 +896,9 @@
   {
     "id": 256,
     "displayName": "Iron Shovel",
-    "stackSize": 1,
     "name": "iron_shovel",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1103,14 +906,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 257,
     "displayName": "Iron Pickaxe",
-    "stackSize": 1,
     "name": "iron_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1118,14 +921,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 258,
     "displayName": "Iron Axe",
-    "stackSize": 1,
     "name": "iron_axe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1133,49 +936,48 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 259,
     "displayName": "Flint and Steel",
-    "stackSize": 1,
     "name": "flint_and_steel",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 260,
     "displayName": "Apple",
-    "stackSize": 64,
-    "name": "apple"
+    "name": "apple",
+    "stackSize": 64
   },
   {
     "id": 261,
     "displayName": "Bow",
-    "stackSize": 1,
     "name": "bow",
+    "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 262,
     "displayName": "Arrow",
-    "stackSize": 64,
-    "name": "arrow"
+    "name": "arrow",
+    "stackSize": 64
   },
   {
     "id": 263,
     "displayName": "Coal",
-    "stackSize": 64,
     "name": "coal",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -1190,26 +992,27 @@
   {
     "id": 264,
     "displayName": "Diamond",
-    "stackSize": 64,
-    "name": "diamond"
+    "name": "diamond",
+    "stackSize": 64
   },
   {
     "id": 265,
     "displayName": "Iron Ingot",
-    "stackSize": 64,
-    "name": "iron_ingot"
+    "name": "iron_ingot",
+    "stackSize": 64
   },
   {
     "id": 266,
     "displayName": "Gold Ingot",
-    "stackSize": 64,
-    "name": "gold_ingot"
+    "name": "gold_ingot",
+    "stackSize": 64
   },
   {
     "id": 267,
     "displayName": "Iron Sword",
-    "stackSize": 1,
     "name": "iron_sword",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1217,14 +1020,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 268,
     "displayName": "Wooden Sword",
-    "stackSize": 1,
     "name": "wooden_sword",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1239,14 +1042,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 269,
     "displayName": "Wooden Shovel",
-    "stackSize": 1,
     "name": "wooden_shovel",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1261,14 +1064,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 270,
     "displayName": "Wooden Pickaxe",
-    "stackSize": 1,
     "name": "wooden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1283,14 +1086,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 271,
     "displayName": "Wooden Axe",
-    "stackSize": 1,
     "name": "wooden_axe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1305,14 +1108,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 272,
     "displayName": "Stone Sword",
-    "stackSize": 1,
     "name": "stone_sword",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1321,14 +1124,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 273,
     "displayName": "Stone Shovel",
-    "stackSize": 1,
     "name": "stone_shovel",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1337,14 +1140,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 274,
     "displayName": "Stone Pickaxe",
-    "stackSize": 1,
     "name": "stone_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1353,14 +1156,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 275,
     "displayName": "Stone Axe",
-    "stackSize": 1,
     "name": "stone_axe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1369,14 +1172,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 276,
     "displayName": "Diamond Sword",
-    "stackSize": 1,
     "name": "diamond_sword",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1384,14 +1187,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 277,
     "displayName": "Diamond Shovel",
-    "stackSize": 1,
     "name": "diamond_shovel",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1399,14 +1202,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 278,
     "displayName": "Diamond Pickaxe",
-    "stackSize": 1,
     "name": "diamond_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1414,14 +1217,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 279,
     "displayName": "Diamond Axe",
-    "stackSize": 1,
     "name": "diamond_axe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1429,32 +1232,32 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 280,
     "displayName": "Stick",
-    "stackSize": 64,
-    "name": "stick"
+    "name": "stick",
+    "stackSize": 64
   },
   {
     "id": 281,
     "displayName": "Bowl",
-    "stackSize": 64,
-    "name": "bowl"
+    "name": "bowl",
+    "stackSize": 64
   },
   {
     "id": 282,
     "displayName": "Mushroom Stew",
-    "stackSize": 1,
-    "name": "mushroom_stew"
+    "name": "mushroom_stew",
+    "stackSize": 1
   },
   {
     "id": 283,
     "displayName": "Golden Sword",
-    "stackSize": 1,
     "name": "golden_sword",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1462,14 +1265,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 284,
     "displayName": "Golden Shovel",
-    "stackSize": 1,
     "name": "golden_shovel",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1477,14 +1280,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 285,
     "displayName": "Golden Pickaxe",
-    "stackSize": 1,
     "name": "golden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1492,14 +1295,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 286,
     "displayName": "Golden Axe",
-    "stackSize": 1,
     "name": "golden_axe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1507,32 +1310,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 287,
     "displayName": "String",
-    "stackSize": 64,
-    "name": "string"
+    "name": "string",
+    "stackSize": 64
   },
   {
     "id": 288,
     "displayName": "Feather",
-    "stackSize": 64,
-    "name": "feather"
+    "name": "feather",
+    "stackSize": 64
   },
   {
     "id": 289,
     "displayName": "Gunpowder",
-    "stackSize": 64,
-    "name": "gunpowder"
+    "name": "gunpowder",
+    "stackSize": 64
   },
   {
     "id": 290,
     "displayName": "Wooden Hoe",
-    "stackSize": 1,
     "name": "wooden_hoe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1547,14 +1350,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 291,
     "displayName": "Stone Hoe",
-    "stackSize": 1,
     "name": "stone_hoe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1563,14 +1366,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 292,
     "displayName": "Iron Hoe",
-    "stackSize": 1,
     "name": "iron_hoe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1578,14 +1381,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 293,
     "displayName": "Diamond Hoe",
-    "stackSize": 1,
     "name": "diamond_hoe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1593,14 +1396,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 294,
     "displayName": "Golden Hoe",
-    "stackSize": 1,
     "name": "golden_hoe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1608,32 +1411,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 295,
     "displayName": "Seeds",
-    "stackSize": 64,
-    "name": "wheat_seeds"
+    "name": "wheat_seeds",
+    "stackSize": 64
   },
   {
     "id": 296,
     "displayName": "Wheat",
-    "stackSize": 64,
-    "name": "wheat"
+    "name": "wheat",
+    "stackSize": 64
   },
   {
     "id": 297,
     "displayName": "Bread",
-    "stackSize": 64,
-    "name": "bread"
+    "name": "bread",
+    "stackSize": 64
   },
   {
     "id": 298,
     "displayName": "Leather Cap",
-    "stackSize": 1,
     "name": "leather_helmet",
+    "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1643,14 +1446,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 299,
     "displayName": "Leather Tunic",
-    "stackSize": 1,
     "name": "leather_chestplate",
+    "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1660,14 +1463,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 300,
     "displayName": "Leather Pants",
-    "stackSize": 1,
     "name": "leather_leggings",
+    "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1676,14 +1479,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 301,
     "displayName": "Leather Boots",
-    "stackSize": 1,
     "name": "leather_boots",
+    "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1693,14 +1496,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 302,
     "displayName": "Chain Helmet",
-    "stackSize": 1,
     "name": "chainmail_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1710,14 +1513,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 303,
     "displayName": "Chain Chestplate",
-    "stackSize": 1,
     "name": "chainmail_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1727,14 +1530,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 304,
     "displayName": "Chain Leggings",
-    "stackSize": 1,
     "name": "chainmail_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1743,14 +1546,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 305,
     "displayName": "Chain Boots",
-    "stackSize": 1,
     "name": "chainmail_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1760,14 +1563,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 306,
     "displayName": "Iron Helmet",
-    "stackSize": 1,
     "name": "iron_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1777,14 +1580,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 307,
     "displayName": "Iron Chestplate",
-    "stackSize": 1,
     "name": "iron_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1794,14 +1597,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 308,
     "displayName": "Iron Leggings",
-    "stackSize": 1,
     "name": "iron_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1810,14 +1613,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 309,
     "displayName": "Iron Boots",
-    "stackSize": 1,
     "name": "iron_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1827,14 +1630,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 310,
     "displayName": "Diamond Helmet",
-    "stackSize": 1,
     "name": "diamond_helmet",
+    "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1844,14 +1647,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 311,
     "displayName": "Diamond Chestplate",
-    "stackSize": 1,
     "name": "diamond_chestplate",
+    "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1861,14 +1664,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 312,
     "displayName": "Diamond Leggings",
-    "stackSize": 1,
     "name": "diamond_leggings",
+    "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1877,14 +1680,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 313,
     "displayName": "Diamond Boots",
-    "stackSize": 1,
     "name": "diamond_boots",
+    "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1894,14 +1697,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 314,
     "displayName": "Golden Helmet",
-    "stackSize": 1,
     "name": "golden_helmet",
+    "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1911,14 +1714,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 315,
     "displayName": "Golden Chestplate",
-    "stackSize": 1,
     "name": "golden_chestplate",
+    "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1928,14 +1731,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 316,
     "displayName": "Golden Leggings",
-    "stackSize": 1,
     "name": "golden_leggings",
+    "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1944,14 +1747,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 317,
     "displayName": "Golden Boots",
-    "stackSize": 1,
     "name": "golden_boots",
+    "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1961,38 +1764,37 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 318,
     "displayName": "Flint",
-    "stackSize": 64,
-    "name": "flint"
+    "name": "flint",
+    "stackSize": 64
   },
   {
     "id": 319,
     "displayName": "Raw Porkchop",
-    "stackSize": 64,
-    "name": "porkchop"
+    "name": "porkchop",
+    "stackSize": 64
   },
   {
     "id": 320,
     "displayName": "Cooked Porkchop",
-    "stackSize": 64,
-    "name": "cooked_porkchop"
+    "name": "cooked_porkchop",
+    "stackSize": 64
   },
   {
     "id": 321,
     "displayName": "Painting",
-    "stackSize": 64,
-    "name": "painting"
+    "name": "painting",
+    "stackSize": 64
   },
   {
     "id": 322,
     "displayName": "Golden Apple",
-    "stackSize": 64,
     "name": "golden_apple",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2007,170 +1809,170 @@
   {
     "id": 323,
     "displayName": "Sign",
-    "stackSize": 16,
-    "name": "sign"
+    "name": "sign",
+    "stackSize": 16
   },
   {
     "id": 324,
     "displayName": "Oak Door",
-    "stackSize": 64,
-    "name": "wooden_door"
+    "name": "wooden_door",
+    "stackSize": 64
   },
   {
     "id": 325,
     "displayName": "Bucket",
-    "stackSize": 16,
-    "name": "bucket"
+    "name": "bucket",
+    "stackSize": 16
   },
   {
     "id": 326,
     "displayName": "Water Bucket",
-    "stackSize": 64,
-    "name": "water_bucket"
+    "name": "water_bucket",
+    "stackSize": 1
   },
   {
     "id": 327,
     "displayName": "Lava Bucket",
-    "stackSize": 64,
-    "name": "lava_bucket"
+    "name": "lava_bucket",
+    "stackSize": 1
   },
   {
     "id": 328,
     "displayName": "Minecart",
-    "stackSize": 1,
-    "name": "minecart"
+    "name": "minecart",
+    "stackSize": 1
   },
   {
     "id": 329,
     "displayName": "Saddle",
-    "stackSize": 1,
-    "name": "saddle"
+    "name": "saddle",
+    "stackSize": 1
   },
   {
     "id": 330,
     "displayName": "Iron Door",
-    "stackSize": 64,
-    "name": "iron_door"
+    "name": "iron_door",
+    "stackSize": 64
   },
   {
     "id": 331,
     "displayName": "Redstone",
-    "stackSize": 64,
-    "name": "redstone"
+    "name": "redstone",
+    "stackSize": 64
   },
   {
     "id": 332,
     "displayName": "Snowball",
-    "stackSize": 16,
-    "name": "snowball"
+    "name": "snowball",
+    "stackSize": 16
   },
   {
     "id": 333,
     "displayName": "Boat",
-    "stackSize": 1,
-    "name": "boat"
+    "name": "boat",
+    "stackSize": 1
   },
   {
     "id": 334,
     "displayName": "Leather",
-    "stackSize": 64,
-    "name": "leather"
+    "name": "leather",
+    "stackSize": 64
   },
   {
     "id": 335,
     "displayName": "Milk",
-    "stackSize": 1,
-    "name": "milk_bucket"
+    "name": "milk_bucket",
+    "stackSize": 1
   },
   {
     "id": 336,
     "displayName": "Brick",
-    "stackSize": 64,
-    "name": "brick"
+    "name": "brick",
+    "stackSize": 64
   },
   {
     "id": 337,
     "displayName": "Clay",
-    "stackSize": 64,
-    "name": "clay_ball"
+    "name": "clay_ball",
+    "stackSize": 64
   },
   {
     "id": 338,
-    "displayName": "Sugar Cane",
-    "stackSize": 64,
-    "name": "reeds"
+    "displayName": "Sugar Canes",
+    "name": "reeds",
+    "stackSize": 64
   },
   {
     "id": 339,
     "displayName": "Paper",
-    "stackSize": 64,
-    "name": "paper"
+    "name": "paper",
+    "stackSize": 64
   },
   {
     "id": 340,
     "displayName": "Book",
-    "stackSize": 64,
-    "name": "book"
+    "name": "book",
+    "stackSize": 64
   },
   {
     "id": 341,
     "displayName": "Slimeball",
-    "stackSize": 64,
-    "name": "slime_ball"
+    "name": "slime_ball",
+    "stackSize": 64
   },
   {
     "id": 342,
     "displayName": "Minecart with Chest",
-    "stackSize": 1,
-    "name": "chest_minecart"
+    "name": "chest_minecart",
+    "stackSize": 1
   },
   {
     "id": 343,
     "displayName": "Minecart with Furnace",
-    "stackSize": 1,
-    "name": "furnace_minecart"
+    "name": "furnace_minecart",
+    "stackSize": 1
   },
   {
     "id": 344,
     "displayName": "Egg",
-    "stackSize": 16,
-    "name": "egg"
+    "name": "egg",
+    "stackSize": 16
   },
   {
     "id": 345,
     "displayName": "Compass",
-    "stackSize": 64,
-    "name": "compass"
+    "name": "compass",
+    "stackSize": 64
   },
   {
     "id": 346,
     "displayName": "Fishing Rod",
-    "stackSize": 1,
     "name": "fishing_rod",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 347,
     "displayName": "Clock",
-    "stackSize": 64,
-    "name": "clock"
+    "name": "clock",
+    "stackSize": 64
   },
   {
     "id": 348,
     "displayName": "Glowstone Dust",
-    "stackSize": 64,
-    "name": "glowstone_dust"
+    "name": "glowstone_dust",
+    "stackSize": 64
   },
   {
     "id": 349,
-    "displayName": "Raw Fish",
-    "stackSize": 64,
+    "displayName": "Fish",
     "name": "fish",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2193,14 +1995,14 @@
   {
     "id": 350,
     "displayName": "Cooked Fish",
-    "stackSize": 64,
-    "name": "cooked_fish"
+    "name": "cooked_fish",
+    "stackSize": 64
   },
   {
     "id": 351,
     "displayName": "Dye",
-    "stackSize": 64,
     "name": "dye",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2271,241 +2073,241 @@
   {
     "id": 352,
     "displayName": "Bone",
-    "stackSize": 64,
-    "name": "bone"
+    "name": "bone",
+    "stackSize": 64
   },
   {
     "id": 353,
     "displayName": "Sugar",
-    "stackSize": 64,
-    "name": "sugar"
+    "name": "sugar",
+    "stackSize": 64
   },
   {
     "id": 354,
     "displayName": "Cake",
-    "stackSize": 1,
-    "name": "cake"
+    "name": "cake",
+    "stackSize": 1
   },
   {
     "id": 355,
     "displayName": "Bed",
-    "stackSize": 1,
-    "name": "bed"
+    "name": "bed",
+    "stackSize": 1
   },
   {
     "id": 356,
     "displayName": "Redstone Repeater",
-    "stackSize": 64,
-    "name": "repeater"
+    "name": "repeater",
+    "stackSize": 64
   },
   {
     "id": 357,
     "displayName": "Cookie",
-    "stackSize": 64,
-    "name": "cookie"
+    "name": "cookie",
+    "stackSize": 64
   },
   {
     "id": 358,
     "displayName": "Map",
-    "stackSize": 64,
-    "name": "filled_map"
+    "name": "filled_map",
+    "stackSize": 64
   },
   {
     "id": 359,
     "displayName": "Shears",
-    "stackSize": 1,
     "name": "shears",
+    "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 360,
     "displayName": "Melon",
-    "stackSize": 64,
-    "name": "melon"
+    "name": "melon",
+    "stackSize": 64
   },
   {
     "id": 361,
     "displayName": "Pumpkin Seeds",
-    "stackSize": 64,
-    "name": "pumpkin_seeds"
+    "name": "pumpkin_seeds",
+    "stackSize": 64
   },
   {
     "id": 362,
     "displayName": "Melon Seeds",
-    "stackSize": 64,
-    "name": "melon_seeds"
+    "name": "melon_seeds",
+    "stackSize": 64
   },
   {
     "id": 363,
     "displayName": "Raw Beef",
-    "stackSize": 64,
-    "name": "beef"
+    "name": "beef",
+    "stackSize": 64
   },
   {
     "id": 364,
     "displayName": "Steak",
-    "stackSize": 64,
-    "name": "cooked_beef"
+    "name": "cooked_beef",
+    "stackSize": 64
   },
   {
     "id": 365,
     "displayName": "Raw Chicken",
-    "stackSize": 64,
-    "name": "chicken"
+    "name": "chicken",
+    "stackSize": 64
   },
   {
     "id": 366,
     "displayName": "Cooked Chicken",
-    "stackSize": 64,
-    "name": "cooked_chicken"
+    "name": "cooked_chicken",
+    "stackSize": 64
   },
   {
     "id": 367,
     "displayName": "Rotten Flesh",
-    "stackSize": 64,
-    "name": "rotten_flesh"
+    "name": "rotten_flesh",
+    "stackSize": 64
   },
   {
     "id": 368,
     "displayName": "Ender Pearl",
-    "stackSize": 16,
-    "name": "ender_pearl"
+    "name": "ender_pearl",
+    "stackSize": 16
   },
   {
     "id": 369,
     "displayName": "Blaze Rod",
-    "stackSize": 64,
-    "name": "blaze_rod"
+    "name": "blaze_rod",
+    "stackSize": 64
   },
   {
     "id": 370,
     "displayName": "Ghast Tear",
-    "stackSize": 64,
-    "name": "ghast_tear"
+    "name": "ghast_tear",
+    "stackSize": 64
   },
   {
     "id": 371,
     "displayName": "Gold Nugget",
-    "stackSize": 64,
-    "name": "gold_nugget"
+    "name": "gold_nugget",
+    "stackSize": 64
   },
   {
     "id": 372,
     "displayName": "Nether Wart",
-    "stackSize": 64,
-    "name": "nether_wart"
+    "name": "nether_wart",
+    "stackSize": 64
   },
   {
     "id": 373,
     "displayName": "Potion",
-    "stackSize": 1,
-    "name": "potion"
+    "name": "potion",
+    "stackSize": 1
   },
   {
     "id": 374,
     "displayName": "Glass Bottle",
-    "stackSize": 64,
-    "name": "glass_bottle"
+    "name": "glass_bottle",
+    "stackSize": 64
   },
   {
     "id": 375,
     "displayName": "Spider Eye",
-    "stackSize": 64,
-    "name": "spider_eye"
+    "name": "spider_eye",
+    "stackSize": 64
   },
   {
     "id": 376,
     "displayName": "Fermented Spider Eye",
-    "stackSize": 64,
-    "name": "fermented_spider_eye"
+    "name": "fermented_spider_eye",
+    "stackSize": 64
   },
   {
     "id": 377,
     "displayName": "Blaze Powder",
-    "stackSize": 64,
-    "name": "blaze_powder"
+    "name": "blaze_powder",
+    "stackSize": 64
   },
   {
     "id": 378,
     "displayName": "Magma Cream",
-    "stackSize": 64,
-    "name": "magma_cream"
+    "name": "magma_cream",
+    "stackSize": 64
   },
   {
     "id": 379,
     "displayName": "Brewing Stand",
-    "stackSize": 64,
-    "name": "brewing_stand"
+    "name": "brewing_stand",
+    "stackSize": 64
   },
   {
     "id": 380,
     "displayName": "Cauldron",
-    "stackSize": 64,
-    "name": "cauldron"
+    "name": "cauldron",
+    "stackSize": 64
   },
   {
     "id": 381,
     "displayName": "Eye of Ender",
-    "stackSize": 64,
-    "name": "ender_eye"
+    "name": "ender_eye",
+    "stackSize": 64
   },
   {
     "id": 382,
     "displayName": "Glistering Melon",
-    "stackSize": 64,
-    "name": "speckled_melon"
+    "name": "speckled_melon",
+    "stackSize": 64
   },
   {
     "id": 383,
     "displayName": "Spawn Egg",
-    "stackSize": 64,
-    "name": "spawn_egg"
+    "name": "spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 384,
     "displayName": "Bottle o' Enchanting",
-    "stackSize": 64,
-    "name": "experience_bottle"
+    "name": "experience_bottle",
+    "stackSize": 64
   },
   {
     "id": 385,
     "displayName": "Fire Charge",
-    "stackSize": 64,
-    "name": "fire_charge"
+    "name": "fire_charge",
+    "stackSize": 64
   },
   {
     "id": 386,
     "displayName": "Book and Quill",
-    "stackSize": 1,
-    "name": "writable_book"
+    "name": "writable_book",
+    "stackSize": 1
   },
   {
     "id": 387,
     "displayName": "Written Book",
-    "stackSize": 16,
-    "name": "written_book"
+    "name": "written_book",
+    "stackSize": 16
   },
   {
     "id": 388,
     "displayName": "Emerald",
-    "stackSize": 64,
-    "name": "emerald"
+    "name": "emerald",
+    "stackSize": 64
   },
   {
     "id": 389,
     "displayName": "Item Frame",
-    "stackSize": 64,
-    "name": "item_frame"
+    "name": "item_frame",
+    "stackSize": 64
   },
   {
     "id": 390,
     "displayName": "Flower Pot",
-    "stackSize": 64,
     "name": "flower_pot",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2568,44 +2370,44 @@
   {
     "id": 391,
     "displayName": "Carrot",
-    "stackSize": 64,
-    "name": "carrot"
+    "name": "carrot",
+    "stackSize": 64
   },
   {
     "id": 392,
     "displayName": "Potato",
-    "stackSize": 64,
-    "name": "potato"
+    "name": "potato",
+    "stackSize": 64
   },
   {
     "id": 393,
     "displayName": "Baked Potato",
-    "stackSize": 64,
-    "name": "baked_potato"
+    "name": "baked_potato",
+    "stackSize": 64
   },
   {
     "id": 394,
     "displayName": "Poisonous Potato",
-    "stackSize": 64,
-    "name": "poisonous_potato"
+    "name": "poisonous_potato",
+    "stackSize": 64
   },
   {
     "id": 395,
     "displayName": "Empty Map",
-    "stackSize": 64,
-    "name": "map"
+    "name": "map",
+    "stackSize": 64
   },
   {
     "id": 396,
     "displayName": "Golden Carrot",
-    "stackSize": 64,
-    "name": "golden_carrot"
+    "name": "golden_carrot",
+    "stackSize": 64
   },
   {
     "id": 397,
-    "displayName": "Mob head",
-    "stackSize": 64,
+    "displayName": "Skull",
     "name": "skull",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2632,276 +2434,276 @@
   {
     "id": 398,
     "displayName": "Carrot on a Stick",
-    "stackSize": 1,
     "name": "carrot_on_a_stick",
+    "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 399,
     "displayName": "Nether Star",
-    "stackSize": 64,
-    "name": "nether_star"
+    "name": "nether_star",
+    "stackSize": 64
   },
   {
     "id": 400,
     "displayName": "Pumpkin Pie",
-    "stackSize": 64,
-    "name": "pumpkin_pie"
+    "name": "pumpkin_pie",
+    "stackSize": 64
   },
   {
     "id": 401,
     "displayName": "Firework Rocket",
-    "stackSize": 64,
-    "name": "fireworks"
+    "name": "fireworks",
+    "stackSize": 64
   },
   {
     "id": 402,
     "displayName": "Firework Star",
-    "stackSize": 64,
-    "name": "firework_charge"
+    "name": "firework_charge",
+    "stackSize": 64
   },
   {
     "id": 403,
     "displayName": "Enchanted Book",
-    "stackSize": 1,
-    "name": "enchanted_book"
+    "name": "enchanted_book",
+    "stackSize": 1
   },
   {
     "id": 404,
     "displayName": "Redstone Comparator",
-    "stackSize": 64,
-    "name": "comparator"
+    "name": "comparator",
+    "stackSize": 64
   },
   {
     "id": 405,
     "displayName": "Nether Brick",
-    "stackSize": 64,
-    "name": "netherbrick"
+    "name": "netherbrick",
+    "stackSize": 64
   },
   {
     "id": 406,
     "displayName": "Nether Quartz",
-    "stackSize": 64,
-    "name": "quartz"
+    "name": "quartz",
+    "stackSize": 64
   },
   {
     "id": 407,
     "displayName": "Minecart with TNT",
-    "stackSize": 1,
-    "name": "tnt_minecart"
+    "name": "tnt_minecart",
+    "stackSize": 1
   },
   {
     "id": 408,
     "displayName": "Minecart with Hopper",
-    "stackSize": 1,
-    "name": "hopper_minecart"
+    "name": "hopper_minecart",
+    "stackSize": 1
   },
   {
     "id": 409,
     "displayName": "Prismarine Shard",
-    "stackSize": 64,
-    "name": "prismarine_shard"
+    "name": "prismarine_shard",
+    "stackSize": 64
   },
   {
     "id": 410,
     "displayName": "Prismarine Crystals",
-    "stackSize": 64,
-    "name": "prismarine_crystals"
+    "name": "prismarine_crystals",
+    "stackSize": 64
   },
   {
     "id": 411,
     "displayName": "Raw Rabbit",
-    "stackSize": 64,
-    "name": "rabbit"
+    "name": "rabbit",
+    "stackSize": 64
   },
   {
     "id": 412,
     "displayName": "Cooked Rabbit",
-    "stackSize": 64,
-    "name": "cooked_rabbit"
+    "name": "cooked_rabbit",
+    "stackSize": 64
   },
   {
     "id": 413,
     "displayName": "Rabbit Stew",
-    "stackSize": 1,
-    "name": "rabbit_stew"
+    "name": "rabbit_stew",
+    "stackSize": 1
   },
   {
     "id": 414,
     "displayName": "Rabbit's Foot",
-    "stackSize": 64,
-    "name": "rabbit_foot"
+    "name": "rabbit_foot",
+    "stackSize": 64
   },
   {
     "id": 415,
     "displayName": "Rabbit Hide",
-    "stackSize": 64,
-    "name": "rabbit_hide"
+    "name": "rabbit_hide",
+    "stackSize": 64
   },
   {
     "id": 416,
     "displayName": "Armor Stand",
-    "stackSize": 16,
-    "name": "armor_stand"
+    "name": "armor_stand",
+    "stackSize": 16
   },
   {
     "id": 417,
     "displayName": "Iron Horse Armor",
-    "stackSize": 1,
-    "name": "iron_horse_armor"
+    "name": "iron_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 418,
-    "displayName": "Golden Horse Armor",
-    "stackSize": 1,
-    "name": "golden_horse_armor"
+    "displayName": "Gold Horse Armor",
+    "name": "golden_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 419,
     "displayName": "Diamond Horse Armor",
-    "stackSize": 1,
-    "name": "diamond_horse_armor"
+    "name": "diamond_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 420,
     "displayName": "Lead",
-    "stackSize": 64,
-    "name": "lead"
+    "name": "lead",
+    "stackSize": 64
   },
   {
     "id": 421,
     "displayName": "Name Tag",
-    "stackSize": 64,
-    "name": "name_tag"
+    "name": "name_tag",
+    "stackSize": 64
   },
   {
     "id": 422,
     "displayName": "Minecart with Command Block",
-    "stackSize": 1,
-    "name": "command_block_minecart"
+    "name": "command_block_minecart",
+    "stackSize": 1
   },
   {
     "id": 423,
     "displayName": "Raw Mutton",
-    "stackSize": 64,
-    "name": "mutton"
+    "name": "mutton",
+    "stackSize": 64
   },
   {
     "id": 424,
     "displayName": "Cooked Mutton",
-    "stackSize": 64,
-    "name": "cooked_mutton"
+    "name": "cooked_mutton",
+    "stackSize": 64
   },
   {
     "id": 425,
     "displayName": "Banner",
-    "stackSize": 16,
-    "name": "banner"
+    "name": "banner",
+    "stackSize": 16
   },
   {
     "id": 427,
     "displayName": "Spruce Door",
-    "stackSize": 64,
-    "name": "spruce_door"
+    "name": "spruce_door",
+    "stackSize": 64
   },
   {
     "id": 428,
     "displayName": "Birch Door",
-    "stackSize": 64,
-    "name": "birch_door"
+    "name": "birch_door",
+    "stackSize": 64
   },
   {
     "id": 429,
     "displayName": "Jungle Door",
-    "stackSize": 64,
-    "name": "jungle_door"
+    "name": "jungle_door",
+    "stackSize": 64
   },
   {
     "id": 430,
     "displayName": "Acacia Door",
-    "stackSize": 64,
-    "name": "acacia_door"
+    "name": "acacia_door",
+    "stackSize": 64
   },
   {
     "id": 431,
     "displayName": "Dark Oak Door",
-    "stackSize": 64,
-    "name": "dark_oak_door"
+    "name": "dark_oak_door",
+    "stackSize": 64
   },
   {
     "id": 2256,
     "displayName": "13 Disc",
-    "stackSize": 1,
-    "name": "record_13"
+    "name": "record_13",
+    "stackSize": 1
   },
   {
     "id": 2257,
     "displayName": "Cat Disc",
-    "stackSize": 1,
-    "name": "record_cat"
+    "name": "record_cat",
+    "stackSize": 1
   },
   {
     "id": 2258,
     "displayName": "Blocks Disc",
-    "stackSize": 1,
-    "name": "record_blocks"
+    "name": "record_blocks",
+    "stackSize": 1
   },
   {
     "id": 2259,
     "displayName": "Chirp Disc",
-    "stackSize": 1,
-    "name": "record_chirp"
+    "name": "record_chirp",
+    "stackSize": 1
   },
   {
     "id": 2260,
     "displayName": "Far Disc",
-    "stackSize": 1,
-    "name": "record_far"
+    "name": "record_far",
+    "stackSize": 1
   },
   {
     "id": 2261,
     "displayName": "Mall Disc",
-    "stackSize": 1,
-    "name": "record_mall"
+    "name": "record_mall",
+    "stackSize": 1
   },
   {
     "id": 2262,
     "displayName": "Mellohi Disc",
-    "stackSize": 1,
-    "name": "record_mellohi"
+    "name": "record_mellohi",
+    "stackSize": 1
   },
   {
     "id": 2263,
     "displayName": "Stal Disc",
-    "stackSize": 1,
-    "name": "record_stal"
+    "name": "record_stal",
+    "stackSize": 1
   },
   {
     "id": 2264,
     "displayName": "Strad Disc",
-    "stackSize": 1,
-    "name": "record_strad"
+    "name": "record_strad",
+    "stackSize": 1
   },
   {
     "id": 2265,
     "displayName": "Ward Disc",
-    "stackSize": 1,
-    "name": "record_ward"
+    "name": "record_ward",
+    "stackSize": 1
   },
   {
     "id": 2266,
     "displayName": "11 Disc",
-    "stackSize": 1,
-    "name": "record_11"
+    "name": "record_11",
+    "stackSize": 1
   },
   {
     "id": 2267,
     "displayName": "Wait Disc",
-    "stackSize": 1,
-    "name": "record_wait"
+    "name": "record_wait",
+    "stackSize": 1
   }
 ]

--- a/data/pc/1.9/items.json
+++ b/data/pc/1.9/items.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": 0,
-    "displayName": "Air",
-    "name": "air",
-    "stackSize": 64
-  },
-  {
     "id": 1,
     "displayName": "Stone",
     "name": "stone",
@@ -31,7 +25,7 @@
   },
   {
     "id": 5,
-    "displayName": "Wood Planks",
+    "displayName": "Wooden Planks",
     "name": "planks",
     "stackSize": 64
   },
@@ -45,30 +39,6 @@
     "id": 7,
     "displayName": "Bedrock",
     "name": "bedrock",
-    "stackSize": 64
-  },
-  {
-    "id": 8,
-    "displayName": "Water",
-    "name": "flowing_water",
-    "stackSize": 64
-  },
-  {
-    "id": 9,
-    "displayName": "Stationary Water",
-    "name": "water",
-    "stackSize": 64
-  },
-  {
-    "id": 10,
-    "displayName": "Lava",
-    "name": "flowing_lava",
-    "stackSize": 64
-  },
-  {
-    "id": 11,
-    "displayName": "Stationary Lava",
-    "name": "lava",
     "stackSize": 64
   },
   {
@@ -198,21 +168,9 @@
     "stackSize": 64
   },
   {
-    "id": 34,
-    "displayName": "Piston Head",
-    "name": "piston_head",
-    "stackSize": 64
-  },
-  {
     "id": 35,
     "displayName": "Wool",
     "name": "wool",
-    "stackSize": 64
-  },
-  {
-    "id": 36,
-    "displayName": "Block moved by Piston",
-    "name": "piston_extension",
     "stackSize": 64
   },
   {
@@ -252,12 +210,6 @@
     "stackSize": 64
   },
   {
-    "id": 43,
-    "displayName": "Double Stone Slab",
-    "name": "double_stone_slab",
-    "stackSize": 64
-  },
-  {
     "id": 44,
     "displayName": "Stone Slab",
     "name": "stone_slab",
@@ -265,7 +217,7 @@
   },
   {
     "id": 45,
-    "displayName": "Bricks",
+    "displayName": "Brick",
     "name": "brick_block",
     "stackSize": 64
   },
@@ -300,12 +252,6 @@
     "stackSize": 64
   },
   {
-    "id": 51,
-    "displayName": "Fire",
-    "name": "fire",
-    "stackSize": 64
-  },
-  {
     "id": 52,
     "displayName": "Monster Spawner",
     "name": "mob_spawner",
@@ -321,12 +267,6 @@
     "id": 54,
     "displayName": "Chest",
     "name": "chest",
-    "stackSize": 64
-  },
-  {
-    "id": 55,
-    "displayName": "Redstone Wire",
-    "name": "redstone_wire",
     "stackSize": 64
   },
   {
@@ -360,18 +300,6 @@
     "stackSize": 64
   },
   {
-    "id": 62,
-    "displayName": "Burning Furnace",
-    "name": "lit_furnace",
-    "stackSize": 64
-  },
-  {
-    "id": 63,
-    "displayName": "Standing Sign",
-    "name": "standing_sign",
-    "stackSize": 64
-  },
-  {
     "id": 65,
     "displayName": "Ladder",
     "name": "ladder",
@@ -387,12 +315,6 @@
     "id": 67,
     "displayName": "Cobblestone Stairs",
     "name": "stone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 68,
-    "displayName": "Wall Sign",
-    "name": "wall_sign",
     "stackSize": 64
   },
   {
@@ -420,20 +342,8 @@
     "stackSize": 64
   },
   {
-    "id": 74,
-    "displayName": "Glowing Redstone Ore",
-    "name": "lit_redstone_ore",
-    "stackSize": 64
-  },
-  {
-    "id": 75,
-    "displayName": "Redstone Torch (inactive)",
-    "name": "unlit_redstone_torch",
-    "stackSize": 64
-  },
-  {
     "id": 76,
-    "displayName": "Redstone Torch (active)",
+    "displayName": "Redstone Torch",
     "name": "redstone_torch",
     "stackSize": 64
   },
@@ -445,7 +355,7 @@
   },
   {
     "id": 78,
-    "displayName": "Snow (layer)",
+    "displayName": "Snow",
     "name": "snow_layer",
     "stackSize": 64
   },
@@ -481,7 +391,7 @@
   },
   {
     "id": 85,
-    "displayName": "Fence",
+    "displayName": "Oak Fence",
     "name": "fence",
     "stackSize": 64
   },
@@ -510,27 +420,9 @@
     "stackSize": 64
   },
   {
-    "id": 90,
-    "displayName": "Nether Portal",
-    "name": "portal",
-    "stackSize": 64
-  },
-  {
     "id": 91,
     "displayName": "Jack o'Lantern",
     "name": "lit_pumpkin",
-    "stackSize": 64
-  },
-  {
-    "id": 93,
-    "displayName": "Redstone Repeater (inactive)",
-    "name": "unpowered_repeater",
-    "stackSize": 64
-  },
-  {
-    "id": 94,
-    "displayName": "Redstone Repeater (active)",
-    "name": "powered_repeater",
     "stackSize": 64
   },
   {
@@ -541,7 +433,7 @@
   },
   {
     "id": 96,
-    "displayName": "Trapdoor",
+    "displayName": "Wooden Trapdoor",
     "name": "trapdoor",
     "stackSize": 64
   },
@@ -559,13 +451,13 @@
   },
   {
     "id": 99,
-    "displayName": "Brown Mushroom (block)",
+    "displayName": "Brown Mushroom Block",
     "name": "brown_mushroom_block",
     "stackSize": 64
   },
   {
     "id": 100,
-    "displayName": "Red Mushroom (block)",
+    "displayName": "Red Mushroom Block",
     "name": "red_mushroom_block",
     "stackSize": 64
   },
@@ -588,18 +480,6 @@
     "stackSize": 64
   },
   {
-    "id": 104,
-    "displayName": "Pumpkin Stem",
-    "name": "pumpkin_stem",
-    "stackSize": 64
-  },
-  {
-    "id": 105,
-    "displayName": "Melon Stem",
-    "name": "melon_stem",
-    "stackSize": 64
-  },
-  {
     "id": 106,
     "displayName": "Vines",
     "name": "vine",
@@ -607,7 +487,7 @@
   },
   {
     "id": 107,
-    "displayName": "Fence Gate",
+    "displayName": "Oak Fence Gate",
     "name": "fence_gate",
     "stackSize": 64
   },
@@ -660,12 +540,6 @@
     "stackSize": 64
   },
   {
-    "id": 119,
-    "displayName": "End Portal",
-    "name": "end_portal",
-    "stackSize": 64
-  },
-  {
     "id": 120,
     "displayName": "End Portal Frame",
     "name": "end_portal_frame",
@@ -685,32 +559,14 @@
   },
   {
     "id": 123,
-    "displayName": "Redstone Lamp (inactive)",
+    "displayName": "Redstone Lamp",
     "name": "redstone_lamp",
     "stackSize": 64
   },
   {
-    "id": 124,
-    "displayName": "Redstone Lamp (active)",
-    "name": "lit_redstone_lamp",
-    "stackSize": 64
-  },
-  {
-    "id": 125,
-    "displayName": "Double Wooden Slab",
-    "name": "double_wooden_slab",
-    "stackSize": 64
-  },
-  {
     "id": 126,
-    "displayName": "Wooden Slab",
+    "displayName": "Wood Slab",
     "name": "wooden_slab",
-    "stackSize": 64
-  },
-  {
-    "id": 127,
-    "displayName": "Cocoa",
-    "name": "cocoa",
     "stackSize": 64
   },
   {
@@ -735,12 +591,6 @@
     "id": 131,
     "displayName": "Tripwire Hook",
     "name": "tripwire_hook",
-    "stackSize": 64
-  },
-  {
-    "id": 132,
-    "displayName": "Tripwire",
-    "name": "tripwire",
     "stackSize": 64
   },
   {
@@ -786,18 +636,6 @@
     "stackSize": 64
   },
   {
-    "id": 141,
-    "displayName": "Carrot",
-    "name": "carrots",
-    "stackSize": 64
-  },
-  {
-    "id": 142,
-    "displayName": "Potato",
-    "name": "potatoes",
-    "stackSize": 64
-  },
-  {
     "id": 143,
     "displayName": "Wooden Button",
     "name": "wooden_button",
@@ -828,20 +666,8 @@
     "stackSize": 64
   },
   {
-    "id": 149,
-    "displayName": "Redstone Comparator",
-    "name": "unpowered_comparator",
-    "stackSize": 64
-  },
-  {
-    "id": 150,
-    "displayName": "Redstone Comparator (deprecated)",
-    "name": "powered_comparator",
-    "stackSize": 64
-  },
-  {
     "id": 151,
-    "displayName": "Daylight Sensor",
+    "displayName": "Daylight Detector",
     "name": "daylight_detector",
     "stackSize": 64
   },
@@ -853,7 +679,7 @@
   },
   {
     "id": 153,
-    "displayName": "Nether Quartz Ore",
+    "displayName": "Nether Quartz",
     "name": "quartz_ore",
     "stackSize": 64
   },
@@ -901,13 +727,13 @@
   },
   {
     "id": 161,
-    "displayName": "Leaves (Acacia/Dark Oak)",
+    "displayName": "Leaves",
     "name": "leaves2",
     "stackSize": 64
   },
   {
     "id": 162,
-    "displayName": "Wood (Acacia/Dark Oak)",
+    "displayName": "Wood",
     "name": "log2",
     "stackSize": 64
   },
@@ -990,24 +816,6 @@
     "stackSize": 64
   },
   {
-    "id": 176,
-    "displayName": "Standing Banner",
-    "name": "standing_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 177,
-    "displayName": "Wall Banner",
-    "name": "wall_banner",
-    "stackSize": 64
-  },
-  {
-    "id": 178,
-    "displayName": "Inverted Daylight Sensor",
-    "name": "daylight_detector_inverted",
-    "stackSize": 64
-  },
-  {
     "id": 179,
     "displayName": "Red Sandstone",
     "name": "red_sandstone",
@@ -1017,12 +825,6 @@
     "id": 180,
     "displayName": "Red Sandstone Stairs",
     "name": "red_sandstone_stairs",
-    "stackSize": 64
-  },
-  {
-    "id": 181,
-    "displayName": "Double Red Sandstone Slab",
-    "name": "double_stone_slab2",
     "stackSize": 64
   },
   {
@@ -1128,12 +930,6 @@
     "stackSize": 64
   },
   {
-    "id": 204,
-    "displayName": "Purpur Double Slab",
-    "name": "purpur_double_slab",
-    "stackSize": 64
-  },
-  {
     "id": 205,
     "displayName": "Purpur Slab",
     "name": "purpur_slab",
@@ -1146,21 +942,9 @@
     "stackSize": 64
   },
   {
-    "id": 207,
-    "displayName": "Beetroot Seeds",
-    "name": "beetroots",
-    "stackSize": 64
-  },
-  {
     "id": 208,
     "displayName": "Grass Path",
     "name": "grass_path",
-    "stackSize": 64
-  },
-  {
-    "id": 209,
-    "displayName": "End Gateway",
-    "name": "end_gateway",
     "stackSize": 64
   },
   {
@@ -1176,22 +960,11 @@
     "stackSize": 64
   },
   {
-    "id": 212,
-    "displayName": "Frosted Ice",
-    "name": "frosted_ice",
-    "stackSize": 64
-  },
-  {
-    "id": 255,
-    "displayName": "Structure Block",
-    "name": "structure_block",
-    "stackSize": 64
-  },
-  {
     "id": 256,
     "displayName": "Iron Shovel",
-    "stackSize": 1,
     "name": "iron_shovel",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1199,14 +972,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 257,
     "displayName": "Iron Pickaxe",
-    "stackSize": 1,
     "name": "iron_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1214,14 +987,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 258,
     "displayName": "Iron Axe",
-    "stackSize": 1,
     "name": "iron_axe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1229,49 +1002,48 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 259,
     "displayName": "Flint and Steel",
-    "stackSize": 1,
     "name": "flint_and_steel",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 260,
     "displayName": "Apple",
-    "stackSize": 64,
-    "name": "apple"
+    "name": "apple",
+    "stackSize": 64
   },
   {
     "id": 261,
     "displayName": "Bow",
-    "stackSize": 1,
     "name": "bow",
+    "stackSize": 1,
+    "maxDurability": 384,
     "enchantCategories": [
       "breakable",
       "bow",
       "vanishable"
-    ],
-    "maxDurability": 384
+    ]
   },
   {
     "id": 262,
     "displayName": "Arrow",
-    "stackSize": 64,
-    "name": "arrow"
+    "name": "arrow",
+    "stackSize": 64
   },
   {
     "id": 263,
     "displayName": "Coal",
-    "stackSize": 64,
     "name": "coal",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -1282,30 +1054,32 @@
         "displayName": "Charcoal"
       }
     ]
+
   },
   {
     "id": 264,
     "displayName": "Diamond",
-    "stackSize": 64,
-    "name": "diamond"
+    "name": "diamond",
+    "stackSize": 64
   },
   {
     "id": 265,
     "displayName": "Iron Ingot",
-    "stackSize": 64,
-    "name": "iron_ingot"
+    "name": "iron_ingot",
+    "stackSize": 64
   },
   {
     "id": 266,
     "displayName": "Gold Ingot",
-    "stackSize": 64,
-    "name": "gold_ingot"
+    "name": "gold_ingot",
+    "stackSize": 64
   },
   {
     "id": 267,
     "displayName": "Iron Sword",
-    "stackSize": 1,
     "name": "iron_sword",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1313,14 +1087,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 268,
     "displayName": "Wooden Sword",
-    "stackSize": 1,
     "name": "wooden_sword",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1335,14 +1109,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 269,
     "displayName": "Wooden Shovel",
-    "stackSize": 1,
     "name": "wooden_shovel",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1357,14 +1131,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 270,
     "displayName": "Wooden Pickaxe",
-    "stackSize": 1,
     "name": "wooden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1379,14 +1153,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 271,
     "displayName": "Wooden Axe",
-    "stackSize": 1,
     "name": "wooden_axe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1401,14 +1175,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 272,
     "displayName": "Stone Sword",
-    "stackSize": 1,
     "name": "stone_sword",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1417,14 +1191,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 273,
     "displayName": "Stone Shovel",
-    "stackSize": 1,
     "name": "stone_shovel",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1433,14 +1207,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 274,
     "displayName": "Stone Pickaxe",
-    "stackSize": 1,
     "name": "stone_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1449,14 +1223,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 275,
     "displayName": "Stone Axe",
-    "stackSize": 1,
     "name": "stone_axe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1465,14 +1239,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 276,
     "displayName": "Diamond Sword",
-    "stackSize": 1,
     "name": "diamond_sword",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1480,14 +1254,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 277,
     "displayName": "Diamond Shovel",
-    "stackSize": 1,
     "name": "diamond_shovel",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1495,14 +1269,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 278,
     "displayName": "Diamond Pickaxe",
-    "stackSize": 1,
     "name": "diamond_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1510,14 +1284,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 279,
     "displayName": "Diamond Axe",
-    "stackSize": 1,
     "name": "diamond_axe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1525,32 +1299,32 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 280,
     "displayName": "Stick",
-    "stackSize": 64,
-    "name": "stick"
+    "name": "stick",
+    "stackSize": 64
   },
   {
     "id": 281,
     "displayName": "Bowl",
-    "stackSize": 64,
-    "name": "bowl"
+    "name": "bowl",
+    "stackSize": 64
   },
   {
     "id": 282,
     "displayName": "Mushroom Stew",
-    "stackSize": 1,
-    "name": "mushroom_stew"
+    "name": "mushroom_stew",
+    "stackSize": 1
   },
   {
     "id": 283,
     "displayName": "Golden Sword",
-    "stackSize": 1,
     "name": "golden_sword",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "weapon",
       "breakable",
@@ -1558,14 +1332,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 284,
     "displayName": "Golden Shovel",
-    "stackSize": 1,
     "name": "golden_shovel",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1573,14 +1347,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 285,
     "displayName": "Golden Pickaxe",
-    "stackSize": 1,
     "name": "golden_pickaxe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1588,14 +1362,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 286,
     "displayName": "Golden Axe",
-    "stackSize": 1,
     "name": "golden_axe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1603,32 +1377,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 287,
     "displayName": "String",
-    "stackSize": 64,
-    "name": "string"
+    "name": "string",
+    "stackSize": 64
   },
   {
     "id": 288,
     "displayName": "Feather",
-    "stackSize": 64,
-    "name": "feather"
+    "name": "feather",
+    "stackSize": 64
   },
   {
     "id": 289,
     "displayName": "Gunpowder",
-    "stackSize": 64,
-    "name": "gunpowder"
+    "name": "gunpowder",
+    "stackSize": 64
   },
   {
     "id": 290,
     "displayName": "Wooden Hoe",
-    "stackSize": 1,
     "name": "wooden_hoe",
+    "stackSize": 1,
+    "maxDurability": 59,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1643,14 +1417,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 59
+    ]
   },
   {
     "id": 291,
     "displayName": "Stone Hoe",
-    "stackSize": 1,
     "name": "stone_hoe",
+    "stackSize": 1,
+    "maxDurability": 131,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1659,14 +1433,14 @@
     "repairWith": [
       "cobblestone",
       "blackstone"
-    ],
-    "maxDurability": 131
+    ]
   },
   {
     "id": 292,
     "displayName": "Iron Hoe",
-    "stackSize": 1,
     "name": "iron_hoe",
+    "stackSize": 1,
+    "maxDurability": 250,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1674,14 +1448,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 250
+    ]
   },
   {
     "id": 293,
     "displayName": "Diamond Hoe",
-    "stackSize": 1,
     "name": "diamond_hoe",
+    "stackSize": 1,
+    "maxDurability": 1561,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1689,14 +1463,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 1561
+    ]
   },
   {
     "id": 294,
     "displayName": "Golden Hoe",
-    "stackSize": 1,
     "name": "golden_hoe",
+    "stackSize": 1,
+    "maxDurability": 32,
     "enchantCategories": [
       "digger",
       "breakable",
@@ -1704,32 +1478,32 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 32
+    ]
   },
   {
     "id": 295,
     "displayName": "Seeds",
-    "stackSize": 64,
-    "name": "wheat_seeds"
+    "name": "wheat_seeds",
+    "stackSize": 64
   },
   {
     "id": 296,
     "displayName": "Wheat",
-    "stackSize": 64,
-    "name": "wheat"
+    "name": "wheat",
+    "stackSize": 64
   },
   {
     "id": 297,
     "displayName": "Bread",
-    "stackSize": 64,
-    "name": "bread"
+    "name": "bread",
+    "stackSize": 64
   },
   {
     "id": 298,
     "displayName": "Leather Cap",
-    "stackSize": 1,
     "name": "leather_helmet",
+    "stackSize": 1,
+    "maxDurability": 55,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1739,14 +1513,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 55
+    ]
   },
   {
     "id": 299,
     "displayName": "Leather Tunic",
-    "stackSize": 1,
     "name": "leather_chestplate",
+    "stackSize": 1,
+    "maxDurability": 80,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1756,14 +1530,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 80
+    ]
   },
   {
     "id": 300,
     "displayName": "Leather Pants",
-    "stackSize": 1,
     "name": "leather_leggings",
+    "stackSize": 1,
+    "maxDurability": 75,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1772,14 +1546,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 75
+    ]
   },
   {
     "id": 301,
     "displayName": "Leather Boots",
-    "stackSize": 1,
     "name": "leather_boots",
+    "stackSize": 1,
+    "maxDurability": 65,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1789,14 +1563,14 @@
     ],
     "repairWith": [
       "leather"
-    ],
-    "maxDurability": 65
+    ]
   },
   {
     "id": 302,
     "displayName": "Chain Helmet",
-    "stackSize": 1,
     "name": "chainmail_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1806,14 +1580,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 303,
     "displayName": "Chain Chestplate",
-    "stackSize": 1,
     "name": "chainmail_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1823,14 +1597,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 304,
     "displayName": "Chain Leggings",
-    "stackSize": 1,
     "name": "chainmail_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1839,14 +1613,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 305,
     "displayName": "Chain Boots",
-    "stackSize": 1,
     "name": "chainmail_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1856,14 +1630,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 306,
     "displayName": "Iron Helmet",
-    "stackSize": 1,
     "name": "iron_helmet",
+    "stackSize": 1,
+    "maxDurability": 165,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1873,14 +1647,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 165
+    ]
   },
   {
     "id": 307,
     "displayName": "Iron Chestplate",
-    "stackSize": 1,
     "name": "iron_chestplate",
+    "stackSize": 1,
+    "maxDurability": 240,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1890,14 +1664,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 240
+    ]
   },
   {
     "id": 308,
     "displayName": "Iron Leggings",
-    "stackSize": 1,
     "name": "iron_leggings",
+    "stackSize": 1,
+    "maxDurability": 225,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1906,14 +1680,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 225
+    ]
   },
   {
     "id": 309,
     "displayName": "Iron Boots",
-    "stackSize": 1,
     "name": "iron_boots",
+    "stackSize": 1,
+    "maxDurability": 195,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1923,14 +1697,14 @@
     ],
     "repairWith": [
       "iron_ingot"
-    ],
-    "maxDurability": 195
+    ]
   },
   {
     "id": 310,
     "displayName": "Diamond Helmet",
-    "stackSize": 1,
     "name": "diamond_helmet",
+    "stackSize": 1,
+    "maxDurability": 363,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -1940,14 +1714,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 363
+    ]
   },
   {
     "id": 311,
     "displayName": "Diamond Chestplate",
-    "stackSize": 1,
     "name": "diamond_chestplate",
+    "stackSize": 1,
+    "maxDurability": 528,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -1957,14 +1731,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 528
+    ]
   },
   {
     "id": 312,
     "displayName": "Diamond Leggings",
-    "stackSize": 1,
     "name": "diamond_leggings",
+    "stackSize": 1,
+    "maxDurability": 495,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -1973,14 +1747,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 495
+    ]
   },
   {
     "id": 313,
     "displayName": "Diamond Boots",
-    "stackSize": 1,
     "name": "diamond_boots",
+    "stackSize": 1,
+    "maxDurability": 429,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -1990,14 +1764,14 @@
     ],
     "repairWith": [
       "diamond"
-    ],
-    "maxDurability": 429
+    ]
   },
   {
     "id": 314,
     "displayName": "Golden Helmet",
-    "stackSize": 1,
     "name": "golden_helmet",
+    "stackSize": 1,
+    "maxDurability": 77,
     "enchantCategories": [
       "armor",
       "armor_head",
@@ -2007,14 +1781,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 77
+    ]
   },
   {
     "id": 315,
     "displayName": "Golden Chestplate",
-    "stackSize": 1,
     "name": "golden_chestplate",
+    "stackSize": 1,
+    "maxDurability": 112,
     "enchantCategories": [
       "armor",
       "armor_chest",
@@ -2024,14 +1798,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 112
+    ]
   },
   {
     "id": 316,
     "displayName": "Golden Leggings",
-    "stackSize": 1,
     "name": "golden_leggings",
+    "stackSize": 1,
+    "maxDurability": 105,
     "enchantCategories": [
       "armor",
       "breakable",
@@ -2040,14 +1814,14 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 105
+    ]
   },
   {
     "id": 317,
     "displayName": "Golden Boots",
-    "stackSize": 1,
     "name": "golden_boots",
+    "stackSize": 1,
+    "maxDurability": 91,
     "enchantCategories": [
       "armor",
       "armor_feet",
@@ -2057,38 +1831,37 @@
     ],
     "repairWith": [
       "gold_ingot"
-    ],
-    "maxDurability": 91
+    ]
   },
   {
     "id": 318,
     "displayName": "Flint",
-    "stackSize": 64,
-    "name": "flint"
+    "name": "flint",
+    "stackSize": 64
   },
   {
     "id": 319,
     "displayName": "Raw Porkchop",
-    "stackSize": 64,
-    "name": "porkchop"
+    "name": "porkchop",
+    "stackSize": 64
   },
   {
     "id": 320,
     "displayName": "Cooked Porkchop",
-    "stackSize": 64,
-    "name": "cooked_porkchop"
+    "name": "cooked_porkchop",
+    "stackSize": 64
   },
   {
     "id": 321,
     "displayName": "Painting",
-    "stackSize": 64,
-    "name": "painting"
+    "name": "painting",
+    "stackSize": 64
   },
   {
     "id": 322,
     "displayName": "Golden Apple",
-    "stackSize": 64,
     "name": "golden_apple",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2103,170 +1876,170 @@
   {
     "id": 323,
     "displayName": "Sign",
-    "stackSize": 16,
-    "name": "sign"
+    "name": "sign",
+    "stackSize": 16
   },
   {
     "id": 324,
     "displayName": "Oak Door",
-    "stackSize": 64,
-    "name": "wooden_door"
+    "name": "wooden_door",
+    "stackSize": 64
   },
   {
     "id": 325,
     "displayName": "Bucket",
-    "stackSize": 16,
-    "name": "bucket"
+    "name": "bucket",
+    "stackSize": 16
   },
   {
     "id": 326,
     "displayName": "Water Bucket",
-    "stackSize": 1,
-    "name": "water_bucket"
+    "name": "water_bucket",
+    "stackSize": 1
   },
   {
     "id": 327,
     "displayName": "Lava Bucket",
-    "stackSize": 1,
-    "name": "lava_bucket"
+    "name": "lava_bucket",
+    "stackSize": 1
   },
   {
     "id": 328,
     "displayName": "Minecart",
-    "stackSize": 1,
-    "name": "minecart"
+    "name": "minecart",
+    "stackSize": 1
   },
   {
     "id": 329,
     "displayName": "Saddle",
-    "stackSize": 1,
-    "name": "saddle"
+    "name": "saddle",
+    "stackSize": 1
   },
   {
     "id": 330,
     "displayName": "Iron Door",
-    "stackSize": 64,
-    "name": "iron_door"
+    "name": "iron_door",
+    "stackSize": 64
   },
   {
     "id": 331,
     "displayName": "Redstone",
-    "stackSize": 64,
-    "name": "redstone"
+    "name": "redstone",
+    "stackSize": 64
   },
   {
     "id": 332,
     "displayName": "Snowball",
-    "stackSize": 16,
-    "name": "snowball"
+    "name": "snowball",
+    "stackSize": 16
   },
   {
     "id": 333,
     "displayName": "Boat",
-    "stackSize": 1,
-    "name": "boat"
+    "name": "boat",
+    "stackSize": 1
   },
   {
     "id": 334,
     "displayName": "Leather",
-    "stackSize": 64,
-    "name": "leather"
+    "name": "leather",
+    "stackSize": 64
   },
   {
     "id": 335,
     "displayName": "Milk",
-    "stackSize": 1,
-    "name": "milk_bucket"
+    "name": "milk_bucket",
+    "stackSize": 1
   },
   {
     "id": 336,
     "displayName": "Brick",
-    "stackSize": 64,
-    "name": "brick"
+    "name": "brick",
+    "stackSize": 64
   },
   {
     "id": 337,
     "displayName": "Clay",
-    "stackSize": 64,
-    "name": "clay_ball"
+    "name": "clay_ball",
+    "stackSize": 64
   },
   {
     "id": 338,
-    "displayName": "Sugar Cane",
-    "stackSize": 64,
-    "name": "reeds"
+    "displayName": "Sugar Canes",
+    "name": "reeds",
+    "stackSize": 64
   },
   {
     "id": 339,
     "displayName": "Paper",
-    "stackSize": 64,
-    "name": "paper"
+    "name": "paper",
+    "stackSize": 64
   },
   {
     "id": 340,
     "displayName": "Book",
-    "stackSize": 64,
-    "name": "book"
+    "name": "book",
+    "stackSize": 64
   },
   {
     "id": 341,
     "displayName": "Slimeball",
-    "stackSize": 64,
-    "name": "slime_ball"
+    "name": "slime_ball",
+    "stackSize": 64
   },
   {
     "id": 342,
     "displayName": "Minecart with Chest",
-    "stackSize": 1,
-    "name": "chest_minecart"
+    "name": "chest_minecart",
+    "stackSize": 1
   },
   {
     "id": 343,
     "displayName": "Minecart with Furnace",
-    "stackSize": 1,
-    "name": "furnace_minecart"
+    "name": "furnace_minecart",
+    "stackSize": 1
   },
   {
     "id": 344,
     "displayName": "Egg",
-    "stackSize": 16,
-    "name": "egg"
+    "name": "egg",
+    "stackSize": 16
   },
   {
     "id": 345,
     "displayName": "Compass",
-    "stackSize": 64,
-    "name": "compass"
+    "name": "compass",
+    "stackSize": 64
   },
   {
     "id": 346,
     "displayName": "Fishing Rod",
-    "stackSize": 1,
     "name": "fishing_rod",
+    "stackSize": 1,
+    "maxDurability": 64,
     "enchantCategories": [
       "breakable",
       "fishing_rod",
       "vanishable"
-    ],
-    "maxDurability": 64
+    ]
   },
   {
     "id": 347,
     "displayName": "Clock",
-    "stackSize": 64,
-    "name": "clock"
+    "name": "clock",
+    "stackSize": 64
   },
   {
     "id": 348,
     "displayName": "Glowstone Dust",
-    "stackSize": 64,
-    "name": "glowstone_dust"
+    "name": "glowstone_dust",
+    "stackSize": 64
   },
   {
     "id": 349,
-    "displayName": "Raw Fish",
-    "stackSize": 64,
+    "displayName": "Fish",
     "name": "fish",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2289,14 +2062,14 @@
   {
     "id": 350,
     "displayName": "Cooked Fish",
-    "stackSize": 64,
-    "name": "cooked_fish"
+    "name": "cooked_fish",
+    "stackSize": 64
   },
   {
     "id": 351,
     "displayName": "Dye",
-    "stackSize": 64,
     "name": "dye",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2367,241 +2140,241 @@
   {
     "id": 352,
     "displayName": "Bone",
-    "stackSize": 64,
-    "name": "bone"
+    "name": "bone",
+    "stackSize": 64
   },
   {
     "id": 353,
     "displayName": "Sugar",
-    "stackSize": 64,
-    "name": "sugar"
+    "name": "sugar",
+    "stackSize": 64
   },
   {
     "id": 354,
     "displayName": "Cake",
-    "stackSize": 1,
-    "name": "cake"
+    "name": "cake",
+    "stackSize": 1
   },
   {
     "id": 355,
     "displayName": "Bed",
-    "stackSize": 1,
-    "name": "bed"
+    "name": "bed",
+    "stackSize": 1
   },
   {
     "id": 356,
     "displayName": "Redstone Repeater",
-    "stackSize": 64,
-    "name": "repeater"
+    "name": "repeater",
+    "stackSize": 64
   },
   {
     "id": 357,
     "displayName": "Cookie",
-    "stackSize": 64,
-    "name": "cookie"
+    "name": "cookie",
+    "stackSize": 64
   },
   {
     "id": 358,
     "displayName": "Map",
-    "stackSize": 64,
-    "name": "filled_map"
+    "name": "filled_map",
+    "stackSize": 64
   },
   {
     "id": 359,
     "displayName": "Shears",
-    "stackSize": 1,
     "name": "shears",
+    "stackSize": 1,
+    "maxDurability": 238,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 238
+    ]
   },
   {
     "id": 360,
     "displayName": "Melon",
-    "stackSize": 64,
-    "name": "melon"
+    "name": "melon",
+    "stackSize": 64
   },
   {
     "id": 361,
     "displayName": "Pumpkin Seeds",
-    "stackSize": 64,
-    "name": "pumpkin_seeds"
+    "name": "pumpkin_seeds",
+    "stackSize": 64
   },
   {
     "id": 362,
     "displayName": "Melon Seeds",
-    "stackSize": 64,
-    "name": "melon_seeds"
+    "name": "melon_seeds",
+    "stackSize": 64
   },
   {
     "id": 363,
     "displayName": "Raw Beef",
-    "stackSize": 64,
-    "name": "beef"
+    "name": "beef",
+    "stackSize": 64
   },
   {
     "id": 364,
     "displayName": "Steak",
-    "stackSize": 64,
-    "name": "cooked_beef"
+    "name": "cooked_beef",
+    "stackSize": 64
   },
   {
     "id": 365,
     "displayName": "Raw Chicken",
-    "stackSize": 64,
-    "name": "chicken"
+    "name": "chicken",
+    "stackSize": 64
   },
   {
     "id": 366,
     "displayName": "Cooked Chicken",
-    "stackSize": 64,
-    "name": "cooked_chicken"
+    "name": "cooked_chicken",
+    "stackSize": 64
   },
   {
     "id": 367,
     "displayName": "Rotten Flesh",
-    "stackSize": 64,
-    "name": "rotten_flesh"
+    "name": "rotten_flesh",
+    "stackSize": 64
   },
   {
     "id": 368,
     "displayName": "Ender Pearl",
-    "stackSize": 16,
-    "name": "ender_pearl"
+    "name": "ender_pearl",
+    "stackSize": 16
   },
   {
     "id": 369,
     "displayName": "Blaze Rod",
-    "stackSize": 64,
-    "name": "blaze_rod"
+    "name": "blaze_rod",
+    "stackSize": 64
   },
   {
     "id": 370,
     "displayName": "Ghast Tear",
-    "stackSize": 64,
-    "name": "ghast_tear"
+    "name": "ghast_tear",
+    "stackSize": 64
   },
   {
     "id": 371,
     "displayName": "Gold Nugget",
-    "stackSize": 64,
-    "name": "gold_nugget"
+    "name": "gold_nugget",
+    "stackSize": 64
   },
   {
     "id": 372,
     "displayName": "Nether Wart",
-    "stackSize": 64,
-    "name": "nether_wart"
+    "name": "nether_wart",
+    "stackSize": 64
   },
   {
     "id": 373,
     "displayName": "Potion",
-    "stackSize": 1,
-    "name": "potion"
+    "name": "potion",
+    "stackSize": 1
   },
   {
     "id": 374,
     "displayName": "Glass Bottle",
-    "stackSize": 64,
-    "name": "glass_bottle"
+    "name": "glass_bottle",
+    "stackSize": 64
   },
   {
     "id": 375,
     "displayName": "Spider Eye",
-    "stackSize": 64,
-    "name": "spider_eye"
+    "name": "spider_eye",
+    "stackSize": 64
   },
   {
     "id": 376,
     "displayName": "Fermented Spider Eye",
-    "stackSize": 64,
-    "name": "fermented_spider_eye"
+    "name": "fermented_spider_eye",
+    "stackSize": 64
   },
   {
     "id": 377,
     "displayName": "Blaze Powder",
-    "stackSize": 64,
-    "name": "blaze_powder"
+    "name": "blaze_powder",
+    "stackSize": 64
   },
   {
     "id": 378,
     "displayName": "Magma Cream",
-    "stackSize": 64,
-    "name": "magma_cream"
+    "name": "magma_cream",
+    "stackSize": 64
   },
   {
     "id": 379,
     "displayName": "Brewing Stand",
-    "stackSize": 64,
-    "name": "brewing_stand"
+    "name": "brewing_stand",
+    "stackSize": 64
   },
   {
     "id": 380,
     "displayName": "Cauldron",
-    "stackSize": 64,
-    "name": "cauldron"
+    "name": "cauldron",
+    "stackSize": 64
   },
   {
     "id": 381,
     "displayName": "Eye of Ender",
-    "stackSize": 64,
-    "name": "ender_eye"
+    "name": "ender_eye",
+    "stackSize": 64
   },
   {
     "id": 382,
     "displayName": "Glistering Melon",
-    "stackSize": 64,
-    "name": "speckled_melon"
+    "name": "speckled_melon",
+    "stackSize": 64
   },
   {
     "id": 383,
     "displayName": "Spawn Egg",
-    "stackSize": 64,
-    "name": "spawn_egg"
+    "name": "spawn_egg",
+    "stackSize": 64
   },
   {
     "id": 384,
     "displayName": "Bottle o' Enchanting",
-    "stackSize": 64,
-    "name": "experience_bottle"
+    "name": "experience_bottle",
+    "stackSize": 64
   },
   {
     "id": 385,
     "displayName": "Fire Charge",
-    "stackSize": 64,
-    "name": "fire_charge"
+    "name": "fire_charge",
+    "stackSize": 64
   },
   {
     "id": 386,
     "displayName": "Book and Quill",
-    "stackSize": 1,
-    "name": "writable_book"
+    "name": "writable_book",
+    "stackSize": 1
   },
   {
     "id": 387,
     "displayName": "Written Book",
-    "stackSize": 16,
-    "name": "written_book"
+    "name": "written_book",
+    "stackSize": 16
   },
   {
     "id": 388,
     "displayName": "Emerald",
-    "stackSize": 64,
-    "name": "emerald"
+    "name": "emerald",
+    "stackSize": 64
   },
   {
     "id": 389,
     "displayName": "Item Frame",
-    "stackSize": 64,
-    "name": "item_frame"
+    "name": "item_frame",
+    "stackSize": 64
   },
   {
     "id": 390,
     "displayName": "Flower Pot",
-    "stackSize": 64,
     "name": "flower_pot",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2664,44 +2437,44 @@
   {
     "id": 391,
     "displayName": "Carrot",
-    "stackSize": 64,
-    "name": "carrot"
+    "name": "carrot",
+    "stackSize": 64
   },
   {
     "id": 392,
     "displayName": "Potato",
-    "stackSize": 64,
-    "name": "potato"
+    "name": "potato",
+    "stackSize": 64
   },
   {
     "id": 393,
     "displayName": "Baked Potato",
-    "stackSize": 64,
-    "name": "baked_potato"
+    "name": "baked_potato",
+    "stackSize": 64
   },
   {
     "id": 394,
     "displayName": "Poisonous Potato",
-    "stackSize": 64,
-    "name": "poisonous_potato"
+    "name": "poisonous_potato",
+    "stackSize": 64
   },
   {
     "id": 395,
     "displayName": "Empty Map",
-    "stackSize": 64,
-    "name": "map"
+    "name": "map",
+    "stackSize": 64
   },
   {
     "id": 396,
     "displayName": "Golden Carrot",
-    "stackSize": 64,
-    "name": "golden_carrot"
+    "name": "golden_carrot",
+    "stackSize": 64
   },
   {
     "id": 397,
-    "displayName": "Mob head",
-    "stackSize": 64,
+    "displayName": "Skull",
     "name": "skull",
+    "stackSize": 64,
     "variations": [
       {
         "metadata": 0,
@@ -2728,277 +2501,278 @@
   {
     "id": 398,
     "displayName": "Carrot on a Stick",
-    "stackSize": 1,
     "name": "carrot_on_a_stick",
+    "stackSize": 1,
+    "maxDurability": 25,
     "enchantCategories": [
       "breakable",
       "vanishable"
-    ],
-    "maxDurability": 25
+    ]
   },
   {
     "id": 399,
     "displayName": "Nether Star",
-    "stackSize": 64,
-    "name": "nether_star"
+    "name": "nether_star",
+    "stackSize": 64
   },
   {
     "id": 400,
     "displayName": "Pumpkin Pie",
-    "stackSize": 64,
-    "name": "pumpkin_pie"
+    "name": "pumpkin_pie",
+    "stackSize": 64
   },
   {
     "id": 401,
     "displayName": "Firework Rocket",
-    "stackSize": 64,
-    "name": "fireworks"
+    "name": "fireworks",
+    "stackSize": 64
   },
   {
     "id": 402,
     "displayName": "Firework Star",
-    "stackSize": 64,
-    "name": "firework_charge"
+    "name": "firework_charge",
+    "stackSize": 64
   },
   {
     "id": 403,
     "displayName": "Enchanted Book",
-    "stackSize": 1,
-    "name": "enchanted_book"
+    "name": "enchanted_book",
+    "stackSize": 1
   },
   {
     "id": 404,
     "displayName": "Redstone Comparator",
-    "stackSize": 64,
-    "name": "comparator"
+    "name": "comparator",
+    "stackSize": 64
   },
   {
     "id": 405,
     "displayName": "Nether Brick",
-    "stackSize": 64,
-    "name": "netherbrick"
+    "name": "netherbrick",
+    "stackSize": 64
   },
   {
     "id": 406,
     "displayName": "Nether Quartz",
-    "stackSize": 64,
-    "name": "quartz"
+    "name": "quartz",
+    "stackSize": 64
   },
   {
     "id": 407,
     "displayName": "Minecart with TNT",
-    "stackSize": 1,
-    "name": "tnt_minecart"
+    "name": "tnt_minecart",
+    "stackSize": 1
   },
   {
     "id": 408,
     "displayName": "Minecart with Hopper",
-    "stackSize": 1,
-    "name": "hopper_minecart"
+    "name": "hopper_minecart",
+    "stackSize": 1
   },
   {
     "id": 409,
     "displayName": "Prismarine Shard",
-    "stackSize": 64,
-    "name": "prismarine_shard"
+    "name": "prismarine_shard",
+    "stackSize": 64
   },
   {
     "id": 410,
     "displayName": "Prismarine Crystals",
-    "stackSize": 64,
-    "name": "prismarine_crystals"
+    "name": "prismarine_crystals",
+    "stackSize": 64
   },
   {
     "id": 411,
     "displayName": "Raw Rabbit",
-    "stackSize": 64,
-    "name": "rabbit"
+    "name": "rabbit",
+    "stackSize": 64
   },
   {
     "id": 412,
     "displayName": "Cooked Rabbit",
-    "stackSize": 64,
-    "name": "cooked_rabbit"
+    "name": "cooked_rabbit",
+    "stackSize": 64
   },
   {
     "id": 413,
     "displayName": "Rabbit Stew",
-    "stackSize": 1,
-    "name": "rabbit_stew"
+    "name": "rabbit_stew",
+    "stackSize": 1
   },
   {
     "id": 414,
     "displayName": "Rabbit's Foot",
-    "stackSize": 64,
-    "name": "rabbit_foot"
+    "name": "rabbit_foot",
+    "stackSize": 64
   },
   {
     "id": 415,
     "displayName": "Rabbit Hide",
-    "stackSize": 64,
-    "name": "rabbit_hide"
+    "name": "rabbit_hide",
+    "stackSize": 64
   },
   {
     "id": 416,
     "displayName": "Armor Stand",
-    "stackSize": 16,
-    "name": "armor_stand"
+    "name": "armor_stand",
+    "stackSize": 16
   },
   {
     "id": 417,
     "displayName": "Iron Horse Armor",
-    "stackSize": 1,
-    "name": "iron_horse_armor"
+    "name": "iron_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 418,
-    "displayName": "Golden Horse Armor",
-    "stackSize": 1,
-    "name": "golden_horse_armor"
+    "displayName": "Gold Horse Armor",
+    "name": "golden_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 419,
     "displayName": "Diamond Horse Armor",
-    "stackSize": 1,
-    "name": "diamond_horse_armor"
+    "name": "diamond_horse_armor",
+    "stackSize": 1
   },
   {
     "id": 420,
     "displayName": "Lead",
-    "stackSize": 64,
-    "name": "lead"
+    "name": "lead",
+    "stackSize": 64
   },
   {
     "id": 421,
     "displayName": "Name Tag",
-    "stackSize": 64,
-    "name": "name_tag"
+    "name": "name_tag",
+    "stackSize": 64
   },
   {
     "id": 422,
     "displayName": "Minecart with Command Block",
-    "stackSize": 1,
-    "name": "command_block_minecart"
+    "name": "command_block_minecart",
+    "stackSize": 1
   },
   {
     "id": 423,
     "displayName": "Raw Mutton",
-    "stackSize": 64,
-    "name": "mutton"
+    "name": "mutton",
+    "stackSize": 64
   },
   {
     "id": 424,
     "displayName": "Cooked Mutton",
-    "stackSize": 64,
-    "name": "cooked_mutton"
+    "name": "cooked_mutton",
+    "stackSize": 64
   },
   {
     "id": 425,
     "displayName": "Banner",
-    "stackSize": 16,
-    "name": "banner"
+    "name": "banner",
+    "stackSize": 16
   },
   {
     "id": 426,
     "displayName": "End Crystal",
-    "stackSize": 64,
-    "name": "end_crystal"
+    "name": "end_crystal",
+    "stackSize": 64
   },
   {
     "id": 427,
     "displayName": "Spruce Door",
-    "stackSize": 64,
-    "name": "spruce_door"
+    "name": "spruce_door",
+    "stackSize": 64
   },
   {
     "id": 428,
     "displayName": "Birch Door",
-    "stackSize": 64,
-    "name": "birch_door"
+    "name": "birch_door",
+    "stackSize": 64
   },
   {
     "id": 429,
     "displayName": "Jungle Door",
-    "stackSize": 64,
-    "name": "jungle_door"
+    "name": "jungle_door",
+    "stackSize": 64
   },
   {
     "id": 430,
     "displayName": "Acacia Door",
-    "stackSize": 64,
-    "name": "acacia_door"
+    "name": "acacia_door",
+    "stackSize": 64
   },
   {
     "id": 431,
     "displayName": "Dark Oak Door",
-    "stackSize": 64,
-    "name": "dark_oak_door"
+    "name": "dark_oak_door",
+    "stackSize": 64
   },
   {
     "id": 432,
     "displayName": "Chorus Fruit",
-    "stackSize": 64,
-    "name": "chorus_fruit"
+    "name": "chorus_fruit",
+    "stackSize": 64
   },
   {
     "id": 433,
     "displayName": "Popped Chorus Fruit",
-    "stackSize": 64,
-    "name": "chorus_fruit_popped"
+    "name": "chorus_fruit_popped",
+    "stackSize": 64
   },
   {
     "id": 434,
     "displayName": "Beetroot",
-    "stackSize": 64,
-    "name": "beetroot"
+    "name": "beetroot",
+    "stackSize": 64
   },
   {
     "id": 435,
     "displayName": "Beetroot Seeds",
-    "stackSize": 64,
-    "name": "beetroot_seeds"
+    "name": "beetroot_seeds",
+    "stackSize": 64
   },
   {
     "id": 436,
     "displayName": "Beetroot Soup",
-    "stackSize": 1,
-    "name": "beetroot_soup"
+    "name": "beetroot_soup",
+    "stackSize": 1
   },
   {
     "id": 437,
     "displayName": "Dragon's Breath",
-    "stackSize": 64,
-    "name": "dragon_breath"
+    "name": "dragon_breath",
+    "stackSize": 64
   },
   {
     "id": 438,
     "displayName": "Splash Potion",
-    "stackSize": 1,
-    "name": "splash_potion"
+    "name": "splash_potion",
+    "stackSize": 1
   },
   {
     "id": 439,
     "displayName": "Spectral Arrow",
-    "stackSize": 64,
-    "name": "spectral_arrow"
+    "name": "spectral_arrow",
+    "stackSize": 64
   },
   {
     "id": 440,
     "displayName": "Tipped Arrow",
-    "stackSize": 64,
-    "name": "tipped_arrow"
+    "name": "tipped_arrow",
+    "stackSize": 64
   },
   {
     "id": 441,
     "displayName": "Lingering Potion",
-    "stackSize": 1,
-    "name": "lingering_potion"
+    "name": "lingering_potion",
+    "stackSize": 1
   },
   {
     "id": 442,
     "displayName": "Shield",
-    "stackSize": 1,
     "name": "shield",
+    "stackSize": 1,
+    "maxDurability": 336,
     "enchantCategories": [
       "breakable",
       "vanishable"
@@ -3012,14 +2786,14 @@
       "dark_oak_planks",
       "crimson_planks",
       "warped_planks"
-    ],
-    "maxDurability": 336
+    ]
   },
   {
     "id": 443,
     "displayName": "Elytra",
-    "stackSize": 1,
     "name": "elytra",
+    "stackSize": 1,
+    "maxDurability": 432,
     "enchantCategories": [
       "breakable",
       "wearable",
@@ -3027,109 +2801,108 @@
     ],
     "repairWith": [
       "phantom_membrane"
-    ],
-    "maxDurability": 432
+    ]
   },
   {
     "id": 444,
     "displayName": "Spruce Boat",
-    "stackSize": 1,
-    "name": "spruce_boat"
+    "name": "spruce_boat",
+    "stackSize": 1
   },
   {
     "id": 445,
     "displayName": "Birch Boat",
-    "stackSize": 1,
-    "name": "birch_boat"
+    "name": "birch_boat",
+    "stackSize": 1
   },
   {
     "id": 446,
     "displayName": "Jungle Boat",
-    "stackSize": 1,
-    "name": "jungle_boat"
+    "name": "jungle_boat",
+    "stackSize": 1
   },
   {
     "id": 447,
     "displayName": "Acacia Boat",
-    "stackSize": 1,
-    "name": "acacia_boat"
+    "name": "acacia_boat",
+    "stackSize": 1
   },
   {
     "id": 448,
     "displayName": "Dark Oak Boat",
-    "stackSize": 1,
-    "name": "dark_oak_boat"
+    "name": "dark_oak_boat",
+    "stackSize": 1
   },
   {
     "id": 2256,
     "displayName": "13 Disc",
-    "stackSize": 1,
-    "name": "record_13"
+    "name": "record_13",
+    "stackSize": 1
   },
   {
     "id": 2257,
     "displayName": "Cat Disc",
-    "stackSize": 1,
-    "name": "record_cat"
+    "name": "record_cat",
+    "stackSize": 1
   },
   {
     "id": 2258,
     "displayName": "Blocks Disc",
-    "stackSize": 1,
-    "name": "record_blocks"
+    "name": "record_blocks",
+    "stackSize": 1
   },
   {
     "id": 2259,
     "displayName": "Chirp Disc",
-    "stackSize": 1,
-    "name": "record_chirp"
+    "name": "record_chirp",
+    "stackSize": 1
   },
   {
     "id": 2260,
     "displayName": "Far Disc",
-    "stackSize": 1,
-    "name": "record_far"
+    "name": "record_far",
+    "stackSize": 1
   },
   {
     "id": 2261,
     "displayName": "Mall Disc",
-    "stackSize": 1,
-    "name": "record_mall"
+    "name": "record_mall",
+    "stackSize": 1
   },
   {
     "id": 2262,
     "displayName": "Mellohi Disc",
-    "stackSize": 1,
-    "name": "record_mellohi"
+    "name": "record_mellohi",
+    "stackSize": 1
   },
   {
     "id": 2263,
     "displayName": "Stal Disc",
-    "stackSize": 1,
-    "name": "record_stal"
+    "name": "record_stal",
+    "stackSize": 1
   },
   {
     "id": 2264,
     "displayName": "Strad Disc",
-    "stackSize": 1,
-    "name": "record_strad"
+    "name": "record_strad",
+    "stackSize": 1
   },
   {
     "id": 2265,
     "displayName": "Ward Disc",
-    "stackSize": 1,
-    "name": "record_ward"
+    "name": "record_ward",
+    "stackSize": 1
   },
   {
     "id": 2266,
     "displayName": "11 Disc",
-    "stackSize": 1,
-    "name": "record_11"
+    "name": "record_11",
+    "stackSize": 1
   },
   {
     "id": 2267,
     "displayName": "Wait Disc",
-    "stackSize": 1,
-    "name": "record_wait"
+    "name": "record_wait",
+    "stackSize": 1
   }
 ]


### PR DESCRIPTION
This started as an attempt to fix https://github.com/PrismarineJS/minecraft-data/issues/199 and got out of control

Stuff this PR does to items.json:

* Removes non-items across all versions:
  * Air (1.13+ this is typically the only removed "item")
  * Plant stems
  * Liquids
  * Piston Heads
  * Double slabs
  * Fire
  * Redstone Wire
  * Burning Furnace
  * Placed signs
  * You get the idea
  
* Removes a bunch of items from 1.7 that aren't in 1.7

* Add missing items to 1.8+:
  * Magma Block
  * Nether Wart Block
  * Red Nether Block
  * Bone Block
  * Structure Void

* Add Knowledge Book to 1.12+ (Fixes #199)

* Fix some random stacksize bugs (ex. 1.7 had doors as stacksize 1)

* Fixes some display name capitalizations ("mall Disc" -> "Mall Disc")

* A truly laughable amount of noise from burger-extractor and turbo-inventor re-ordering fields. It's my hope that this is a one-time cost and future runs through the data won't induce so much noise. Post-flattening data versions already mostly used this field order, so now all `items.json` do.

**Now the bad news:**
This commit _doesn't_ fix the lack of "variations" provided by pre-flattening data. Ie. All `stone` still looks the same in `items.json`. We provide variations inconsistently for a handful of items, but a complete solution will have to be done in a followup