### PR TITLE
update bedrock 1.18 data, bedrock recipes schema

### DIFF
--- a/data/bedrock/1.18.0/biomes.json
+++ b/data/bedrock/1.18.0/biomes.json
@@ -964,5 +964,101 @@
         "offset": 0.175
       }
     ]
+  },
+  {
+    "id": 182,
+    "name": "jagged_peaks",
+    "category": "",
+    "precipitation": "rain",
+    "depth": 0,
+    "dimension": "overworld",
+    "displayName": "jagged_peaks",
+    "color": 0,
+    "rainfall": 0.8999999761581421,
+    "temperature": -0.699999988079071
+  },
+  {
+    "id": 183,
+    "name": "frozen_peaks",
+    "category": "",
+    "precipitation": "rain",
+    "depth": 0,
+    "dimension": "overworld",
+    "displayName": "frozen_peaks",
+    "color": 0,
+    "rainfall": 0.8999999761581421,
+    "temperature": -0.699999988079071
+  },
+  {
+    "id": 184,
+    "name": "snowy_slopes",
+    "category": "",
+    "precipitation": "rain",
+    "depth": 0,
+    "dimension": "overworld",
+    "displayName": "snowy_slopes",
+    "color": 0,
+    "rainfall": 0.8999999761581421,
+    "temperature": -0.30000001192092896
+  },
+  {
+    "id": 185,
+    "name": "grove",
+    "category": "",
+    "precipitation": "rain",
+    "depth": 0,
+    "dimension": "overworld",
+    "displayName": "grove",
+    "color": 0,
+    "rainfall": 0.800000011920929,
+    "temperature": -0.20000000298023224
+  },
+  {
+    "id": 186,
+    "name": "meadow",
+    "category": "",
+    "precipitation": "rain",
+    "depth": 0,
+    "dimension": "overworld",
+    "displayName": "meadow",
+    "color": 0,
+    "rainfall": 0.800000011920929,
+    "temperature": 0.30000001192092896
+  },
+  {
+    "id": 187,
+    "name": "lush_caves",
+    "category": "",
+    "precipitation": "rain",
+    "depth": 0,
+    "dimension": "overworld",
+    "displayName": "lush_caves",
+    "color": 0,
+    "rainfall": 0,
+    "temperature": 0.8999999761581421
+  },
+  {
+    "id": 188,
+    "name": "dripstone_caves",
+    "category": "",
+    "precipitation": "rain",
+    "depth": 0,
+    "dimension": "overworld",
+    "displayName": "dripstone_caves",
+    "color": 0,
+    "rainfall": 0,
+    "temperature": 0.20000000298023224
+  },
+  {
+    "id": 189,
+    "name": "stony_peaks",
+    "category": "",
+    "precipitation": "rain",
+    "depth": 0,
+    "dimension": "overworld",
+    "displayName": "stony_peaks",
+    "color": 0,
+    "rainfall": 0.30000001192092896,
+    "temperature": 1
   }
 ]

--- a/data/bedrock/1.18.0/items.json
+++ b/data/bedrock/1.18.0/items.json
@@ -685,12 +685,6 @@
     "name": "crimson_stem"
   },
   {
-    "id": 107,
-    "displayName": "Air",
-    "name": "pistonArmCollision",
-    "stackSize": 64
-  },
-  {
     "id": 108,
     "stackSize": 64,
     "displayName": "Warped Stem",
@@ -755,12 +749,6 @@
     "stackSize": 64,
     "displayName": "Stripped Warped Hyphae",
     "name": "stripped_warped_hyphae"
-  },
-  {
-    "id": 124,
-    "displayName": "Air",
-    "name": "movingBlock",
-    "stackSize": 64
   },
   {
     "id": 125,
@@ -1310,12 +1298,6 @@
     "stackSize": 64,
     "displayName": "Kelp",
     "name": "kelp"
-  },
-  {
-    "id": 197,
-    "displayName": "Sugar Cane",
-    "name": "reeds",
-    "stackSize": 64
   },
   {
     "id": 198,
@@ -1890,12 +1872,6 @@
         "stackSize": 64
       }
     ]
-  },
-  {
-    "id": 285,
-    "displayName": "String",
-    "name": "tripWire",
-    "stackSize": 64
   },
   {
     "id": 287,
@@ -2769,12 +2745,6 @@
         "stackSize": 64
       }
     ]
-  },
-  {
-    "id": 403,
-    "displayName": "Sea Lantern",
-    "name": "seaLantern",
-    "stackSize": 64
   },
   {
     "id": 416,
@@ -3903,12 +3873,6 @@
         "stackSize": 64
       }
     ]
-  },
-  {
-    "id": 572,
-    "displayName": "White Concrete Powder",
-    "name": "concretePowder",
-    "stackSize": 64
   },
   {
     "id": 580,
@@ -7761,42 +7725,6 @@
     "stackSize": 64,
     "displayName": "Pointed Dripstone",
     "name": "pointed_dripstone"
-  },
-  {
-    "id": 5107,
-    "displayName": "InvisibleBedrock",
-    "name": "invisibleBedrock",
-    "stackSize": 64
-  },
-  {
-    "id": 8002,
-    "displayName": "Air",
-    "name": "stickyPistonArmCollision",
-    "stackSize": 64
-  },
-  {
-    "id": 8010,
-    "displayName": "Prismarine Slab",
-    "name": "stone_slab2",
-    "stackSize": 64
-  },
-  {
-    "id": 8012,
-    "displayName": "Stone Slab",
-    "name": "stone_slab4",
-    "stackSize": 64
-  },
-  {
-    "id": 8013,
-    "displayName": "Smooth Stone Slab",
-    "name": "stone_slab",
-    "stackSize": 64
-  },
-  {
-    "id": 8014,
-    "displayName": "Polished Granite Slab",
-    "name": "stone_slab3",
-    "stackSize": 64
   },
   {
     "id": 9005,

--- a/data/bedrock/1.18.0/recipes.json
+++ b/data/bedrock/1.18.0/recipes.json
@@ -1404,14 +1404,14 @@
     "output": [{"name": "daylight_detector", "metadata": 0, "count": 1}]
   },
   "208": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "FireCharge_blaze_powder_coal_sulphur_recipeId",
     "ingredients": [{"name": "blaze_powder", "count": 1}, {"name": "charcoal", "count": 1}, {"name": "gunpowder", "count": 1}],
     "input": [[1, 2, 3]],
     "output": [{"name": "fire_charge", "metadata": 0, "count": 3}]
   },
   "209": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "FireCharge_coal_sulphur_recipeId",
     "ingredients": [{"name": "blaze_powder", "count": 1}, {"name": "coal", "count": 1}, {"name": "gunpowder", "count": 1}],
     "input": [[1, 2, 3]],
