### PR TITLE
bedrock: update protocol subchunk field

### DIFF
--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -9311,10 +9311,6 @@
                   "default": "void"
                 }
               ]
-            },
-            {
-              "name": "blob_id",
-              "type": "lu64"
             }
           ]
         ]

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3304,7 +3304,6 @@ SubChunkEntryWithoutCaching: []lu32
       3: too_low
    heightmap: heightmap_type ?
       if has_data: '["buffer", { "count": 256 }]'
-   blob_id: lu64
 
 SubChunkEntryWithCaching: []lu32
    dx: u8


### PR DESCRIPTION
remove blob_id field from non-cached subchunk packet