### PR TITLE
Fix 1.17+ biome colors

### DIFF
--- a/data/pc/1.17/biomes.json
+++ b/data/pc/1.17/biomes.json
@@ -5,10 +5,10 @@
     "category": "ocean",
     "temperature": 0.5,
     "precipitation": "rain",
-    "depth": -1.0,
+    "depth": -1,
     "dimension": "overworld",
     "displayName": "Ocean",
-    "color": 8103167,
+    "color": 112,
     "rainfall": 0.5
   },
   {
@@ -20,20 +20,20 @@
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Plains",
-    "color": 7907327,
+    "color": 9286496,
     "rainfall": 0.4
   },
   {
     "id": 2,
     "name": "desert",
     "category": "desert",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Desert",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 16421912,
+    "rainfall": 0
   },
   {
     "id": 3,
@@ -41,10 +41,10 @@
     "category": "extreme_hills",
     "temperature": 0.2,
     "precipitation": "rain",
-    "depth": 1.0,
+    "depth": 1,
     "dimension": "overworld",
     "displayName": "Mountains",
-    "color": 8233727,
+    "color": 6316128,
     "rainfall": 0.3
   },
   {
@@ -56,7 +56,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Forest",
-    "color": 7972607,
+    "color": 353825,
     "rainfall": 0.8
   },
   {
@@ -68,7 +68,7 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Taiga",
-    "color": 8233983,
+    "color": 747097,
     "rainfall": 0.8
   },
   {
@@ -80,7 +80,7 @@
     "depth": -0.2,
     "dimension": "overworld",
     "displayName": "Swamp",
-    "color": 7907327,
+    "color": 522674,
     "rainfall": 0.9
   },
   {
@@ -92,20 +92,20 @@
     "depth": -0.5,
     "dimension": "overworld",
     "displayName": "River",
-    "color": 8103167,
+    "color": 255,
     "rainfall": 0.5
   },
   {
     "id": 8,
     "name": "nether_wastes",
     "category": "nether",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.1,
     "dimension": "nether",
     "displayName": "Nether Wastes",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 12532539,
+    "rainfall": 0
   },
   {
     "id": 9,
@@ -116,55 +116,55 @@
     "depth": 0.1,
     "dimension": "end",
     "displayName": "The End",
-    "color": 0,
+    "color": 8421631,
     "rainfall": 0.5
   },
   {
     "id": 10,
     "name": "frozen_ocean",
     "category": "ocean",
-    "temperature": 0.0,
+    "temperature": 0,
     "precipitation": "snow",
-    "depth": -1.0,
+    "depth": -1,
     "dimension": "overworld",
     "displayName": "Frozen Ocean",
-    "color": 8364543,
+    "color": 7368918,
     "rainfall": 0.5
   },
   {
     "id": 11,
     "name": "frozen_river",
     "category": "river",
-    "temperature": 0.0,
+    "temperature": 0,
     "precipitation": "snow",
     "depth": -0.5,
     "dimension": "overworld",
     "displayName": "Frozen River",
-    "color": 8364543,
+    "color": 10526975,
     "rainfall": 0.5
   },
   {
     "id": 12,
     "name": "snowy_tundra",
     "category": "icy",
-    "temperature": 0.0,
+    "temperature": 0,
     "precipitation": "snow",
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Snowy Tundra",
-    "color": 8364543,
+    "color": 16777215,
     "rainfall": 0.5
   },
   {
     "id": 13,
     "name": "snowy_mountains",
     "category": "icy",
-    "temperature": 0.0,
+    "temperature": 0,
     "precipitation": "snow",
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Snowy Mountains",
-    "color": 8364543,
+    "color": 10526880,
     "rainfall": 0.5
   },
   {
@@ -176,8 +176,8 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Mushroom Fields",
-    "color": 7842047,
-    "rainfall": 1.0
+    "color": 16711935,
+    "rainfall": 1
   },
   {
     "id": 15,
@@ -185,11 +185,11 @@
     "category": "mushroom",
     "temperature": 0.9,
     "precipitation": "rain",
-    "depth": 0.0,
+    "depth": 0,
     "dimension": "overworld",
     "displayName": "Mushroom Field Shore",
-    "color": 7842047,
-    "rainfall": 1.0
+    "color": 10486015,
+    "rainfall": 1
   },
   {
     "id": 16,
@@ -197,23 +197,23 @@
     "category": "beach",
     "temperature": 0.8,
     "precipitation": "rain",
-    "depth": 0.0,
+    "depth": 0,
     "dimension": "overworld",
     "displayName": "Beach",
-    "color": 7907327,
+    "color": 16440917,
     "rainfall": 0.4
   },
   {
     "id": 17,
     "name": "desert_hills",
     "category": "desert",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Desert Hills",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 13786898,
+    "rainfall": 0
   },
   {
     "id": 18,
@@ -224,7 +224,7 @@
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Wooded Hills",
-    "color": 7972607,
+    "color": 2250012,
     "rainfall": 0.8
   },
   {
@@ -236,7 +236,7 @@
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Taiga Hills",
-    "color": 8233983,
+    "color": 1456435,
     "rainfall": 0.8
   },
   {
@@ -248,7 +248,7 @@
     "depth": 0.8,
     "dimension": "overworld",
     "displayName": "Mountain Edge",
-    "color": 8233727,
+    "color": 7501978,
     "rainfall": 0.3
   },
   {
@@ -260,7 +260,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Jungle",
-    "color": 7842047,
+    "color": 5470985,
     "rainfall": 0.9
   },
   {
@@ -272,7 +272,7 @@
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Jungle Hills",
-    "color": 7842047,
+    "color": 2900485,
     "rainfall": 0.9
   },
   {
@@ -284,7 +284,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Jungle Edge",
-    "color": 7842047,
+    "color": 6458135,
     "rainfall": 0.8
   },
   {
@@ -296,7 +296,7 @@
     "depth": -1.8,
     "dimension": "overworld",
     "displayName": "Deep Ocean",
-    "color": 8103167,
+    "color": 48,
     "rainfall": 0.5
   },
   {
@@ -308,7 +308,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Stone Shore",
-    "color": 8233727,
+    "color": 10658436,
     "rainfall": 0.3
   },
   {
@@ -317,10 +317,10 @@
     "category": "beach",
     "temperature": 0.05,
     "precipitation": "snow",
-    "depth": 0.0,
+    "depth": 0,
     "dimension": "overworld",
     "displayName": "Snowy Beach",
-    "color": 8364543,
+    "color": 16445632,
     "rainfall": 0.3
   },
   {
@@ -332,7 +332,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Birch Forest",
-    "color": 8037887,
+    "color": 3175492,
     "rainfall": 0.6
   },
   {
@@ -344,7 +344,7 @@
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Birch Forest Hills",
-    "color": 8037887,
+    "color": 2055986,
     "rainfall": 0.6
   },
   {
@@ -356,7 +356,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Dark Forest",
-    "color": 7972607,
+    "color": 4215066,
     "rainfall": 0.8
   },
   {
@@ -368,7 +368,7 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Snowy Taiga",
-    "color": 8625919,
+    "color": 3233098,
     "rainfall": 0.4
   },
   {
@@ -380,7 +380,7 @@
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Snowy Taiga Hills",
-    "color": 8625919,
+    "color": 2375478,
     "rainfall": 0.4
   },
   {
@@ -392,7 +392,7 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Giant Tree Taiga",
-    "color": 8168447,
+    "color": 5858897,
     "rainfall": 0.8
   },
   {
@@ -404,7 +404,7 @@
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Giant Tree Taiga Hills",
-    "color": 8168447,
+    "color": 4542270,
     "rainfall": 0.8
   },
   {
@@ -413,10 +413,10 @@
     "category": "extreme_hills",
     "temperature": 0.2,
     "precipitation": "rain",
-    "depth": 1.0,
+    "depth": 1,
     "dimension": "overworld",
     "displayName": "Wooded Mountains",
-    "color": 8233727,
+    "color": 5271632,
     "rainfall": 0.3
   },
   {
@@ -428,56 +428,56 @@
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Savanna",
-    "color": 7711487,
-    "rainfall": 0.0
+    "color": 12431967,
+    "rainfall": 0
   },
   {
     "id": 36,
     "name": "savanna_plateau",
     "category": "savanna",
-    "temperature": 1.0,
+    "temperature": 1,
     "precipitation": "none",
     "depth": 1.5,
     "dimension": "overworld",
     "displayName": "Savanna Plateau",
-    "color": 7776511,
-    "rainfall": 0.0
+    "color": 10984804,
+    "rainfall": 0
   },
   {
     "id": 37,
     "name": "badlands",
     "category": "mesa",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Badlands",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 14238997,
+    "rainfall": 0
   },
   {
     "id": 38,
     "name": "wooded_badlands_plateau",
     "category": "mesa",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 1.5,
     "dimension": "overworld",
     "displayName": "Wooded Badlands Plateau",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 11573093,
+    "rainfall": 0
   },
   {
     "id": 39,
     "name": "badlands_plateau",
     "category": "mesa",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 1.5,
     "dimension": "overworld",
     "displayName": "Badlands Plateau",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 13274213,
+    "rainfall": 0
   },
   {
     "id": 40,
@@ -488,7 +488,7 @@
     "depth": 0.1,
     "dimension": "end",
     "displayName": "Small End Islands",
-    "color": 0,
+    "color": 42,
     "rainfall": 0.5
   },
   {
@@ -500,7 +500,7 @@
     "depth": 0.1,
     "dimension": "end",
     "displayName": "End Midlands",
-    "color": 0,
+    "color": 15464630,
     "rainfall": 0.5
   },
   {
@@ -512,7 +512,7 @@
     "depth": 0.1,
     "dimension": "end",
     "displayName": "End Highlands",
-    "color": 0,
+    "color": 12828041,
     "rainfall": 0.5
   },
   {
@@ -524,7 +524,7 @@
     "depth": 0.1,
     "dimension": "end",
     "displayName": "End Barrens",
-    "color": 0,
+    "color": 9474162,
     "rainfall": 0.5
   },
   {
@@ -533,10 +533,10 @@
     "category": "ocean",
     "temperature": 0.5,
     "precipitation": "rain",
-    "depth": -1.0,
+    "depth": -1,
     "dimension": "overworld",
     "displayName": "Warm Ocean",
-    "color": 8103167,
+    "color": 172,
     "rainfall": 0.5
   },
   {
@@ -545,10 +545,10 @@
     "category": "ocean",
     "temperature": 0.5,
     "precipitation": "rain",
-    "depth": -1.0,
+    "depth": -1,
     "dimension": "overworld",
     "displayName": "Lukewarm Ocean",
-    "color": 8103167,
+    "color": 144,
     "rainfall": 0.5
   },
   {
@@ -557,10 +557,10 @@
     "category": "ocean",
     "temperature": 0.5,
     "precipitation": "rain",
-    "depth": -1.0,
+    "depth": -1,
     "dimension": "overworld",
     "displayName": "Cold Ocean",
-    "color": 8103167,
+    "color": 2105456,
     "rainfall": 0.5
   },
   {
@@ -572,7 +572,7 @@
     "depth": -1.8,
     "dimension": "overworld",
     "displayName": "Deep Warm Ocean",
-    "color": 8103167,
+    "color": 80,
     "rainfall": 0.5
   },
   {
@@ -584,7 +584,7 @@
     "depth": -1.8,
     "dimension": "overworld",
     "displayName": "Deep Lukewarm Ocean",
-    "color": 8103167,
+    "color": 64,
     "rainfall": 0.5
   },
   {
@@ -596,7 +596,7 @@
     "depth": -1.8,
     "dimension": "overworld",
     "displayName": "Deep Cold Ocean",
-    "color": 8103167,
+    "color": 2105400,
     "rainfall": 0.5
   },
   {
@@ -608,7 +608,7 @@
     "depth": -1.8,
     "dimension": "overworld",
     "displayName": "Deep Frozen Ocean",
-    "color": 8103167,
+    "color": 4210832,
     "rainfall": 0.5
   },
   {
@@ -620,7 +620,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "The Void",
-    "color": 8103167,
+    "color": 0,
     "rainfall": 0.5
   },
   {
@@ -632,20 +632,20 @@
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Sunflower Plains",
-    "color": 7907327,
+    "color": 11918216,
     "rainfall": 0.4
   },
   {
     "id": 130,
     "name": "desert_lakes",
     "category": "desert",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.225,
     "dimension": "overworld",
     "displayName": "Desert Lakes",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 16759872,
+    "rainfall": 0
   },
   {
     "id": 131,
@@ -653,10 +653,10 @@
     "category": "extreme_hills",
     "temperature": 0.2,
     "precipitation": "rain",
-    "depth": 1.0,
+    "depth": 1,
     "dimension": "overworld",
     "displayName": "Gravelly Mountains",
-    "color": 8233727,
+    "color": 8947848,
     "rainfall": 0.3
   },
   {
@@ -668,7 +668,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Flower Forest",
-    "color": 7972607,
+    "color": 2985545,
     "rainfall": 0.8
   },
   {
@@ -680,7 +680,7 @@
     "depth": 0.3,
     "dimension": "overworld",
     "displayName": "Taiga Mountains",
-    "color": 8233983,
+    "color": 3378817,
     "rainfall": 0.8
   },
   {
@@ -692,19 +692,19 @@
     "depth": -0.1,
     "dimension": "overworld",
     "displayName": "Swamp Hills",
-    "color": 7907327,
+    "color": 3145690,
     "rainfall": 0.9
   },
   {
     "id": 140,
     "name": "ice_spikes",
     "category": "icy",
-    "temperature": 0.0,
+    "temperature": 0,
     "precipitation": "snow",
     "depth": 0.425,
     "dimension": "overworld",
     "displayName": "Ice Spikes",
-    "color": 8364543,
+    "color": 11853020,
     "rainfall": 0.5
   },
   {
@@ -716,7 +716,7 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Modified Jungle",
-    "color": 7842047,
+    "color": 8102705,
     "rainfall": 0.9
   },
   {
@@ -728,7 +728,7 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Modified Jungle Edge",
-    "color": 7842047,
+    "color": 9089855,
     "rainfall": 0.8
   },
   {
@@ -740,7 +740,7 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Tall Birch Forest",
-    "color": 8037887,
+    "color": 5807212,
     "rainfall": 0.6
   },
   {
@@ -752,7 +752,7 @@
     "depth": 0.55,
     "dimension": "overworld",
     "displayName": "Tall Birch Hills",
-    "color": 8037887,
+    "color": 4687706,
     "rainfall": 0.6
   },
   {
@@ -764,7 +764,7 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Dark Forest Hills",
-    "color": 7972607,
+    "color": 6846786,
     "rainfall": 0.8
   },
   {
@@ -776,7 +776,7 @@
     "depth": 0.3,
     "dimension": "overworld",
     "displayName": "Snowy Taiga Mountains",
-    "color": 8625919,
+    "color": 5864818,
     "rainfall": 0.4
   },
   {
@@ -788,7 +788,7 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Giant Spruce Taiga",
-    "color": 8233983,
+    "color": 8490617,
     "rainfall": 0.8
   },
   {
@@ -800,7 +800,7 @@
     "depth": 0.2,
     "dimension": "overworld",
     "displayName": "Giant Spruce Taiga Hills",
-    "color": 8233983,
+    "color": 7173990,
     "rainfall": 0.8
   },
   {
@@ -809,10 +809,10 @@
     "category": "extreme_hills",
     "temperature": 0.2,
     "precipitation": "rain",
-    "depth": 1.0,
+    "depth": 1,
     "dimension": "overworld",
     "displayName": "Gravelly Mountains+",
-    "color": 8233727,
+    "color": 7903352,
     "rainfall": 0.3
   },
   {
@@ -824,56 +824,56 @@
     "depth": 0.3625,
     "dimension": "overworld",
     "displayName": "Shattered Savanna",
-    "color": 7776767,
-    "rainfall": 0.0
+    "color": 15063687,
+    "rainfall": 0
   },
   {
     "id": 164,
     "name": "shattered_savanna_plateau",
     "category": "savanna",
-    "temperature": 1.0,
+    "temperature": 1,
     "precipitation": "none",
     "depth": 1.05,
     "dimension": "overworld",
     "displayName": "Shattered Savanna Plateau",
-    "color": 7776511,
-    "rainfall": 0.0
+    "color": 13616524,
+    "rainfall": 0
   },
   {
     "id": 165,
     "name": "eroded_badlands",
     "category": "mesa",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Eroded Badlands",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 16739645,
+    "rainfall": 0
   },
   {
     "id": 166,
     "name": "modified_wooded_badlands_plateau",
     "category": "mesa",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Modified Wooded Badlands Plateau",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 14204813,
+    "rainfall": 0
   },
   {
     "id": 167,
     "name": "modified_badlands_plateau",
     "category": "mesa",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Modified Badlands Plateau",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 15905933,
+    "rainfall": 0
   },
   {
     "id": 168,
@@ -884,7 +884,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Bamboo Jungle",
-    "color": 7842047,
+    "color": 7769620,
     "rainfall": 0.9
   },
   {
@@ -896,56 +896,56 @@
     "depth": 0.45,
     "dimension": "overworld",
     "displayName": "Bamboo Jungle Hills",
-    "color": 7842047,
+    "color": 3884810,
     "rainfall": 0.9
   },
   {
     "id": 170,
     "name": "soul_sand_valley",
     "category": "nether",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.1,
     "dimension": "nether",
     "displayName": "Soul Sand Valley",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 6174768,
+    "rainfall": 0
   },
   {
     "id": 171,
     "name": "crimson_forest",
     "category": "nether",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.1,
     "dimension": "nether",
     "displayName": "Crimson Forest",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 14485512,
+    "rainfall": 0
   },
   {
     "id": 172,
     "name": "warped_forest",
     "category": "nether",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.1,
     "dimension": "nether",
     "displayName": "Warped Forest",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 4821115,
+    "rainfall": 0
   },
   {
     "id": 173,
     "name": "basalt_deltas",
     "category": "nether",
-    "temperature": 2.0,
+    "temperature": 2,
     "precipitation": "none",
     "depth": 0.1,
     "dimension": "nether",
     "displayName": "Basalt Deltas",
-    "color": 7254527,
-    "rainfall": 0.0
+    "color": 4208182,
+    "rainfall": 0
   },
   {
     "id": 174,
@@ -956,7 +956,7 @@
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Dripstone Caves",
-    "color": 7907327,
+    "color": 12690831,
     "rainfall": 0.4
   },
   {
@@ -968,7 +968,7 @@
     "depth": 0.1,
     "dimension": "overworld",
     "displayName": "Lush Caves",
-    "color": 8103167,
+    "color": 14652980,
     "rainfall": 0.5
   }
 ]