@@ -1959,2100 +1959,2100 @@
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "292": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "293": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "294": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "295": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "296": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "297": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "298": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "299": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "300": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "301": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "302": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "303": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "304": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "305": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "306": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_0_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "307": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "308": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "309": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "310": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "311": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "312": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "313": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "314": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "315": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "316": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "317": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "318": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "319": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "320": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "321": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_10_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 5, "count": 1}]
   },
   "322": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "323": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "324": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "325": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "326": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "327": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "328": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "329": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "330": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "331": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "332": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "333": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "334": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "335": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "336": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_11_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 4, "count": 1}]
   },
   "337": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "338": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "339": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "340": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "341": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "342": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "343": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "344": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "345": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "346": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "347": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "348": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "349": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "350": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "351": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_12_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 3, "count": 1}]
   },
   "352": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "353": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "354": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "355": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "356": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "357": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "358": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "359": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "360": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "361": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "362": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "363": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "364": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "365": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "366": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_13_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 2, "count": 1}]
   },
   "367": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "368": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "369": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "370": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "371": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "372": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "373": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "374": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "375": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "376": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "377": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "378": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "379": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "380": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "381": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_14_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 1, "count": 1}]
   },
   "382": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "383": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "384": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "385": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "386": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "387": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "388": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "389": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "390": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "391": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "392": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "393": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "394": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "395": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "396": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_15_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "397": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "398": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "399": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "400": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "401": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "402": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "403": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "404": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "405": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "406": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "407": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "408": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "409": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "410": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "411": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_16_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 15, "count": 1}]
   },
   "412": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "413": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "414": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "415": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "416": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "417": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "418": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "419": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "420": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "421": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "422": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "423": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "424": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "425": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "426": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_17_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "427": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "428": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "429": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "430": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "431": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "432": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "433": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "434": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "435": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "436": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "437": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "438": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "439": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "440": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "441": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_18_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "442": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "443": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "444": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "445": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "446": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "447": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "448": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "449": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "450": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "451": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "452": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "453": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "454": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "455": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "456": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_19_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 0, "count": 1}]
   },
   "457": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "458": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "459": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "460": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "461": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "462": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "463": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "464": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "465": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "466": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "467": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "468": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "469": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "470": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "471": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_1_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 14, "count": 1}]
   },
   "472": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "473": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "474": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "475": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "476": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "477": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "478": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "479": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "480": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "481": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "482": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "483": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "484": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "485": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "486": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_2_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 13, "count": 1}]
   },
   "487": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "488": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "489": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "490": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "491": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "492": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "493": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "494": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "495": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "496": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "497": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "498": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "499": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "500": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "501": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_3_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 12, "count": 1}]
   },
   "502": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "503": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "504": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "505": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "506": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "507": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "508": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "509": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "510": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "511": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "512": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "513": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "514": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "515": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "516": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_4_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 11, "count": 1}]
   },
   "517": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "518": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "519": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "520": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "521": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "522": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "523": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "524": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "525": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "526": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "527": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "528": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "529": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "530": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "531": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_5_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 10, "count": 1}]
   },
   "532": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "533": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "534": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "535": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "536": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "537": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "538": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "539": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "540": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "541": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "542": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "543": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "544": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "545": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "546": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_6_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 9, "count": 1}]
   },
   "547": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "548": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "549": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "550": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "551": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "552": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "553": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "554": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "555": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "556": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "557": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "558": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "559": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "560": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "561": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_7_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 8, "count": 1}]
   },
   "562": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "563": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "564": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "565": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "566": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "567": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "568": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "569": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "570": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "571": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "572": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "573": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "574": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "575": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "576": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_8_9",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 7, "count": 1}]
   },
   "577": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_0",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "578": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_1",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "579": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_10",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "580": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_11",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "581": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_12",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "582": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_13",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "583": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_14",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "584": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_15",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "585": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_2",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "586": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_3",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "587": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_4",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "588": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_5",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "589": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_6",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "590": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_7",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "bed", "metadata": 6, "count": 1}]
   },
   "591": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "bed_dye_9_8",
     "ingredients": [{"name": "bed", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
@@ -4208,7 +4208,7 @@
     "output": [{"name": "amethyst_block", "metadata": 0, "count": 1}]
   },
   "618": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:andesite",
     "ingredients": [{"name": "stone", "count": 1}, {"name": "cobblestone", "count": 1}],
     "input": [[1, 2]],
@@ -4250,42 +4250,42 @@
     "output": [{"name": "arrow", "metadata": 0, "count": 4}]
   },
   "624": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:banner_pattern_bricks",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "brick_block", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "field_masoned_banner_pattern", "metadata": 0, "count": 1}]
   },
   "625": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:banner_pattern_creeper",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "skull", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "creeper_banner_pattern", "metadata": 0, "count": 1}]
   },
   "626": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:banner_pattern_flower",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "flower_banner_pattern", "metadata": 0, "count": 1}]
   },
   "627": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:banner_pattern_skull",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "skull", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "skull_banner_pattern", "metadata": 0, "count": 1}]
   },
   "628": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:banner_pattern_thing",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "enchanted_golden_apple", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "mojang_banner_pattern", "metadata": 0, "count": 1}]
   },
   "629": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:banner_pattern_vines",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "vine", "count": 1}],
     "input": [[1, 2]],
@@ -4313,7 +4313,7 @@
     "output": [{"name": "barrel", "metadata": 0, "count": 1}]
   },
   "633": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:basic_map_to_enhanced",
     "ingredients": [{"name": "empty_map", "count": 1}, {"name": "compass", "count": 1}],
     "input": [[1, 2]],
@@ -4348,7 +4348,7 @@
     "output": [{"name": "beehive", "metadata": 0, "count": 1}]
   },
   "638": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:beetroot_soup",
     "ingredients": [{"name": "bowl", "count": 1}, {"name": "beetroot", "count": 6}],
     "input": [[1, 2, 2, 2, 2, 2, 2]],
