### PR TITLE
Bedrock 1.19.10 - Fix set_entity_data tick datatype

### DIFF
--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -834,7 +834,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 packet_set_entity_motion:
    !id: 0x28

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -4478,7 +4478,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -849,7 +849,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -4629,7 +4629,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -878,7 +878,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -5059,7 +5059,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -879,7 +879,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -5137,7 +5137,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -962,7 +962,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -5227,7 +5227,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -967,7 +967,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -5345,7 +5345,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -970,7 +970,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -5376,7 +5376,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -973,7 +973,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -5391,7 +5391,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -973,7 +973,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -5426,7 +5426,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -981,7 +981,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -5509,7 +5509,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -991,7 +991,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -5563,7 +5563,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -2817,6 +2817,34 @@
         }
       }
     ],
+    "CommandPermissionLevel": [
+      "mapper",
+      {
+        "type": "u8",
+        "mappings": {
+          "0": "normal",
+          "1": "operator",
+          "2": "automation",
+          "3": "host",
+          "4": "owner",
+          "5": "internal"
+        }
+      }
+    ],
+    "CommandPermissionLevelVarint": [
+      "mapper",
+      {
+        "type": "u8",
+        "mappings": {
+          "0": "normal",
+          "1": "operator",
+          "2": "automation",
+          "3": "host",
+          "4": "owner",
+          "5": "internal"
+        }
+      }
+    ],
     "WindowID": [
       "mapper",
       {
@@ -3436,7 +3464,7 @@
           "429": "ItemTaken",
           "430": "Disappeared",
           "431": "Reappeared",
-          "432": "_",
+          "432": "DrinkMilk",
           "433": "FrogspawnHatched",
           "434": "LaySpawn",
           "435": "FrogspawnBreak",
@@ -3445,9 +3473,10 @@
           "438": "SoundeventItemThrown",
           "439": "Record5",
           "440": "ConvertToFrog",
-          "441": "DrinkMilk",
-          "442": "RecordPlaying",
-          "443": "Undefined"
+          "441": "RecordPlaying",
+          "442": "DrinkMilk",
+          "443": "RecordPlaying",
+          "444": "Undefined"
         }
       }
     ],
@@ -3583,38 +3612,11 @@
         }
       }
     ],
-    "AdventureCommandPermissionLevel": [
-      "mapper",
-      {
-        "type": "lu32",
-        "mappings": {
-          "0": "normal",
-          "1": "game_director",
-          "2": "admin",
-          "3": "host",
-          "4": "owner",
-          "5": "internal"
-        }
-      }
-    ],
-    "CommandPermissionLevel": [
-      "mapper",
-      {
-        "type": "u8",
-        "mappings": {
-          "0": "normal",
-          "1": "operator",
-          "2": "host",
-          "3": "automation",
-          "4": "admin"
-        }
-      }
-    ],
     "AbilityLayers": [
       "container",
       [
         {
-          "name": "layer_type",
+          "name": "type",
           "type": [
             "mapper",
             {
@@ -3629,11 +3631,11 @@
           ]
         },
         {
-          "name": "abilities",
+          "name": "allowed",
           "type": "AbilitySet"
         },
         {
-          "name": "values",
+          "name": "enabled",
           "type": "AbilitySet"
         },
         {
@@ -4094,8 +4096,8 @@
                 "5": "failed_vanilla_edu",
                 "6": "failed_edu_vanilla",
                 "7": "failed_server_full",
-                "8": "editor_vanilla_mismatch",
-                "9": "vanilla_editor_mismatch"
+                "8": "failed_editor_vanilla_mismatch",
+                "9": "failed_vanilla_editor_mismatch"
               }
             }
           ]
@@ -4705,11 +4707,7 @@
           "type": "string"
         },
         {
-          "name": "unique_entity_id",
-          "type": "zigzag64"
-        },
-        {
-          "name": "runtime_entity_id",
+          "name": "runtime_id",
           "type": "varint64"
         },
         {
@@ -4749,8 +4747,8 @@
           "type": "MetadataDictionary"
         },
         {
-          "name": "entity_id",
-          "type": "zigzag64"
+          "name": "unique_id",
+          "type": "li64"
         },
         {
           "name": "permission_level",
@@ -4761,11 +4759,11 @@
           "type": "CommandPermissionLevel"
         },
         {
-          "name": "ability_layers",
+          "name": "abilities",
           "type": [
             "array",
             {
-              "countType": "varint",
+              "countType": "u8",
               "type": "AbilityLayers"
             }
           ]
@@ -4788,11 +4786,11 @@
       "container",
       [
         {
-          "name": "entity_id_self",
+          "name": "unique_id",
           "type": "zigzag64"
         },
         {
-          "name": "runtime_entity_id",
+          "name": "runtime_id",
           "type": "varint64"
         },
         {
@@ -5394,7 +5392,8 @@
                 "74": "charged_crossbow",
                 "75": "fall",
                 "76": "grow_up",
-                "77": "vibration_detected"
+                "77": "vibration_detected",
+                "78": "drink_milk"
               }
             }
           ]
