### PR TITLE
[1.19] clarify crypto-related field naming during login state

### DIFF
--- a/data/pc/1.19/protocol.json
+++ b/data/pc/1.19/protocol.json
@@ -1282,7 +1282,7 @@
               "type": "string"
             },
             {
-              "name": "signature",
+              "name": "crypto",
               "type": [
                 "option",
                 [
@@ -1361,7 +1361,7 @@
                           "type": "i64"
                         },
                         {
-                          "name": "messageSignature",
+                          "name": "encryptedVerifyToken",
                           "type": [
                             "buffer",
                             {

--- a/data/pc/1.19/protocol.json
+++ b/data/pc/1.19/protocol.json
@@ -1289,7 +1289,7 @@
                   "container",
                   [
                     {
-                      "name": "timestamp",
+                      "name": "expiresAt",
                       "type": "i64"
                     },
                     {


### PR DESCRIPTION
having `signature.signature` is comfusing and renaming the entire object to `crypto` seems logical
`messageSignature` doesn't convey the task of the field or how it's related to the previously received clientbound encryption_begin. `encryptedVerifyToken` clearly explains that the field contains the previously received `verifyToken` but encrypted.