@@ -4434,14 +4434,14 @@
     "output": [{"name": "banner", "metadata": 0, "count": 1}]
   },
   "652": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:black_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "black_candle", "metadata": 0, "count": 1}]
   },
   "653": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:black_candle_from_ink_sac",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
@@ -4456,28 +4456,28 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "656": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:black_concrete_powder",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "657": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:black_concrete_powder_from_ink_sac",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "658": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:black_dye_from_ink_sac",
     "ingredients": [{"name": "ink_sac", "count": 1}],
     "input": [[1]],
     "output": [{"name": "black_dye", "metadata": 0, "count": 1}]
   },
   "659": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:black_dye_from_wither_rose",
     "ingredients": [{"name": "wither_rose", "count": 1}],
     "input": [[1]],
@@ -4554,7 +4554,7 @@
     "output": [{"name": "blast_furnace", "metadata": 0, "count": 1}]
   },
   "670": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:blaze_powder",
     "ingredients": [{"name": "blaze_rod", "count": 1}],
     "input": [[1]],
@@ -4568,14 +4568,14 @@
     "output": [{"name": "banner", "metadata": 4, "count": 1}]
   },
   "672": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:blue_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "blue_candle", "metadata": 0, "count": 1}]
   },
   "673": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:blue_candle_from_lapis_lazuli",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
@@ -4590,28 +4590,28 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "676": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:blue_concrete_powder",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "677": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:blue_concrete_powder_from_lapis_lazuli",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "678": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:blue_dye_from_cornflower",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
     "output": [{"name": "blue_dye", "metadata": 0, "count": 1}]
   },
   "679": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:blue_dye_from_lapis_lazuli",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}],
     "input": [[1]],
@@ -4681,21 +4681,21 @@
     "output": [{"name": "bone_block", "metadata": 0, "count": 1}]
   },
   "689": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:bone_meal_from_block",
     "ingredients": [{"name": "bone_block", "count": 1}],
     "input": [[1]],
     "output": [{"name": "bone_meal", "metadata": 0, "count": 9}]
   },
   "690": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:bone_meal_from_bone",
     "ingredients": [{"name": "bone", "count": 1}],
     "input": [[1]],
     "output": [{"name": "bone_meal", "metadata": 0, "count": 3}]
   },
   "691": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:book",
     "ingredients": [{"name": "paper", "count": 3}, {"name": "leather", "count": 1}],
     "input": [[1, 1, 1, 2]],
@@ -4787,14 +4787,14 @@
     "output": [{"name": "banner", "metadata": 3, "count": 1}]
   },
   "705": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:brown_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "brown_candle", "metadata": 0, "count": 1}]
   },
   "706": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:brown_candle_from_cocoa_beans",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
@@ -4809,21 +4809,21 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "709": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:brown_concrete_powder",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "710": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:brown_concrete_powder_from_cocoa_beans",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "711": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:brown_dye_from_cocoa_beans",
     "ingredients": [{"name": "cocoa_beans", "count": 1}],
     "input": [[1]],
@@ -5188,7 +5188,13 @@
     "input": [[1, 1], [1, 1], [1, 1]],
     "output": [{"name": "cobblestone_wall", "metadata": 0, "count": 6}]
   },
-  "765": {"type": "crafting_table", "name": "minecraft:cobweb_to_string", "ingredients": [{"name": "web", "count": 1}], "input": [[1]], "output": [{"name": "string", "metadata": 0, "count": 9}]},
+  "765": {
+    "type": "crafting_table_shapeless",
+    "name": "minecraft:cobweb_to_string",
+    "ingredients": [{"name": "web", "count": 1}],
+    "input": [[1]],
+    "output": [{"name": "string", "metadata": 0, "count": 9}]
+  },
   "766": {
     "type": "crafting_table",
     "name": "minecraft:comparator",
@@ -5540,7 +5546,7 @@
     "output": [{"name": "banner", "metadata": 6, "count": 1}]
   },
   "816": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:cyan_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
@@ -5555,21 +5561,21 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "819": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:cyan_concrete_powder",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "820": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:cyan_dye",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "cyan_dye", "metadata": 0, "count": 2}]
   },
   "821": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:cyan_dye_from_lapis_lazuli",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
@@ -5915,7 +5921,7 @@
     "output": [{"name": "emerald_block", "metadata": 0, "count": 1}]
   },
   "873": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:empty_map_to_enhanced",
     "ingredients": [{"name": "empty_map", "count": 1}, {"name": "compass", "count": 1}],
     "input": [[1, 2]],
@@ -5971,7 +5977,7 @@
     "output": [{"name": "ender_chest", "metadata": 0, "count": 1}]
   },
   "881": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:ender_eye",
     "ingredients": [{"name": "ender_pearl", "count": 1}, {"name": "blaze_powder", "count": 1}],
     "input": [[1, 2]],
@@ -5992,7 +5998,7 @@
     "output": [{"name": "fence_gate", "metadata": 0, "count": 1}]
   },
   "884": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:fermented_spider_eye",
     "ingredients": [{"name": "spider_eye", "count": 1}, {"name": "brown_mushroom", "count": 1}, {"name": "sugar", "count": 1}],
     "input": [[1, 2, 3]],
@@ -6027,7 +6033,7 @@
     "output": [{"name": "fletching_table", "metadata": 0, "count": 1}]
   },
   "889": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:flint_and_steel",
     "ingredients": [{"name": "iron_ingot", "count": 1}, {"name": "flint", "count": 1}],
     "input": [[1, 2]],
@@ -6076,7 +6082,7 @@
     "output": [{"name": "glass_pane", "metadata": 0, "count": 16}]
   },
   "896": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:glow_frame",
     "ingredients": [{"name": "frame", "count": 1}, {"name": "glow_ink_sac", "count": 1}],
     "input": [[1, 2]],
@@ -6202,7 +6208,7 @@
     "output": [{"name": "golden_sword", "metadata": 0, "count": 1}]
   },
   "914": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:granite",
     "ingredients": [{"name": "stone", "count": 1}, {"name": "quartz", "count": 1}],
     "input": [[1, 2]],
@@ -6230,7 +6236,7 @@
     "output": [{"name": "banner", "metadata": 8, "count": 1}]
   },
   "918": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:gray_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
