### PR TITLE
New Version Script

### DIFF
--- a/tools/js/incrementVersion.js
+++ b/tools/js/incrementVersion.js
@@ -13,19 +13,19 @@ function writeJSON (path, data) {
   fs.writeFileSync(path, JSON.stringify(data, null, 2), 'utf-8')
 }
 
-function alterJSON(path, callback) {
+function alterJSON (path, callback) {
   const jsonContents = getJSON(path)
   if (callback(jsonContents) !== false) {
     writeJSON(path, jsonContents)
   }
 }
 
-if (process.argv.length != 5) {
+if (process.argv.length !== 5) {
   console.log(`Usage: npm run version <${platforms.join('|')}> {version} {protocol_version}`)
   process.exit(1)
 }
 
-const [,, platform, version, protocol] = process.argv;
+const [,, platform, version, protocol] = process.argv
 
 if (!platforms.includes(platform)) {
   console.log(`Received platform ${platform}, expected one of (${platforms.join(', ')})`)
@@ -37,14 +37,13 @@ if (fs.existsSync(join(data, platform, version))) {
   process.exit(1)
 }
 
-
 alterJSON(join(data, 'dataPaths.json'), dataPaths => {
-  let latest = null;
+  let latest = null
   Object.entries(dataPaths[platform]).forEach(([ver, values]) => {
-    if (values['proto'] == `${platform}/latest`) {
-      latest = ver;
+    if (values.proto === `${platform}/latest`) {
+      latest = ver
     }
-  });
+  })
 
   if (latest === null) {
     console.log('Unable to determine previous version.')
@@ -52,9 +51,9 @@ alterJSON(join(data, 'dataPaths.json'), dataPaths => {
   }
 
   dataPaths[platform][version] = Object.assign({}, dataPaths[platform][latest])
-  dataPaths[platform][version]['version'] = `${platform}/${version}`
-  dataPaths[platform][latest]['proto'] = `${platform}/${latest}`
-  dataPaths[platform][latest]['types'] = `${platform}/${latest}`
+  dataPaths[platform][version].version = `${platform}/${version}`
+  dataPaths[platform][latest].proto = `${platform}/${latest}`
+  dataPaths[platform][latest].types = `${platform}/${latest}`
   fs.copyFileSync(
     join(data, platform, 'latest', 'proto.yml'),
     join(data, platform, latest, 'proto.yml'))
@@ -67,7 +66,7 @@ const protocolVersion = {
   version: parseInt(protocol),
   minecraftVersion: version,
   majorVersion: version.split('.').slice(0, 2).join('.'),
-  releaseType: "release"
+  releaseType: 'release'
 }
 
 alterJSON(join(data, platform, 'common', 'protocolVersions.json'), protoVers => {

--- a/tools/js/incrementVersion.js
+++ b/tools/js/incrementVersion.js
@@ -64,7 +64,7 @@ alterJSON(join(data, 'dataPaths.json'), dataPaths => {
 })
 
 const protocolVersion = {
-  version: protocol,
+  version: parseInt(protocol),
   minecraftVersion: version,
   majorVersion: version.split('.').slice(0, 2).join('.'),
   releaseType: "release"

--- a/tools/js/incrementVersion.js
+++ b/tools/js/incrementVersion.js
@@ -52,6 +52,7 @@ function bedrockProtocol (version, protocol) {
 
     paths[version] = Object.assign({}, paths[latest])
     paths[version].version = `bedrock/${version}`
+    paths[version].protocol = `bedrock/${version}`
     paths[latest].proto = `bedrock/${latest}`
     paths[latest].types = `bedrock/${latest}`
     fs.copyFileSync(

--- a/tools/js/incrementVersion.js
+++ b/tools/js/incrementVersion.js
@@ -18,11 +18,11 @@ function alterJSON (path, callback) {
   }
 }
 
-function pcProtocol(version, protocol) {
+function pcProtocol (version, protocol) {
   throw new Error('Not Implemented')
 }
 
-function bedrockProtocol(version, protocol) {
+function bedrockProtoco (version, protocol) {
   const dataRoot = join(data, 'bedrock')
   if (fs.existsSync(join(data, 'bedrock', version))) {
     console.log(`data/bedrock/${version} already exists`)
@@ -38,9 +38,9 @@ function bedrockProtocol(version, protocol) {
 
   alterJSON(join(data, 'dataPaths.json'), dataPaths => {
     let latest = null
-    const paths = dataPaths['bedrock']
+    const paths = dataPaths.bedrock
     Object.entries(paths).forEach(([ver, values]) => {
-      if (values.proto === `bedrock/latest`) {
+      if (values.proto === 'bedrock/latest') {
         latest = ver
       }
     })
@@ -75,7 +75,7 @@ function bedrockProtocol(version, protocol) {
 
   const protoYml = fs.readFileSync(join(dataRoot, 'latest', 'proto.yml'), 'utf-8')
   const protoYmlUpdate = protoYml.replace(/!version: [0-9.]+/, `!version: ${version}`)
-  fs.writeFileSync(join(dataRoot, 'latest', 'proto.yml'), protoYmlUpdate, 'utf-8') 
+  fs.writeFileSync(join(dataRoot, 'latest', 'proto.yml'), protoYmlUpdate, 'utf-8')
 }
 
 const platforms = {
@@ -90,10 +90,9 @@ if (process.argv.length !== 5) {
 
 const [,, platform, version, protocol] = process.argv
 
-if (platforms[platform] == undefined) {
+if (platforms[platform] === undefined) {
   console.log(`Received platform "${platform}", expected one of (${Object.keys(platforms).join(', ')})`)
   process.exit(1)
 }
 
-platforms[platform](version, protocol);
-
+platforms[platform](version, protocol)

--- a/tools/js/incrementVersion.js
+++ b/tools/js/incrementVersion.js
@@ -22,7 +22,7 @@ function pcProtocol (version, protocol) {
   throw new Error('Not Implemented')
 }
 
-function bedrockProtoco (version, protocol) {
+function bedrockProtocol (version, protocol) {
   const dataRoot = join(data, 'bedrock')
   if (fs.existsSync(join(data, 'bedrock', version))) {
     console.log(`data/bedrock/${version} already exists`)

--- a/tools/js/incrementVersion.js
+++ b/tools/js/incrementVersion.js
@@ -1,0 +1,86 @@
+const fs = require('fs')
+const { join } = require('path')
+
+const root = join(__dirname, '..', '..')
+const data = join(root, 'data')
+const platforms = ['bedrock', 'pc']
+
+function getJSON (path) {
+  return JSON.parse(fs.readFileSync(path, 'utf-8'))
+}
+
+function writeJSON (path, data) {
+  fs.writeFileSync(path, JSON.stringify(data, null, 2), 'utf-8')
+}
+
+function alterJSON(path, callback) {
+  const jsonContents = getJSON(path)
+  if (callback(jsonContents) !== false) {
+    writeJSON(path, jsonContents)
+  }
+}
+
+if (process.argv.length != 5) {
+  console.log(`Usage: npm run version <${platforms.join('|')}> {version} {protocol_version}`)
+  process.exit(1)
+}
+
+const [,, platform, version, protocol] = process.argv;
+
+if (!platforms.includes(platform)) {
+  console.log(`Received platform ${platform}, expected one of (${platforms.join(', ')})`)
+  process.exit(1)
+}
+
+if (fs.existsSync(join(data, platform, version))) {
+  console.log(`data/${platform}/${version} already exists`)
+  process.exit(1)
+}
+
+
+alterJSON(join(data, 'dataPaths.json'), dataPaths => {
+  let latest = null;
+  Object.entries(dataPaths[platform]).forEach(([ver, values]) => {
+    if (values['proto'] == `${platform}/latest`) {
+      latest = ver;
+    }
+  });
+
+  if (latest === null) {
+    console.log('Unable to determine previous version.')
+    process.exit(1)
+  }
+
+  dataPaths[platform][version] = Object.assign({}, dataPaths[platform][latest])
+  dataPaths[platform][version]['version'] = `${platform}/${version}`
+  dataPaths[platform][latest]['proto'] = `${platform}/${latest}`
+  dataPaths[platform][latest]['types'] = `${platform}/${latest}`
+  fs.copyFileSync(
+    join(data, platform, 'latest', 'proto.yml'),
+    join(data, platform, latest, 'proto.yml'))
+  fs.copyFileSync(
+    join(data, platform, 'latest', 'types.yml'),
+    join(data, platform, latest, 'types.yml'))
+})
+
+const protocolVersion = {
+  version: protocol,
+  minecraftVersion: version,
+  majorVersion: version.split('.').slice(0, 2).join('.'),
+  releaseType: "release"
+}
+
+alterJSON(join(data, platform, 'common', 'protocolVersions.json'), protoVers => {
+  protoVers.unshift(protocolVersion)
+})
+
+alterJSON(join(data, platform, 'common', 'versions.json'), versions => {
+  versions.push(version)
+})
+
+fs.mkdirSync(join(data, platform, version))
+writeJSON(join(data, platform, version, 'version.json'), protocolVersion)
+
+const protoYml = fs.readFileSync(join(data, platform, 'latest', 'proto.yml'), 'utf-8')
+const protoYmlUpdate = protoYml.replace(/!version: [0-9.]+/, `!version: ${version}`)
+fs.writeFileSync(join(data, platform, 'latest', 'proto.yml'), protoYmlUpdate, 'utf-8')

--- a/tools/js/package.json
+++ b/tools/js/package.json
@@ -7,7 +7,8 @@
     "lint": "standard",
     "fix": "standard --fix",
     "pretest": "npm run lint",
-    "build": "node ./compileProtocol.js"
+    "build": "node ./compileProtocol.js",
+    "version": "node ./incrementVersion.js"
   },
   "dependencies": {
     "ajv": "^6.5.4",


### PR DESCRIPTION
Put together a quick version updater script for adding a new version to minecraft-data.

My 1.19.21 PR (https://github.com/PrismarineJS/minecraft-data/pull/622) was put together with just this script. Not pretty, but it works. Happy to iterate on style if needed.

Currently untested for pc platform.