### PR TITLE
some fixes 1.7 - 1.18.2+

### DIFF
--- a/data/pc/1.10-pre1/protocol.json
+++ b/data/pc/1.10-pre1/protocol.json
@@ -2490,7 +2490,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.10-pre1/protocol.json
+++ b/data/pc/1.10-pre1/protocol.json
@@ -3320,7 +3320,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.10/protocol.json
+++ b/data/pc/1.10/protocol.json
@@ -2490,7 +2490,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.10/protocol.json
+++ b/data/pc/1.10/protocol.json
@@ -3320,7 +3320,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.11/protocol.json
+++ b/data/pc/1.11/protocol.json
@@ -2490,7 +2490,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.11/protocol.json
+++ b/data/pc/1.11/protocol.json
@@ -3325,7 +3325,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.12-pre4/protocol.json
+++ b/data/pc/1.12-pre4/protocol.json
@@ -3625,7 +3625,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.12-pre4/protocol.json
+++ b/data/pc/1.12-pre4/protocol.json
@@ -2707,7 +2707,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.12.1/protocol.json
+++ b/data/pc/1.12.1/protocol.json
@@ -3615,7 +3615,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.12.1/protocol.json
+++ b/data/pc/1.12.1/protocol.json
@@ -2743,7 +2743,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.12.2/protocol.json
+++ b/data/pc/1.12.2/protocol.json
@@ -3615,7 +3615,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.12.2/protocol.json
+++ b/data/pc/1.12.2/protocol.json
@@ -2743,7 +2743,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.12/protocol.json
+++ b/data/pc/1.12/protocol.json
@@ -2730,7 +2730,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.12/protocol.json
+++ b/data/pc/1.12/protocol.json
@@ -3648,7 +3648,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.13.1/protocol.json
+++ b/data/pc/1.13.1/protocol.json
@@ -4012,27 +4012,27 @@
                 },
                 {
                     "name": "offset_x",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "offset_y",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "offset_z",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "size_x",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "size_y",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "size_z",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "mirror",

--- a/data/pc/1.13.1/protocol.json
+++ b/data/pc/1.13.1/protocol.json
@@ -3188,7 +3188,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.13.1/protocol.json
+++ b/data/pc/1.13.1/protocol.json
@@ -4429,7 +4429,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.13.2-pre1/protocol.json
+++ b/data/pc/1.13.2-pre1/protocol.json
@@ -3193,7 +3193,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.13.2-pre1/protocol.json
+++ b/data/pc/1.13.2-pre1/protocol.json
@@ -4017,27 +4017,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.13.2-pre1/protocol.json
+++ b/data/pc/1.13.2-pre1/protocol.json
@@ -4434,7 +4434,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.13.2-pre2/protocol.json
+++ b/data/pc/1.13.2-pre2/protocol.json
@@ -3193,7 +3193,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.13.2-pre2/protocol.json
+++ b/data/pc/1.13.2-pre2/protocol.json
@@ -4017,27 +4017,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.13.2-pre2/protocol.json
+++ b/data/pc/1.13.2-pre2/protocol.json
@@ -4434,7 +4434,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.13.2/protocol.json
+++ b/data/pc/1.13.2/protocol.json
@@ -3193,7 +3193,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.13.2/protocol.json
+++ b/data/pc/1.13.2/protocol.json
@@ -4017,27 +4017,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.13.2/protocol.json
+++ b/data/pc/1.13.2/protocol.json
@@ -4434,7 +4434,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.13/protocol.json
+++ b/data/pc/1.13/protocol.json
@@ -4008,27 +4008,27 @@
                 },
                 {
                     "name": "offset_x",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "offset_y",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "offset_z",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "size_x",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "size_y",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "size_z",
-                    "type": "u8"
+                    "type": "i8"
                 },
                 {
                     "name": "mirror",

--- a/data/pc/1.13/protocol.json
+++ b/data/pc/1.13/protocol.json
@@ -4425,7 +4425,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.13/protocol.json
+++ b/data/pc/1.13/protocol.json
@@ -3188,7 +3188,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.14.1/protocol.json
+++ b/data/pc/1.14.1/protocol.json
@@ -4658,7 +4658,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.14.1/protocol.json
+++ b/data/pc/1.14.1/protocol.json
@@ -3377,7 +3377,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.14.1/protocol.json
+++ b/data/pc/1.14.1/protocol.json
@@ -4232,27 +4232,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.14.3/protocol.json
+++ b/data/pc/1.14.3/protocol.json
@@ -3381,7 +3381,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.14.3/protocol.json
+++ b/data/pc/1.14.3/protocol.json
@@ -4662,7 +4662,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.14.3/protocol.json
+++ b/data/pc/1.14.3/protocol.json
@@ -4236,27 +4236,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.14.4/protocol.json
+++ b/data/pc/1.14.4/protocol.json
@@ -3385,7 +3385,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.14.4/protocol.json
+++ b/data/pc/1.14.4/protocol.json
@@ -4263,27 +4263,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.14.4/protocol.json
+++ b/data/pc/1.14.4/protocol.json
@@ -4689,7 +4689,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.14/protocol.json
+++ b/data/pc/1.14/protocol.json
@@ -4658,7 +4658,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.14/protocol.json
+++ b/data/pc/1.14/protocol.json
@@ -3377,7 +3377,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.14/protocol.json
+++ b/data/pc/1.14/protocol.json
@@ -4232,27 +4232,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.15.1/protocol.json
+++ b/data/pc/1.15.1/protocol.json
@@ -4283,27 +4283,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.15.1/protocol.json
+++ b/data/pc/1.15.1/protocol.json
@@ -3405,7 +3405,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.15.1/protocol.json
+++ b/data/pc/1.15.1/protocol.json
@@ -4709,7 +4709,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.15.2/protocol.json
+++ b/data/pc/1.15.2/protocol.json
@@ -4283,27 +4283,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.15.2/protocol.json
+++ b/data/pc/1.15.2/protocol.json
@@ -3405,7 +3405,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.15.2/protocol.json
+++ b/data/pc/1.15.2/protocol.json
@@ -4709,7 +4709,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.15/protocol.json
+++ b/data/pc/1.15/protocol.json
@@ -4283,27 +4283,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.15/protocol.json
+++ b/data/pc/1.15/protocol.json
@@ -3405,7 +3405,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.15/protocol.json
+++ b/data/pc/1.15/protocol.json
@@ -4709,7 +4709,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.16-rc1/protocol.json
+++ b/data/pc/1.16-rc1/protocol.json
@@ -4768,7 +4768,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.16-rc1/protocol.json
+++ b/data/pc/1.16-rc1/protocol.json
@@ -4329,27 +4329,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.16-rc1/protocol.json
+++ b/data/pc/1.16-rc1/protocol.json
@@ -3439,7 +3439,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.16.1/protocol.json
+++ b/data/pc/1.16.1/protocol.json
@@ -4768,7 +4768,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.16.1/protocol.json
+++ b/data/pc/1.16.1/protocol.json
@@ -4329,27 +4329,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.16.1/protocol.json
+++ b/data/pc/1.16.1/protocol.json
@@ -3439,7 +3439,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.16.2/protocol.json
+++ b/data/pc/1.16.2/protocol.json
@@ -4347,27 +4347,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.16.2/protocol.json
+++ b/data/pc/1.16.2/protocol.json
@@ -4786,7 +4786,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.16.2/protocol.json
+++ b/data/pc/1.16.2/protocol.json
@@ -3457,7 +3457,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.16/protocol.json
+++ b/data/pc/1.16/protocol.json
@@ -4768,7 +4768,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.16/protocol.json
+++ b/data/pc/1.16/protocol.json
@@ -4329,27 +4329,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.16/protocol.json
+++ b/data/pc/1.16/protocol.json
@@ -3439,7 +3439,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.17.1/protocol.json
+++ b/data/pc/1.17.1/protocol.json
@@ -5125,7 +5125,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.17.1/protocol.json
+++ b/data/pc/1.17.1/protocol.json
@@ -3587,7 +3587,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.17.1/protocol.json
+++ b/data/pc/1.17.1/protocol.json
@@ -4677,27 +4677,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.17/protocol.json
+++ b/data/pc/1.17/protocol.json
@@ -4650,27 +4650,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.17/protocol.json
+++ b/data/pc/1.17/protocol.json
@@ -3569,7 +3569,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.17/protocol.json
+++ b/data/pc/1.17/protocol.json
@@ -5094,7 +5094,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.18.2/protocol.json
+++ b/data/pc/1.18.2/protocol.json
@@ -4794,27 +4794,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.18.2/protocol.json
+++ b/data/pc/1.18.2/protocol.json
@@ -5246,7 +5246,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.18.2/protocol.json
+++ b/data/pc/1.18.2/protocol.json
@@ -3693,7 +3693,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.18/protocol.json
+++ b/data/pc/1.18/protocol.json
@@ -4794,27 +4794,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/1.18/protocol.json
+++ b/data/pc/1.18/protocol.json
@@ -5246,7 +5246,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.18/protocol.json
+++ b/data/pc/1.18/protocol.json
@@ -3693,7 +3693,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.7/protocol.json
+++ b/data/pc/1.7/protocol.json
@@ -2036,7 +2036,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.7/protocol.json
+++ b/data/pc/1.7/protocol.json
@@ -2528,7 +2528,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.8/protocol.json
+++ b/data/pc/1.8/protocol.json
@@ -2163,7 +2163,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.8/protocol.json
+++ b/data/pc/1.8/protocol.json
@@ -3002,7 +3002,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.9.1-pre2/protocol.json
+++ b/data/pc/1.9.1-pre2/protocol.json
@@ -3338,7 +3338,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.9.1-pre2/protocol.json
+++ b/data/pc/1.9.1-pre2/protocol.json
@@ -2481,7 +2481,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.9.2/protocol.json
+++ b/data/pc/1.9.2/protocol.json
@@ -3338,7 +3338,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.9.2/protocol.json
+++ b/data/pc/1.9.2/protocol.json
@@ -2481,7 +2481,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.9.4/protocol.json
+++ b/data/pc/1.9.4/protocol.json
@@ -2490,7 +2490,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/1.9.4/protocol.json
+++ b/data/pc/1.9.4/protocol.json
@@ -3320,7 +3320,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.9/protocol.json
+++ b/data/pc/1.9/protocol.json
@@ -3338,7 +3338,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/1.9/protocol.json
+++ b/data/pc/1.9/protocol.json
@@ -2481,7 +2481,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/15w40b/protocol.json
+++ b/data/pc/15w40b/protocol.json
@@ -2090,7 +2090,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/15w40b/protocol.json
+++ b/data/pc/15w40b/protocol.json
@@ -3055,7 +3055,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/16w20a/protocol.json
+++ b/data/pc/16w20a/protocol.json
@@ -2490,7 +2490,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/16w20a/protocol.json
+++ b/data/pc/16w20a/protocol.json
@@ -3320,7 +3320,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/16w35a/protocol.json
+++ b/data/pc/16w35a/protocol.json
@@ -2490,7 +2490,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/16w35a/protocol.json
+++ b/data/pc/16w35a/protocol.json
@@ -3324,7 +3324,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/17w15a/protocol.json
+++ b/data/pc/17w15a/protocol.json
@@ -3617,7 +3617,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/17w15a/protocol.json
+++ b/data/pc/17w15a/protocol.json
@@ -2709,7 +2709,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/17w18b/protocol.json
+++ b/data/pc/17w18b/protocol.json
@@ -3611,7 +3611,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/17w18b/protocol.json
+++ b/data/pc/17w18b/protocol.json
@@ -2707,7 +2707,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/17w50a/protocol.json
+++ b/data/pc/17w50a/protocol.json
@@ -4007,7 +4007,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/17w50a/protocol.json
+++ b/data/pc/17w50a/protocol.json
@@ -2981,7 +2981,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/20w13b/protocol.json
+++ b/data/pc/20w13b/protocol.json
@@ -4283,27 +4283,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/20w13b/protocol.json
+++ b/data/pc/20w13b/protocol.json
@@ -3367,7 +3367,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",

--- a/data/pc/20w13b/protocol.json
+++ b/data/pc/20w13b/protocol.json
@@ -4709,7 +4709,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/21w07a/protocol.json
+++ b/data/pc/21w07a/protocol.json
@@ -4391,27 +4391,27 @@
             },
             {
               "name": "offset_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "offset_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_x",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_y",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "size_z",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "mirror",

--- a/data/pc/21w07a/protocol.json
+++ b/data/pc/21w07a/protocol.json
@@ -4834,7 +4834,7 @@
           [
             {
               "name": "status",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "location",

--- a/data/pc/21w07a/protocol.json
+++ b/data/pc/21w07a/protocol.json
@@ -3429,7 +3429,7 @@
             },
             {
               "name": "action",
-              "type": "i8"
+              "type": "varint"
             },
             {
               "name": "scoreName",


### PR DESCRIPTION
this will also be relevant to 1.19

# fixes

## `play/toServer/packet_block_dig`
field `status` is a varint, not an i8
affected versions 1.9 .. 1.18.2+

## `play/toServer/packet_update_structure_block`
fields `offset_x`, `offset_y`, `offset_z`, `size_x`, `size_y` and `size_z` are i8 and not u8
`offset_{x,y,z}` is furthermore even allowed to have negative values which would have been read incorrectly as a big positive offset
affected versions: 1.13 .. 1.18.2+

## `play/toServer/packet_scoreboard_score`
field `action` is a varint, not an i8
affected versions: 1.7 .. 1.18.2+