@@ -6245,35 +6251,35 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "921": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:gray_concrete_powder",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "922": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:gray_dye",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "gray_dye", "metadata": 0, "count": 2}]
   },
   "923": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:gray_dye_from_black_bonemeal",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "gray_dye", "metadata": 0, "count": 2}]
   },
   "924": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:gray_dye_from_ink_bonemeal",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "gray_dye", "metadata": 0, "count": 2}]
   },
   "925": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:gray_dye_from_ink_white",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
@@ -6315,7 +6321,7 @@
     "output": [{"name": "banner", "metadata": 2, "count": 1}]
   },
   "931": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:green_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
@@ -6330,7 +6336,7 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "934": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:green_concrete_powder",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
@@ -6449,7 +6455,7 @@
     "output": [{"name": "honey_block", "metadata": 0, "count": 1}, {"name": "glass_bottle", "metadata": 0, "count": 4}]
   },
   "951": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:honey_bottle",
     "ingredients": [{"name": "honey_block", "count": 1}, {"name": "glass_bottle", "count": 4}],
     "input": [[1, 2, 2, 2, 2]],
@@ -6815,7 +6821,7 @@
     "output": [{"name": "banner", "metadata": 12, "count": 1}]
   },
   "1005": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_blue_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
@@ -6836,42 +6842,42 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "1008": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_blue_concrete_powder",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1009": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_blue_dye",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "light_blue_dye", "metadata": 0, "count": 2}]
   },
   "1010": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_blue_dye_from_blue_bonemeal",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "light_blue_dye", "metadata": 0, "count": 2}]
   },
   "1011": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_blue_dye_from_blue_orchid",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
     "output": [{"name": "light_blue_dye", "metadata": 0, "count": 1}]
   },
   "1012": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_blue_dye_from_lapis_bonemeal",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "light_blue_dye", "metadata": 0, "count": 2}]
   },
   "1013": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_blue_dye_from_lapis_white",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
@@ -6920,7 +6926,7 @@
     "output": [{"name": "banner", "metadata": 7, "count": 1}]
   },
   "1020": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
@@ -6934,70 +6940,70 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 3}]
   },
   "1022": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_concrete_powder",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1023": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_dye",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "white_dye", "count": 2}],
     "input": [[1, 2, 2]],
     "output": [{"name": "light_gray_dye", "metadata": 0, "count": 3}]
   },
   "1024": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_dye_from_azure_bluet",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
     "output": [{"name": "light_gray_dye", "metadata": 0, "count": 1}]
   },
   "1025": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_dye_from_black_bonemeal",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "bone_meal", "count": 2}],
     "input": [[1, 2, 2]],
     "output": [{"name": "light_gray_dye", "metadata": 0, "count": 3}]
   },
   "1026": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_dye_from_gray_bonemeal",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "light_gray_dye", "metadata": 0, "count": 2}]
   },
   "1027": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_dye_from_gray_white",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "light_gray_dye", "metadata": 0, "count": 2}]
   },
   "1028": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_dye_from_ink_bonemeal",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "bone_meal", "count": 2}],
     "input": [[1, 2, 2]],
     "output": [{"name": "light_gray_dye", "metadata": 0, "count": 3}]
   },
   "1029": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_dye_from_ink_white",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "white_dye", "count": 2}],
     "input": [[1, 2, 2]],
     "output": [{"name": "light_gray_dye", "metadata": 0, "count": 3}]
   },
   "1030": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_dye_from_oxeye_daisy",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
     "output": [{"name": "light_gray_dye", "metadata": 0, "count": 1}]
   },
   "1031": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:light_gray_dye_from_white_tulip",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
@@ -7060,7 +7066,7 @@
     "output": [{"name": "banner", "metadata": 10, "count": 1}]
   },
   "1040": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:lime_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
@@ -7068,21 +7074,21 @@
   },
   "1041": {"type": "crafting_table", "name": "minecraft:lime_carpet", "ingredients": [{"name": "wool", "count": 2}], "input": [[1], [1]], "output": [{"name": "carpet", "metadata": 0, "count": 3}]},
   "1042": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:lime_concrete_powder",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1043": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:lime_dye",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "lime_dye", "metadata": 0, "count": 2}]
   },
   "1044": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:lime_dye_from_bonemeal",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
@@ -7159,7 +7165,7 @@
     "output": [{"name": "banner", "metadata": 13, "count": 1}]
   },
   "1055": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
@@ -7174,70 +7180,70 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "1058": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_concrete_powder",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1059": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_dye",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "red_dye", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2, 3]],
     "output": [{"name": "magenta_dye", "metadata": 0, "count": 3}]
   },
   "1060": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_dye_from_allium",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
     "output": [{"name": "magenta_dye", "metadata": 0, "count": 1}]
   },
   "1061": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_dye_from_blue_ink_bonemeal",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "red_dye", "count": 2}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2, 2, 3]],
     "output": [{"name": "magenta_dye", "metadata": 0, "count": 4}]
   },
   "1062": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_dye_from_blue_ink_white",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "red_dye", "count": 2}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2, 2, 3]],
     "output": [{"name": "magenta_dye", "metadata": 0, "count": 4}]
   },
   "1063": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_dye_from_lapis_ink_bonemeal",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "red_dye", "count": 2}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2, 2, 3]],
     "output": [{"name": "magenta_dye", "metadata": 0, "count": 4}]
   },
   "1064": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_dye_from_lapis_ink_white",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "red_dye", "count": 2}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2, 2, 3]],
     "output": [{"name": "magenta_dye", "metadata": 0, "count": 4}]
   },
   "1065": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_dye_from_lapis_red_pink",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "red_dye", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2, 3]],
     "output": [{"name": "magenta_dye", "metadata": 0, "count": 3}]
   },
   "1066": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_dye_from_lilac",
     "ingredients": [{"name": "double_plant", "count": 1}],
     "input": [[1]],
     "output": [{"name": "magenta_dye", "metadata": 0, "count": 2}]
   },
   "1067": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magenta_dye_from_purple_and_pink",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
@@ -7279,7 +7285,7 @@
     "output": [{"name": "magma", "metadata": 0, "count": 1}]
   },
   "1073": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:magma_cream",
     "ingredients": [{"name": "blaze_powder", "count": 1}, {"name": "slime_ball", "count": 1}],
     "input": [[1, 2]],
