### PR TITLE
replace `varint` with custom native `varlong` where wiki.vg lists VarLong

### DIFF
--- a/data/pc/1.10-pre1/protocol.json
+++ b/data/pc/1.10-pre1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2098,8 +2099,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.10/protocol.json
+++ b/data/pc/1.10/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2098,8 +2099,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.11/protocol.json
+++ b/data/pc/1.11/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2098,8 +2099,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.12-pre4/protocol.json
+++ b/data/pc/1.12-pre4/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2315,8 +2316,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.12.1/protocol.json
+++ b/data/pc/1.12.1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2351,8 +2352,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.12.2/protocol.json
+++ b/data/pc/1.12.2/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2351,8 +2352,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.12/protocol.json
+++ b/data/pc/1.12/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2338,8 +2339,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.13.1/protocol.json
+++ b/data/pc/1.13.1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2796,8 +2797,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.13.1/protocol.json
+++ b/data/pc/1.13.1/protocol.json
@@ -4053,7 +4053,7 @@
                 },
                 {
                     "name": "seed",
-                    "type": "varint"
+                    "type": "varlong"
                 },
                 {
                     "name": "flags",

--- a/data/pc/1.13.2-pre1/protocol.json
+++ b/data/pc/1.13.2-pre1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2801,8 +2802,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.13.2-pre1/protocol.json
+++ b/data/pc/1.13.2-pre1/protocol.json
@@ -4058,7 +4058,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.13.2-pre2/protocol.json
+++ b/data/pc/1.13.2-pre2/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2801,8 +2802,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.13.2-pre2/protocol.json
+++ b/data/pc/1.13.2-pre2/protocol.json
@@ -4058,7 +4058,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.13.2/protocol.json
+++ b/data/pc/1.13.2/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2801,8 +2802,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.13.2/protocol.json
+++ b/data/pc/1.13.2/protocol.json
@@ -4058,7 +4058,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.13/protocol.json
+++ b/data/pc/1.13/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2796,8 +2797,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.13/protocol.json
+++ b/data/pc/1.13/protocol.json
@@ -4049,7 +4049,7 @@
                 },
                 {
                     "name": "seed",
-                    "type": "varint"
+                    "type": "varlong"
                 },
                 {
                     "name": "flags",

--- a/data/pc/1.14.1/protocol.json
+++ b/data/pc/1.14.1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -2963,8 +2964,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4272,7 +4273,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.14.3/protocol.json
+++ b/data/pc/1.14.3/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -2967,8 +2968,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4276,7 +4277,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.14.4/protocol.json
+++ b/data/pc/1.14.4/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -2971,8 +2972,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4303,7 +4304,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.14/protocol.json
+++ b/data/pc/1.14/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -2963,8 +2964,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4272,7 +4273,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.15.1/protocol.json
+++ b/data/pc/1.15.1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -2991,8 +2992,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4323,7 +4324,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.15.2/protocol.json
+++ b/data/pc/1.15.2/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -2991,8 +2992,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4323,7 +4324,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.15/protocol.json
+++ b/data/pc/1.15/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -2991,8 +2992,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4323,7 +4324,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.16-rc1/protocol.json
+++ b/data/pc/1.16-rc1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -3018,8 +3019,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4369,7 +4370,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.16.1/protocol.json
+++ b/data/pc/1.16.1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -3018,8 +3019,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4369,7 +4370,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.16.2/protocol.json
+++ b/data/pc/1.16.2/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -1685,7 +1686,7 @@
                 "array",
                 {
                   "countType": "varint",
-                  "type": "varint"
+                  "type": "varlong"
                 }
               ]
             }
@@ -3036,8 +3037,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4387,7 +4388,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.16/protocol.json
+++ b/data/pc/1.16/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -3018,8 +3019,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4369,7 +4370,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.17.1/protocol.json
+++ b/data/pc/1.17.1/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -1909,7 +1910,7 @@
                 "array",
                 {
                   "countType": "varint",
-                  "type": "varint"
+                  "type": "varlong"
                 }
               ]
             }
@@ -4145,7 +4146,7 @@
             },
             {
               "name": "speed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "portalTeleportBoundary",
@@ -4196,7 +4197,7 @@
             },
             {
               "name": "speed",
-              "type": "varint"
+              "type": "varlong"
             }
           ]
         ],
