### PR TITLE
[1.7 - 1.8] `packet_entity_update_attributes`: `UUID` -> `uuid`

### DIFF
--- a/data/pc/1.7/protocol.json
+++ b/data/pc/1.7/protocol.json
@@ -1299,7 +1299,7 @@
                               "container",
                               [
                                 {
-                                  "name": "UUID",
+                                  "name": "uuid",
                                   "type": "UUID"
                                 },
                                 {

--- a/data/pc/1.8/protocol.json
+++ b/data/pc/1.8/protocol.json
@@ -1278,7 +1278,7 @@
                               "container",
                               [
                                 {
-                                  "name": "UUID",
+                                  "name": "uuid",
                                   "type": "UUID"
                                 },
                                 {

--- a/data/pc/15w40b/protocol.json
+++ b/data/pc/15w40b/protocol.json
@@ -1240,7 +1240,7 @@
                               "container",
                               [
                                 {
-                                  "name": "UUID",
+                                  "name": "uuid",
                                   "type": "UUID"
                                 },
                                 {


### PR DESCRIPTION
to bring these older versions back in line with the newer ones, the field names should be adjusted.
this caused a bug with which effects like speed were applied twice, see [prismarine-physics](https://github.com/PrismarineJS/prismarine-physics/pull/74).