@@ -7321,14 +7327,14 @@
     "output": [{"name": "moss_carpet", "metadata": 0, "count": 3}]
   },
   "1079": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:mossy_cobblestone",
     "ingredients": [{"name": "cobblestone", "count": 1}, {"name": "vine", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "mossy_cobblestone", "metadata": 0, "count": 1}]
   },
   "1080": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:mossy_cobblestone_from_moss",
     "ingredients": [{"name": "cobblestone", "count": 1}, {"name": "moss_block", "count": 1}],
     "input": [[1, 2]],
@@ -7363,21 +7369,21 @@
     "output": [{"name": "cobblestone_wall", "metadata": 0, "count": 6}]
   },
   "1085": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:mossy_stonebrick",
     "ingredients": [{"name": "stonebrick", "count": 1}, {"name": "vine", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "stonebrick", "metadata": 0, "count": 1}]
   },
   "1086": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:mossy_stonebrick_from_moss",
     "ingredients": [{"name": "stonebrick", "count": 1}, {"name": "moss_block", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "stonebrick", "metadata": 0, "count": 1}]
   },
   "1087": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:mushroom_stew",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}],
     "input": [[1, 2, 3]],
@@ -7426,7 +7432,7 @@
     "output": [{"name": "netherite_block", "metadata": 0, "count": 1}]
   },
   "1094": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:netherite_ingot",
     "ingredients": [{"name": "netherite_scrap", "count": 4}, {"name": "gold_ingot", "count": 4}],
     "input": [[1, 1, 1, 1, 2, 2, 2, 2]],
@@ -7512,7 +7518,7 @@
     "output": [{"name": "banner", "metadata": 14, "count": 1}]
   },
   "1108": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:orange_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
@@ -7527,21 +7533,21 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "1111": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:orange_concrete_powder",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1112": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:orange_dye_from_orange_tulip",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
     "output": [{"name": "orange_dye", "metadata": 0, "count": 1}]
   },
   "1113": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:orange_dye_from_red_yellow",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
@@ -7604,7 +7610,7 @@
     "output": [{"name": "banner", "metadata": 9, "count": 1}]
   },
   "1122": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:pink_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
@@ -7619,35 +7625,35 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "1125": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:pink_concrete_powder",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1126": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:pink_dye",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "pink_dye", "metadata": 0, "count": 2}]
   },
   "1127": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:pink_dye_from_peony",
     "ingredients": [{"name": "double_plant", "count": 1}],
     "input": [[1]],
     "output": [{"name": "pink_dye", "metadata": 0, "count": 2}]
   },
   "1128": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:pink_dye_from_pink_tulip",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
     "output": [{"name": "pink_dye", "metadata": 0, "count": 1}]
   },
   "1129": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:pink_dye_from_red_bonemeal",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
@@ -7885,7 +7891,7 @@
     "output": [{"name": "cobblestone_wall", "metadata": 0, "count": 6}]
   },
   "1163": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:pumpkin_pie",
     "ingredients": [{"name": "pumpkin", "count": 1}, {"name": "sugar", "count": 1}, {"name": "egg", "count": 1}],
     "input": [[1, 2, 3]],
@@ -7906,7 +7912,7 @@
     "output": [{"name": "banner", "metadata": 5, "count": 1}]
   },
   "1166": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:purple_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
@@ -7921,21 +7927,21 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "1169": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:purple_concrete_powder",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1170": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:purple_dye",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "purple_dye", "metadata": 0, "count": 2}]
   },
   "1171": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:purple_dye_from_lapis_lazuli",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
@@ -8005,14 +8011,14 @@
     "output": [{"name": "quartz_stairs", "metadata": 0, "count": 4}]
   },
   "1181": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:rabbit_stew_from_brown_mushroom",
     "ingredients": [{"name": "bowl", "count": 1}, {"name": "baked_potato", "count": 1}, {"name": "carrot", "count": 1}, {"name": "brown_mushroom", "count": 1}, {"name": "cooked_rabbit", "count": 1}],
     "input": [[1, 2, 3, 4, 5]],
     "output": [{"name": "rabbit_stew", "metadata": 0, "count": 1}]
   },
   "1182": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:rabbit_stew_from_red_mushroom",
     "ingredients": [{"name": "bowl", "count": 1}, {"name": "baked_potato", "count": 1}, {"name": "carrot", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "cooked_rabbit", "count": 1}],
     "input": [[1, 2, 3, 4, 5]],
@@ -8075,7 +8081,7 @@
     "output": [{"name": "banner", "metadata": 1, "count": 1}]
   },
   "1191": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:red_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
@@ -8090,35 +8096,35 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "1194": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:red_concrete_powder",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1195": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:red_dye_from_beetroot",
     "ingredients": [{"name": "beetroot", "count": 1}],
     "input": [[1]],
     "output": [{"name": "red_dye", "metadata": 0, "count": 1}]
   },
   "1196": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:red_dye_from_poppy",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
     "output": [{"name": "red_dye", "metadata": 0, "count": 1}]
   },
   "1197": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:red_dye_from_rose_bush",
     "ingredients": [{"name": "double_plant", "count": 1}],
     "input": [[1]],
     "output": [{"name": "red_dye", "metadata": 0, "count": 2}]
   },
   "1198": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:red_dye_from_tulip",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
@@ -8985,91 +8991,91 @@
   },
   "1326": {"type": "crafting_table", "name": "minecraft:sugar", "ingredients": [{"name": "sugar_cane", "count": 1}], "input": [[1]], "output": [{"name": "sugar", "metadata": 0, "count": 1}]},
   "1327": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_allium",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 7, "count": 1}]
   },
   "1328": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_azure_bluet",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 3, "count": 1}]
   },
   "1329": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_blue_orchid",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 6, "count": 1}]
   },
   "1330": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_cornflower",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 1, "count": 1}]
   },
   "1331": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_dandelion",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "yellow_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 5, "count": 1}]
   },
   "1332": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_lily_of_the_valley",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 4, "count": 1}]
   },
   "1333": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_oxeye_daisy",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 8, "count": 1}]
   },
   "1334": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_poppy",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 0, "count": 1}]
   },
   "1335": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_tulip_orange",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 2, "count": 1}]
   },
   "1336": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_tulip_pink",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 2, "count": 1}]
   },
   "1337": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_tulip_red",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 2, "count": 1}]
   },
   "1338": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_tulip_white",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "red_flower", "count": 1}],
     "input": [[1, 2, 3, 4]],
     "output": [{"name": "suspicious_stew", "metadata": 2, "count": 1}]
   },
   "1339": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:suspicious_stew_from_wither_rose",
     "ingredients": [{"name": "brown_mushroom", "count": 1}, {"name": "red_mushroom", "count": 1}, {"name": "bowl", "count": 1}, {"name": "wither_rose", "count": 1}],
     "input": [[1, 2, 3, 4]],
