### PR TITLE
Fix 1.7 open_window when opening horse inventory

### DIFF
--- a/data/pc/1.7/protocol.json
+++ b/data/pc/1.7/protocol.json
@@ -1778,7 +1778,7 @@
                 {
                   "compareTo": "inventoryType",
                   "fields": {
-                    "EntityHorse": "i32"
+                    "11": "i32"
                   },
                   "default": "void"
                 }


### PR DESCRIPTION
https://wiki.vg/index.php?title=Protocol&oldid=6003#Open_Window
The current switch is incorrect and is only for 1.8+. 1.7 still uses the old window ids.