@@ -4717,7 +4718,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.17/protocol.json
+++ b/data/pc/1.17/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -1909,7 +1910,7 @@
                 "array",
                 {
                   "countType": "varint",
-                  "type": "varint"
+                  "type": "varlong"
                 }
               ]
             }
@@ -4127,7 +4128,7 @@
             },
             {
               "name": "speed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "portalTeleportBoundary",
@@ -4178,7 +4179,7 @@
             },
             {
               "name": "speed",
-              "type": "varint"
+              "type": "varlong"
             }
           ]
         ],
@@ -4690,7 +4691,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.18.2/protocol.json
+++ b/data/pc/1.18.2/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "buffer": "native",
@@ -1955,7 +1956,7 @@
                 "array",
                 {
                   "countType": "varint",
-                  "type": "varint"
+                  "type": "varlong"
                 }
               ]
             }
@@ -4251,7 +4252,7 @@
             },
             {
               "name": "speed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "portalTeleportBoundary",
@@ -4302,7 +4303,7 @@
             },
             {
               "name": "speed",
-              "type": "varint"
+              "type": "varlong"
             }
           ]
         ],
@@ -4834,7 +4835,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.18/protocol.json
+++ b/data/pc/1.18/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "buffer": "native",
@@ -1955,7 +1956,7 @@
                 "array",
                 {
                   "countType": "varint",
-                  "type": "varint"
+                  "type": "varlong"
                 }
               ]
             }
@@ -4251,7 +4252,7 @@
             },
             {
               "name": "speed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "portalTeleportBoundary",
@@ -4302,7 +4303,7 @@
             },
             {
               "name": "speed",
-              "type": "varint"
+              "type": "varlong"
             }
           ]
         ],
@@ -4834,7 +4835,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/1.8/protocol.json
+++ b/data/pc/1.8/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2512,8 +2513,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.9.1-pre2/protocol.json
+++ b/data/pc/1.9.1-pre2/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2089,8 +2090,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.9.2/protocol.json
+++ b/data/pc/1.9.2/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2089,8 +2090,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.9.4/protocol.json
+++ b/data/pc/1.9.4/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2098,8 +2099,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/1.9/protocol.json
+++ b/data/pc/1.9/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2089,8 +2090,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/15w40b/protocol.json
+++ b/data/pc/15w40b/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2453,8 +2454,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/16w20a/protocol.json
+++ b/data/pc/16w20a/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2098,8 +2099,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/16w35a/protocol.json
+++ b/data/pc/16w35a/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2098,8 +2099,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/17w15a/protocol.json
+++ b/data/pc/17w15a/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2317,8 +2318,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/17w18b/protocol.json
+++ b/data/pc/17w18b/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2315,8 +2316,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/17w50a/protocol.json
+++ b/data/pc/17w50a/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "pstring": "native",
     "u16": "native",
     "u8": "native",
@@ -2589,8 +2590,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }

--- a/data/pc/20w13b/protocol.json
+++ b/data/pc/20w13b/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -2953,8 +2954,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4323,7 +4324,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",

--- a/data/pc/21w07a/protocol.json
+++ b/data/pc/21w07a/protocol.json
@@ -1,6 +1,7 @@
 {
   "types": {
     "varint": "native",
+    "varlong": "native",
     "optvarint": "varint",
     "pstring": "native",
     "u16": "native",
@@ -1647,7 +1648,7 @@
                 "array",
                 {
                   "countType": "varint",
-                  "type": "varint"
+                  "type": "varlong"
                 }
               ]
             }
@@ -3008,8 +3009,8 @@
                 {
                   "compareTo": "action",
                   "fields": {
-                    "1": "varint",
-                    "3": "varint"
+                    "1": "varlong",
+                    "3": "varlong"
                   },
                   "default": "void"
                 }
@@ -4431,7 +4432,7 @@
             },
             {
               "name": "seed",
-              "type": "varint"
+              "type": "varlong"
             },
             {
               "name": "flags",


### PR DESCRIPTION
as the [old pr](https://github.com/PrismarineJS/minecraft-data/pull/592) was accidentally irrevertably closed, here a new one

the purpose is to mark fields which are actually varlongs in the minecraft protocol as such to allow for more accurate implementations in lower level languages than javascript in which the specific number type actually matters.
the PR which adds varlong as a custom minecraft type to nmp is [here](https://github.com/PrismarineJS/node-minecraft-protocol/pull/1018) and just aliases it to varint