@@ -9104,7 +9110,7 @@
     "output": [{"name": "tnt_minecart", "metadata": 0, "count": 1}]
   },
   "1344": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:trapped_chest",
     "ingredients": [{"name": "chest", "count": 1}, {"name": "tripwire_hook", "count": 1}],
     "input": [[1, 2]],
@@ -9237,112 +9243,112 @@
     "output": [{"name": "warped_trapdoor", "metadata": 0, "count": 2}]
   },
   "1363": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_copper_block",
     "ingredients": [{"name": "copper_block", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_copper", "metadata": 0, "count": 1}]
   },
   "1364": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_cut_copper",
     "ingredients": [{"name": "cut_copper", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_cut_copper", "metadata": 0, "count": 1}]
   },
   "1365": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_cut_copper_slab",
     "ingredients": [{"name": "cut_copper_slab", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_cut_copper_slab", "metadata": 0, "count": 1}]
   },
   "1366": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_cut_copper_stairs",
     "ingredients": [{"name": "cut_copper_stairs", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_cut_copper_stairs", "metadata": 0, "count": 1}]
   },
   "1367": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_exposed_copper",
     "ingredients": [{"name": "exposed_copper", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_exposed_copper", "metadata": 0, "count": 1}]
   },
   "1368": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_exposed_cut_copper",
     "ingredients": [{"name": "exposed_cut_copper", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_exposed_cut_copper", "metadata": 0, "count": 1}]
   },
   "1369": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_exposed_cut_copper_slab",
     "ingredients": [{"name": "exposed_cut_copper_slab", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_exposed_cut_copper_slab", "metadata": 0, "count": 1}]
   },
   "1370": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_exposed_cut_copper_stairs",
     "ingredients": [{"name": "exposed_cut_copper_stairs", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_exposed_cut_copper_stairs", "metadata": 0, "count": 1}]
   },
   "1371": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_oxidized_copper",
     "ingredients": [{"name": "oxidized_copper", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_oxidized_copper", "metadata": 0, "count": 1}]
   },
   "1372": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_oxidized_cut_copper",
     "ingredients": [{"name": "oxidized_cut_copper", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_oxidized_cut_copper", "metadata": 0, "count": 1}]
   },
   "1373": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_oxidized_cut_copper_slab",
     "ingredients": [{"name": "oxidized_cut_copper_slab", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_oxidized_cut_copper_slab", "metadata": 0, "count": 1}]
   },
   "1374": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_oxidized_cut_copper_stairs",
     "ingredients": [{"name": "oxidized_cut_copper_stairs", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_oxidized_cut_copper_stairs", "metadata": 0, "count": 1}]
   },
   "1375": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_weathered_copper",
     "ingredients": [{"name": "weathered_copper", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_weathered_copper", "metadata": 0, "count": 1}]
   },
   "1376": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_weathered_cut_copper",
     "ingredients": [{"name": "weathered_cut_copper", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_weathered_cut_copper", "metadata": 0, "count": 1}]
   },
   "1377": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_weathered_cut_copper_slab",
     "ingredients": [{"name": "weathered_cut_copper_slab", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "waxed_weathered_cut_copper_slab", "metadata": 0, "count": 1}]
   },
   "1378": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:waxing_weathered_cut_copper_stairs",
     "ingredients": [{"name": "weathered_cut_copper_stairs", "count": 1}, {"name": "honeycomb", "count": 1}],
     "input": [[1, 2]],
@@ -9357,14 +9363,14 @@
     "output": [{"name": "banner", "metadata": 15, "count": 1}]
   },
   "1381": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:white_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "white_candle", "metadata": 0, "count": 1}]
   },
   "1382": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:white_candle_from_bonemeal",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
@@ -9372,28 +9378,28 @@
   },
   "1383": {"type": "crafting_table", "name": "minecraft:white_carpet", "ingredients": [{"name": "wool", "count": 2}], "input": [[1], [1]], "output": [{"name": "carpet", "metadata": 0, "count": 3}]},
   "1384": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:white_concrete_powder",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1385": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:white_concrete_powder_from_bonemeal",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1386": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:white_dye_from_bone_meal",
     "ingredients": [{"name": "bone_meal", "count": 1}],
     "input": [[1]],
     "output": [{"name": "white_dye", "metadata": 0, "count": 1}]
   },
   "1387": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:white_dye_from_lily_of_the_valley",
     "ingredients": [{"name": "red_flower", "count": 1}],
     "input": [[1]],
@@ -9519,7 +9525,7 @@
     "output": [{"name": "wooden_sword", "metadata": 0, "count": 1}]
   },
   "1405": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:writable_book",
     "ingredients": [{"name": "book", "count": 1}, {"name": "ink_sac", "count": 1}, {"name": "feather", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9533,7 +9539,7 @@
     "output": [{"name": "banner", "metadata": 11, "count": 1}]
   },
   "1407": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:yellow_candle",
     "ingredients": [{"name": "candle", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
@@ -9548,21 +9554,21 @@
     "output": [{"name": "carpet", "metadata": 0, "count": 8}]
   },
   "1410": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:yellow_concrete_powder",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "sand", "count": 4}, {"name": "gravel", "count": 4}],
     "input": [[1, 2, 2, 2, 2, 3, 3, 3, 3]],
     "output": [{"name": "concrete_powder", "metadata": 0, "count": 8}]
   },
   "1411": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:yellow_dye_from_dandelion",
     "ingredients": [{"name": "yellow_flower", "count": 1}],
     "input": [[1]],
     "output": [{"name": "yellow_dye", "metadata": 0, "count": 1}]
   },
   "1412": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "minecraft:yellow_dye_from_sunflower",
     "ingredients": [{"name": "double_plant", "count": 1}],
     "input": [[1]],
@@ -9604,7 +9610,7 @@
     "output": [{"name": "oak_stairs", "metadata": 0, "count": 4}]
   },
   "1418": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_0_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9647,7 +9653,7 @@
     ]
   },
   "1419": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_10_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9690,7 +9696,7 @@
     ]
   },
   "1420": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_11_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9733,7 +9739,7 @@
     ]
   },
   "1421": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_12_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9776,7 +9782,7 @@
     ]
   },
   "1422": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_13_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9819,7 +9825,7 @@
     ]
   },
   "1423": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_14_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9862,7 +9868,7 @@
     ]
   },
   "1424": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_15_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9905,7 +9911,7 @@
     ]
   },
   "1425": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_16_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9948,7 +9954,7 @@
     ]
   },
   "1426": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_17_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -9991,7 +9997,7 @@
     ]
   },
   "1427": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_18_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10034,7 +10040,7 @@
     ]
   },
   "1428": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_19_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10077,7 +10083,7 @@
     ]
   },
   "1429": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_1_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10120,7 +10126,7 @@
     ]
   },
   "1430": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_2_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10163,7 +10169,7 @@
     ]
   },
   "1431": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_3_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10206,7 +10212,7 @@
     ]
   },
   "1432": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_4_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10249,7 +10255,7 @@
     ]
   },
   "1433": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_5_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10292,7 +10298,7 @@
     ]
   },
   "1434": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_6_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10335,7 +10341,7 @@
     ]
   },
   "1435": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_7_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10378,7 +10384,7 @@
     ]
   },
   "1436": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_8_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10421,7 +10427,7 @@
     ]
   },
   "1437": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_charge_9_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}, {"name": "firework_star", "count": 1}],
     "input": [[1, 2, 3]],
