### PR TITLE
For 1.17.1, entities to be destroy are back in an array, so we should…

### DIFF
--- a/data/pc/1.17.1/protocol.json
+++ b/data/pc/1.17.1/protocol.json
@@ -3111,7 +3111,7 @@
             }
           ]
         ],
-        "packet_destroy_entity": [
+        "packet_entity_destroy": [
           "container",
           [
             {
@@ -4342,7 +4342,7 @@
                     "0x37": "face_player",
                     "0x38": "position",
                     "0x39": "unlock_recipes",
-                    "0x3a": "destroy_entity",
+                    "0x3a": "entity_destroy",
                     "0x3b": "remove_entity_effect",
                     "0x3c": "resource_pack_send",
                     "0x3d": "respawn",
@@ -4454,7 +4454,7 @@
                     "player_info": "packet_player_info",
                     "position": "packet_position",
                     "unlock_recipes": "packet_unlock_recipes",
-                    "destroy_entity": "packet_destroy_entity",
+                    "entity_destroy": "packet_entity_destroy",
                     "remove_entity_effect": "packet_remove_entity_effect",
                     "resource_pack_send": "packet_resource_pack_send",
                     "respawn": "packet_respawn",


### PR DESCRIPTION
… revert the name change