### PR TITLE
Change schemas for new extractor

### DIFF
--- a/schemas/biomes_schema.json
+++ b/schemas/biomes_schema.json
@@ -29,10 +29,6 @@
         "description": "The type of precipitation: none, rain or snow",
         "type": "string"
       },
-      "depth": {
-        "description": "The depth of a biome",
-        "type": "number"
-      },
       "dimension": {
         "description": "The dimension of a biome: overworld, nether or end",
         "type": "string"

--- a/schemas/blocks_schema.json
+++ b/schemas/blocks_schema.json
@@ -26,7 +26,7 @@
           "number",
           "null"
         ],
-        "minimum": 0
+        "minimum": -1
       },
       "stackSize": {
         "description": "Stack size for a block",


### PR DESCRIPTION
Block hardness of -1 means unbreakable per: https://github.com/PrismarineJS/prismarine-block/blob/9f7355bd7ee13afa3c465d066d315847851d58df/index.js#L319-L322

I have no idea where to get biome depth, or since it has been removed from the mc client as far as I can tell, if anybody knows how to get this number, I'll add it back.