@@ -10464,7 +10470,7 @@
     ]
   },
   "1438": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_0_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "ink_sac", "count": 1}],
     "input": [[1, 2]],
@@ -10497,7 +10503,7 @@
     ]
   },
   "1439": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_10_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "lime_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10530,7 +10536,7 @@
     ]
   },
   "1440": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_11_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "yellow_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10563,7 +10569,7 @@
     ]
   },
   "1441": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_12_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "light_blue_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10596,7 +10602,7 @@
     ]
   },
   "1442": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_13_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "magenta_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10629,7 +10635,7 @@
     ]
   },
   "1443": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_14_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "orange_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10662,7 +10668,7 @@
     ]
   },
   "1444": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_15_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "bone_meal", "count": 1}],
     "input": [[1, 2]],
@@ -10695,7 +10701,7 @@
     ]
   },
   "1445": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_16_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "black_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10728,7 +10734,7 @@
     ]
   },
   "1446": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_17_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "brown_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10761,7 +10767,7 @@
     ]
   },
   "1447": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_18_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "blue_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10794,7 +10800,7 @@
     ]
   },
   "1448": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_19_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "white_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10827,7 +10833,7 @@
     ]
   },
   "1449": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_1_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "red_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10860,7 +10866,7 @@
     ]
   },
   "1450": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_2_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "green_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10893,7 +10899,7 @@
     ]
   },
   "1451": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_3_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "cocoa_beans", "count": 1}],
     "input": [[1, 2]],
@@ -10926,7 +10932,7 @@
     ]
   },
   "1452": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_4_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "lapis_lazuli", "count": 1}],
     "input": [[1, 2]],
@@ -10959,7 +10965,7 @@
     ]
   },
   "1453": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_5_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "purple_dye", "count": 1}],
     "input": [[1, 2]],
@@ -10992,7 +10998,7 @@
     ]
   },
   "1454": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_6_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "cyan_dye", "count": 1}],
     "input": [[1, 2]],
@@ -11025,7 +11031,7 @@
     ]
   },
   "1455": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_7_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "light_gray_dye", "count": 1}],
     "input": [[1, 2]],
@@ -11058,7 +11064,7 @@
     ]
   },
   "1456": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_8_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "gray_dye", "count": 1}],
     "input": [[1, 2]],
@@ -11091,7 +11097,7 @@
     ]
   },
   "1457": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_dye_9_recipeId",
     "ingredients": [{"name": "gunpowder", "count": 1}, {"name": "pink_dye", "count": 1}],
     "input": [[1, 2]],
@@ -11124,7 +11130,7 @@
     ]
   },
   "1458": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "paper_sulphur_recipeId",
     "ingredients": [{"name": "paper", "count": 1}, {"name": "gunpowder", "count": 1}],
     "input": [[1, 2]],