@@ -5644,7 +5643,7 @@
         },
         {
           "name": "tick",
-          "type": "varint"
+          "type": "varint64"
         }
       ]
     ],
@@ -5986,7 +5985,7 @@
         },
         {
           "name": "command_permission",
-          "type": "AdventureCommandPermissionLevel"
+          "type": "CommandPermissionLevelVarint"
         },
         {
           "name": "action_permissions",
@@ -10014,7 +10013,7 @@
       "container",
       [
         {
-          "name": "entity_id",
+          "name": "entity_unique_id",
           "type": "li64"
         },
         {
@@ -10026,11 +10025,11 @@
           "type": "CommandPermissionLevel"
         },
         {
-          "name": "ability_layers",
+          "name": "abilities",
           "type": [
             "array",
             {
-              "countType": "varint",
+              "countType": "u8",
               "type": "AbilityLayers"
             }
           ]
@@ -10049,7 +10048,7 @@
           "type": "bool"
         },
         {
-          "name": "imutable_world",
+          "name": "immutable_world",
           "type": "bool"
         },
         {
@@ -10070,7 +10069,7 @@
           "type": "string"
         },
         {
-          "name": "parameters",
+          "name": "messages",
           "type": [
             "array",
             {
@@ -10085,7 +10084,7 @@
       "container",
       [
         {
-          "name": "nbt",
+          "name": "payload",
           "type": "nbt"
         }
       ]
@@ -10266,8 +10265,7 @@
           "walk_speed": 16384,
           "muted": 32768,
           "world_builder": 65536,
-          "no_clip": 131072,
-          "ability_count": 262144
+          "no_clip": 131072
         }
       }
     ],

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -1047,7 +1047,7 @@ packet_set_entity_data:
    !bound: both
    runtime_entity_id: varint64
    metadata: MetadataDictionary
-   tick: varint
+   tick: varint64
 
 # SetActorMotion is sent by the server to change the client-side velocity of an entity. It is usually used
 # in combination with server-side movement calculation.


### PR DESCRIPTION
Found an issue with the set_entity_data packet that was causing packet errors. I think I was looking at the gophertunnel packet struct datatypes when i should have been looking at the marshalling functions for datatypes. :-)

Anyway, tested with a bot and a human player in survival, which seemed to trigger the packet errors from before.

Sample packet: 3700000001000100000000000000

Resolves as:

```
{
    "name": "set_entity_data",
    "params": {
      "runtime_entity_id": "1477",
      "metadata": [
        {
          "key": "flags",
          "type": "long",
          "value": {
            "_value": "72198383066939392",
            "onfire": false,
            "sneaking": false,
            "riding": false,
            "sprinting": false,
            "action": false,
            "invisible": false,
            "tempted": false,
            "inlove": false,
            "saddled": false,
            "powered": false,
            "ignited": false,
            "baby": false,
            "converting": false,
            "critical": false,
            "can_show_nametag": false,
            "always_show_nametag": false,
            "no_ai": false,
            "silent": false,
            "wallclimbing": false,
            "can_climb": false,
            "swimmer": true,
            "can_fly": false,
            "walker": false,
            "resting": false,
            "sitting": false,
            "angry": false,
            "interested": false,
            "charged": false,
            "tamed": false,
            "orphaned": false,
            "leashed": false,
            "sheared": false,
            "gliding": false,
            "elder": false,
            "moving": true,
            "breathing": true,
            "chested": false,
            "stackable": false,
            "showbase": false,
            "rearing": false,
            "vibrating": false,
            "idling": false,
            "evoker_spell": false,
            "charge_attack": false,
            "wasd_controlled": false,
            "can_power_jump": false,
            "linger": false,
            "has_collision": true,
            "affected_by_gravity": false,
            "fire_immune": false,
            "dancing": false,
            "enchanted": false,
            "show_trident_rope": false,
            "container_private": false,
            "transforming": false,
            "spin_attack": false,
            "swimming": true,
            "bribed": false,
            "pregnant": false,
            "laying_egg": false,
            "rider_can_pick": false,
            "transition_sitting": false,
            "eating": false,
            "laying_down": false
          }
        }
      ],
      "tick": "0"
    }
  }
```