### PR TITLE
Tag schemas

### DIFF
--- a/schemas/blocks_schema.json
+++ b/schemas/blocks_schema.json
@@ -202,6 +202,13 @@
           "null"
         ],
         "minimum": -1
+      },
+      "tags": {
+        "description": "Block tags",
+        "type": "array",
+        "uniqueItems": true,
+        "minItems": 1,
+        "items": { "type": "string" }
       }
     },
     "required": [

--- a/schemas/entities_schema.json
+++ b/schemas/entities_schema.json
@@ -46,6 +46,13 @@
       "category": {
         "description": "The category of an entity : a semantic category",
         "type": "string"
+      },
+      "tags": {
+        "description": "Entity tags",
+        "type": "array",
+        "uniqueItems": true,
+        "minItems": 1,
+        "items": { "type": "string" }
       }
     },
     "required": [

--- a/schemas/items_schema.json
+++ b/schemas/items_schema.json
@@ -62,6 +62,13 @@
           "required": ["metadata", "displayName"],
           "additionalProperties": true
         }
+      },
+      "tags": {
+        "description": "Item tags",
+        "type": "array",
+        "uniqueItems": true,
+        "minItems": 1,
+        "items": { "type": "string" }
       }
     },
     "required": ["id", "displayName", "stackSize", "name"],

--- a/schemas/tags.json
+++ b/schemas/tags.json
@@ -1,0 +1,36 @@
+{
+  "title": "tags",
+  "type": "object",
+  "properties": {
+    "blocks": {
+      "title": "blockTags",
+      "description": "Block name to tags",
+      "$ref": "#/$defs/tagCollection",
+      "additionalProperties": { "title": "Block tags" }
+    },
+    "items": {
+      "title": "itemTags",
+      "description": "Item name to tags",
+      "$ref": "#/$defs/tagCollection",
+      "additionalProperties": { "title": "Item tags" }
+    },
+    "entities": {
+      "title": "entityTags",
+      "description": "Entity name to tags",
+      "$ref": "#/$defs/tagCollection",
+      "additionalProperties": { "title": "Entity tags" }
+    }
+  },
+  "required": [ "blocks", "items", "entities" ],
+  "$defs": {
+    "tagCollection": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "uniqueItems": true,
+        "minItems": 1,
+        "items": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added Schema files for blocks.json, items.json, entities.json and a new tags.json. This matches the proposal outlined here: https://github.com/PrismarineJS/minecraft-data/issues/463 

On blocks, items and entities the "tags" property is optional. However if it's specified, a minimum of one tag is required. This is to prevent accidentally adding empty tags. If there are no tags for an object, do not put a tags property on that object.

The tags have an enforced uniqueness to prevent duplicates. They do not however enforce any particular naming scheme. While not required, it could be beneficial to prevent a leading `#` if we intend on expanding nested tag references into their final values, something that I would suggest to simplify query complexity at the cost of a more complicated extractor.

As for the tags.json, the keys "blocks", "items" and "entities" are required, but there is no constraint that they are populated. This is consistent with requesting an incorrect block name and it not being present. The tag collections on each block, item or entity must have a minimum of one tag if specified, and uniqueness is enforced. This is consistent with the other files, and an entire definition should be omitted if the tag collection is empty. 

This schema requires at least Draft 4 to be parsable. I would have liked to use `contains` instead of `items`, but it's more modern and the other schema files did not use it. 