@@ -14168,2100 +14174,2100 @@
     "output": [{"name": "wooden_sword", "metadata": 0, "count": 1}]
   },
   "1848": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_1",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1849": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_10",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1850": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_11",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1851": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_12",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1852": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_13",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1853": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_14",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1854": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_15",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1855": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_2",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1856": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_3",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1857": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_4",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1858": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_5",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1859": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_6",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1860": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_7",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1861": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_8",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1862": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_0_9",
     "ingredients": [{"name": "ink_sac", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1863": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_0",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1864": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_1",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1865": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_11",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1866": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_12",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1867": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_13",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1868": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_14",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1869": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_15",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1870": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_2",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1871": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_3",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1872": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_4",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1873": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_5",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1874": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_6",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1875": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_7",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1876": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_8",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1877": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_10_9",
     "ingredients": [{"name": "lime_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1878": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_0",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1879": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_1",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1880": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_10",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1881": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_12",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1882": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_13",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1883": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_14",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1884": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_15",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1885": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_2",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1886": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_3",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1887": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_4",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1888": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_5",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1889": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_6",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1890": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_7",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1891": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_8",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1892": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_11_9",
     "ingredients": [{"name": "yellow_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1893": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_0",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1894": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_1",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1895": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_10",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1896": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_11",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1897": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_13",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1898": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_14",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1899": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_15",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1900": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_2",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1901": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_3",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1902": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_4",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1903": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_5",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1904": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_6",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1905": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_7",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1906": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_8",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1907": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_12_9",
     "ingredients": [{"name": "light_blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1908": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_0",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1909": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_1",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1910": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_10",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1911": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_11",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1912": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_12",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1913": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_14",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1914": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_15",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1915": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_2",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1916": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_3",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1917": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_4",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1918": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_5",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1919": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_6",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1920": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_7",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1921": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_8",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1922": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_13_9",
     "ingredients": [{"name": "magenta_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1923": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_0",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1924": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_1",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1925": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_10",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1926": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_11",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1927": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_12",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1928": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_13",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1929": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_15",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1930": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_2",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1931": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_3",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1932": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_4",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1933": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_5",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1934": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_6",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1935": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_7",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1936": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_8",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1937": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_14_9",
     "ingredients": [{"name": "orange_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1938": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_0",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1939": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_1",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1940": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_10",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1941": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_11",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1942": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_12",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1943": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_13",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1944": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_14",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1945": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_2",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1946": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_3",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1947": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_4",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1948": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_5",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1949": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_6",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1950": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_7",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1951": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_8",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1952": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_15_9",
     "ingredients": [{"name": "bone_meal", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1953": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_1",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1954": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_10",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1955": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_11",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1956": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_12",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1957": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_13",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1958": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_14",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1959": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_15",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1960": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_2",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1961": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_3",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1962": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_4",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1963": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_5",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1964": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_6",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1965": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_7",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1966": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_8",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1967": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_16_9",
     "ingredients": [{"name": "black_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1968": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_0",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1969": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_1",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1970": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_10",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1971": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_11",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1972": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_12",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1973": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_13",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1974": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_14",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1975": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_15",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1976": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_2",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1977": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_4",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1978": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_5",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1979": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_6",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1980": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_7",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1981": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_8",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1982": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_17_9",
     "ingredients": [{"name": "brown_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1983": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_0",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1984": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_1",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1985": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_10",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1986": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_11",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1987": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_12",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1988": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_13",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1989": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_14",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1990": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_15",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1991": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_2",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1992": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_3",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1993": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_5",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1994": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_6",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1995": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_7",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1996": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_8",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1997": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_18_9",
     "ingredients": [{"name": "blue_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1998": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_0",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "1999": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_1",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2000": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_10",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2001": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_11",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2002": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_12",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2003": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_13",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2004": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_14",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2005": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_2",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2006": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_3",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2007": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_4",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2008": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_5",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2009": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_6",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2010": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_7",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2011": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_8",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2012": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_19_9",
     "ingredients": [{"name": "white_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2013": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_0",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2014": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_10",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2015": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_11",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2016": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_12",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2017": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_13",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2018": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_14",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2019": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_15",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2020": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_2",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2021": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_3",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2022": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_4",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2023": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_5",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2024": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_6",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2025": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_7",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2026": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_8",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2027": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_1_9",
     "ingredients": [{"name": "red_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2028": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_0",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2029": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_1",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2030": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_10",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2031": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_11",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2032": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_12",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2033": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_13",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2034": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_14",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2035": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_15",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2036": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_3",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2037": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_4",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2038": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_5",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2039": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_6",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2040": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_7",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2041": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_8",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2042": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_2_9",
     "ingredients": [{"name": "green_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2043": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_0",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2044": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_1",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2045": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_10",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2046": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_11",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2047": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_12",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2048": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_13",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2049": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_14",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2050": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_15",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2051": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_2",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2052": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_4",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2053": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_5",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2054": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_6",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2055": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_7",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2056": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_8",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2057": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_3_9",
     "ingredients": [{"name": "cocoa_beans", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2058": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_0",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2059": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_1",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2060": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_10",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2061": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_11",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2062": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_12",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2063": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_13",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2064": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_14",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2065": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_15",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2066": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_2",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2067": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_3",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2068": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_5",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2069": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_6",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2070": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_7",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2071": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_8",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2072": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_4_9",
     "ingredients": [{"name": "lapis_lazuli", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2073": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_0",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2074": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_1",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2075": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_10",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2076": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_11",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2077": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_12",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2078": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_13",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2079": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_14",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2080": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_15",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2081": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_2",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2082": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_3",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2083": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_4",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2084": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_6",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2085": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_7",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2086": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_8",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2087": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_5_9",
     "ingredients": [{"name": "purple_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2088": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_0",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2089": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_1",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2090": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_10",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2091": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_11",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2092": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_12",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2093": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_13",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2094": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_14",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2095": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_15",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2096": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_2",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2097": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_3",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2098": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_4",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2099": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_5",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2100": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_7",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2101": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_8",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2102": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_6_9",
     "ingredients": [{"name": "cyan_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2103": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_0",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2104": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_1",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2105": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_10",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2106": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_11",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2107": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_12",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2108": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_13",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2109": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_14",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2110": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_15",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2111": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_2",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2112": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_3",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2113": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_4",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2114": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_5",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2115": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_6",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2116": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_8",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2117": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_7_9",
     "ingredients": [{"name": "light_gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2118": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_0",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2119": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_1",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2120": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_10",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2121": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_11",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2122": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_12",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2123": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_13",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2124": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_14",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2125": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_15",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2126": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_2",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2127": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_3",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2128": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_4",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2129": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_5",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2130": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_6",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2131": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_7",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2132": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_8_9",
     "ingredients": [{"name": "gray_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2133": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_0",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2134": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_1",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2135": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_10",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2136": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_11",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2137": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_12",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2138": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_13",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2139": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_14",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2140": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_15",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2141": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_2",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2142": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_3",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2143": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_4",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2144": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_5",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2145": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_6",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2146": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_7",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],
     "output": [{"name": "wool", "metadata": 0, "count": 1}]
   },
   "2147": {
-    "type": "crafting_table",
+    "type": "crafting_table_shapeless",
     "name": "wool_dye_wool_9_8",
     "ingredients": [{"name": "pink_dye", "count": 1}, {"name": "wool", "count": 1}],
     "input": [[1, 2]],

--- a/schemas/recipes_schema.json
+++ b/schemas/recipes_schema.json
@@ -99,7 +99,7 @@
         },
         {
           "title":"new recipe",
-          "description":"New recipe schema",
+          "description":"Bedrock recipe schema",
           "type": "object",
           "properties": {
             "name": {
@@ -114,10 +114,9 @@
               "enum": [
                 "multi",
                 "cartography_table",
-                "shapeless",
                 "stonecutter",
                 "crafting_table",
-                "shaped",
+                "crafting_table_shapeless",
                 "shulker_box",
                 "furnace",
                 "blast_furnace",


### PR DESCRIPTION
* add some missing biomes, remove some invalid items
* make it clearer the new recipe schema is only used on bedrock , rename `shapeless` to `crafting_table_shapeless` for clarity