--- a/data/pc/1.18/biomes.json
+++ b/data/pc/1.18/biomes.json
@@ -8,7 +8,7 @@
     "depth": 0.10000000149011612,
     "dimension": "overworld",
     "displayName": "The Void",
-    "color": 8103167,
+    "color": 0,
     "rainfall": 0.5
   },
   {
@@ -20,7 +20,7 @@
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Plains",
-    "color": 7907327,
+    "color": 9286496,
     "rainfall": 0.4000000059604645
   },
   {
@@ -32,7 +32,7 @@
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Sunflower Plains",
-    "color": 7907327,
+    "color": 11918216,
     "rainfall": 0.4000000059604645
   },
   {
@@ -44,7 +44,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Snowy Plains",
-    "color": 8364543,
+    "color": 16777215,
     "rainfall": 0.5
   },
   {
@@ -56,7 +56,7 @@
     "depth": 0.42500001192092896,
     "dimension": "overworld",
     "displayName": "Ice Spikes",
-    "color": 8364543,
+    "color": 11853020,
     "rainfall": 0.5
   },
   {
@@ -68,7 +68,7 @@
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Desert",
-    "color": 7254527,
+    "color": 16421912,
     "rainfall": 0
   },
   {
@@ -80,7 +80,7 @@
     "depth": -0.20000000298023224,
     "dimension": "overworld",
     "displayName": "Swamp",
-    "color": 7907327,
+    "color": 522674,
     "rainfall": 0.8999999761581421
   },
   {
@@ -92,7 +92,7 @@
     "depth": 0.10000000149011612,
     "dimension": "overworld",
     "displayName": "Forest",
-    "color": 7972607,
+    "color": 353825,
     "rainfall": 0.800000011920929
   },
   {
@@ -104,7 +104,7 @@
     "depth": 0.10000000149011612,
     "dimension": "overworld",
     "displayName": "Flower Forest",
-    "color": 7972607,
+    "color": 2985545,
     "rainfall": 0.800000011920929
   },
   {
@@ -116,7 +116,7 @@
     "depth": 0.10000000149011612,
     "dimension": "overworld",
     "displayName": "Birch Forest",
-    "color": 8037887,
+    "color": 3175492,
     "rainfall": 0.6000000238418579
   },
   {
@@ -128,7 +128,7 @@
     "depth": 0.10000000149011612,
     "dimension": "overworld",
     "displayName": "Dark Forest",
-    "color": 7972607,
+    "color": 4215066,
     "rainfall": 0.800000011920929
   },
   {
@@ -140,7 +140,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Old Growth Birch Forest",
-    "color": 8037887,
+    "color": 5807212,
     "rainfall": 0.6000000238418579
   },
   {
@@ -152,7 +152,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Old Growth Pine Taiga",
-    "color": 8168447,
+    "color": 5858897,
     "rainfall": 0.800000011920929
   },
   {
@@ -164,7 +164,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Old Growth Spruce Taiga",
-    "color": 8233983,
+    "color": 8490617,
     "rainfall": 0.800000011920929
   },
   {
@@ -176,7 +176,7 @@
     "depth": 0.20000000298023224,
     "dimension": "overworld",
     "displayName": "Taiga",
-    "color": 8233983,
+    "color": 747097,
     "rainfall": 0.800000011920929
   },
   {
@@ -188,7 +188,7 @@
     "depth": 0.20000000298023224,
     "dimension": "overworld",
     "displayName": "Snowy Taiga",
-    "color": 8625919,
+    "color": 3233098,
     "rainfall": 0.4000000059604645
   },
   {
@@ -200,7 +200,7 @@
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Savanna",
-    "color": 7254527,
+    "color": 12431967,
     "rainfall": 0
   },
   {
@@ -212,7 +212,7 @@
     "depth": 1.5,
     "dimension": "overworld",
     "displayName": "Savanna Plateau",
-    "color": 7254527,
+    "color": 10984804,
     "rainfall": 0
   },
   {
@@ -224,7 +224,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Windswept Hills",
-    "color": 8233727,
+    "color": 6316128,
     "rainfall": 0.30000001192092896
   },
   {
@@ -236,7 +236,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Windswept Gravelly Hills",
-    "color": 8233727,
+    "color": 8947848,
     "rainfall": 0.30000001192092896
   },
   {
@@ -248,7 +248,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Windswept Forest",
-    "color": 8233727,
+    "color": 2250012,
     "rainfall": 0.30000001192092896
   },
   {
@@ -260,7 +260,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Windswept Savanna",
-    "color": 7254527,
+    "color": 15063687,
     "rainfall": 0
   },
   {
@@ -272,7 +272,7 @@
     "depth": 0.10000000149011612,
     "dimension": "overworld",
     "displayName": "Jungle",
-    "color": 7842047,
+    "color": 5470985,
     "rainfall": 0.8999999761581421
   },
   {
@@ -284,7 +284,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Sparse Jungle",
-    "color": 7842047,
+    "color": 6458135,
     "rainfall": 0.800000011920929
   },
   {
@@ -296,7 +296,7 @@
     "depth": 0.10000000149011612,
     "dimension": "overworld",
     "displayName": "Bamboo Jungle",
-    "color": 7842047,
+    "color": 7769620,
     "rainfall": 0.8999999761581421
   },
   {
@@ -308,7 +308,7 @@
     "depth": 0.10000000149011612,
     "dimension": "overworld",
     "displayName": "Badlands",
-    "color": 7254527,
+    "color": 14238997,
     "rainfall": 0
   },
   {
@@ -320,7 +320,7 @@
     "depth": 0.10000000149011612,
     "dimension": "overworld",
     "displayName": "Eroded Badlands",
-    "color": 7254527,
+    "color": 16739645,
     "rainfall": 0
   },
   {
@@ -332,7 +332,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Wooded Badlands",
-    "color": 7254527,
+    "color": 11573093,
     "rainfall": 0
   },
   {
@@ -344,7 +344,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Meadow",
-    "color": 8103167,
+    "color": 9217136,
     "rainfall": 0.800000011920929
   },
   {
@@ -356,7 +356,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Grove",
-    "color": 8495359,
+    "color": 14675173,
     "rainfall": 0.800000011920929
   },
   {
@@ -368,7 +368,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Snowy Slopes",
-    "color": 8560639,
+    "color": 14348785,
     "rainfall": 0.8999999761581421
   },
   {
@@ -380,7 +380,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Frozen Peaks",
-    "color": 8756735,
+    "color": 15399931,
     "rainfall": 0.8999999761581421
   },
   {
@@ -392,7 +392,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Jagged Peaks",
-    "color": 8756735,
+    "color": 14937325,
     "rainfall": 0.8999999761581421
   },
   {
@@ -404,7 +404,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Stony Peaks",
-    "color": 7776511,
+    "color": 13750737,
     "rainfall": 0.30000001192092896
   },
   {
@@ -416,7 +416,7 @@
     "depth": -0.5,
     "dimension": "overworld",
     "displayName": "River",
-    "color": 8103167,
+    "color": 255,
     "rainfall": 0.5
   },
   {
@@ -428,7 +428,7 @@
     "depth": -0.5,
     "dimension": "overworld",
     "displayName": "Frozen River",
-    "color": 8364543,
+    "color": 10526975,
     "rainfall": 0.5
   },
   {
@@ -440,7 +440,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Beach",
-    "color": 7907327,
+    "color": 16440917,
     "rainfall": 0.4000000059604645
   },
   {
@@ -452,7 +452,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Snowy Beach",
-    "color": 8364543,
+    "color": 16445632,
     "rainfall": 0.30000001192092896
   },
   {
@@ -464,7 +464,7 @@
     "depth": 0,
     "dimension": "overworld",
     "displayName": "Stony Shore",
-    "color": 8233727,
+    "color": 10658436,
     "rainfall": 0.30000001192092896
   },
   {
@@ -476,7 +476,7 @@
     "depth": -1,
     "dimension": "overworld",
     "displayName": "Warm Ocean",
-    "color": 8103167,
+    "color": 172,
     "rainfall": 0.5
   },
   {
@@ -488,7 +488,7 @@
     "depth": -1,
     "dimension": "overworld",
     "displayName": "Lukewarm Ocean",
-    "color": 8103167,
+    "color": 144,
     "rainfall": 0.5
   },
   {
@@ -500,7 +500,7 @@
     "depth": -1.7999999523162842,
     "dimension": "overworld",
     "displayName": "Deep Lukewarm Ocean",
-    "color": 8103167,
+    "color": 64,
     "rainfall": 0.5
   },
   {
@@ -512,7 +512,7 @@
     "depth": -1,
     "dimension": "overworld",
     "displayName": "Ocean",
-    "color": 8103167,
+    "color": 112,
     "rainfall": 0.5
   },
   {
@@ -524,7 +524,7 @@
     "depth": -1.7999999523162842,
     "dimension": "overworld",
     "displayName": "Deep Ocean",
-    "color": 8103167,
+    "color": 48,
     "rainfall": 0.5
   },
   {
@@ -536,7 +536,7 @@
     "depth": -1,
     "dimension": "overworld",
     "displayName": "Cold Ocean",
-    "color": 8103167,
+    "color": 2105456,
     "rainfall": 0.5
   },
   {
@@ -548,7 +548,7 @@
     "depth": -1.7999999523162842,
     "dimension": "overworld",
     "displayName": "Deep Cold Ocean",
-    "color": 8103167,
+    "color": 2105400,
     "rainfall": 0.5
   },
   {
@@ -560,7 +560,7 @@
     "depth": -1,
     "dimension": "overworld",
     "displayName": "Frozen Ocean",
-    "color": 8364543,
+    "color": 7368918,
     "rainfall": 0.5
   },
   {
@@ -572,7 +572,7 @@
     "depth": -1.7999999523162842,
     "dimension": "overworld",
     "displayName": "Deep Frozen Ocean",
-    "color": 8103167,
+    "color": 4210832,
     "rainfall": 0.5
   },
   {
@@ -584,7 +584,7 @@
     "depth": 0.20000000298023224,
     "dimension": "overworld",
     "displayName": "Mushroom Fields",
-    "color": 7842047,
+    "color": 16711935,
     "rainfall": 1
   },
   {
@@ -596,7 +596,7 @@
     "depth": 0.125,
     "dimension": "overworld",
     "displayName": "Dripstone Caves",
-    "color": 7907327,
+    "color": 12690831,
     "rainfall": 0.4000000059604645
   },
   {
@@ -608,7 +608,7 @@
     "depth": 0.5,
     "dimension": "overworld",
     "displayName": "Lush Caves",
-    "color": 8103167,
+    "color": 14652980,
     "rainfall": 0.5
   },
   {
@@ -620,7 +620,7 @@
     "depth": 0.10000000149011612,
     "dimension": "nether",
     "displayName": "Nether Wastes",
-    "color": 7254527,
+    "color": 12532539,
     "rainfall": 0
   },
   {
@@ -632,7 +632,7 @@
     "depth": 0.10000000149011612,
     "dimension": "nether",
     "displayName": "Warped Forest",
-    "color": 7254527,
+    "color": 4821115,
     "rainfall": 0
   },
   {
@@ -644,7 +644,7 @@
     "depth": 0.10000000149011612,
     "dimension": "nether",
     "displayName": "Crimson Forest",
-    "color": 7254527,
+    "color": 14485512,
     "rainfall": 0
   },
   {
@@ -656,7 +656,7 @@
     "depth": 0.10000000149011612,
     "dimension": "nether",
     "displayName": "Soul Sand Valley",
-    "color": 7254527,
+    "color": 6174768,
     "rainfall": 0
   },
   {
@@ -668,7 +668,7 @@
     "depth": 0.10000000149011612,
     "dimension": "nether",
     "displayName": "Basalt Deltas",
-    "color": 7254527,
+    "color": 4208182,
     "rainfall": 0
   },
   {
@@ -680,7 +680,7 @@
     "depth": 0.10000000149011612,
     "dimension": "end",
     "displayName": "The End",
-    "color": 0,
+    "color": 8421631,
     "rainfall": 0.5
   },
   {
@@ -692,7 +692,7 @@
     "depth": 0.10000000149011612,
     "dimension": "end",
     "displayName": "End Highlands",
-    "color": 0,
+    "color": 12828041,
     "rainfall": 0.5
   },
   {
@@ -704,7 +704,7 @@
     "depth": 0.10000000149011612,
     "dimension": "end",
     "displayName": "End Midlands",
-    "color": 0,
+    "color": 15464630,
     "rainfall": 0.5
   },
   {
@@ -716,7 +716,7 @@
     "depth": 0.10000000149011612,
     "dimension": "end",
     "displayName": "Small End Islands",
-    "color": 0,
+    "color": 42,
     "rainfall": 0.5
   },
   {
@@ -728,7 +728,7 @@
     "depth": 0.10000000149011612,
     "dimension": "end",
     "displayName": "End Barrens",
-    "color": 0,
+    "color": 9474162,
     "rainfall": 0.5
   }
 ]


### PR DESCRIPTION
In 1.17 and 1.18 the color field in biomes.json was mistakenly set to the sky_color property of biomes, which is inconstistent with other versions, and breaks the usage of this field for making biome maps.