### PR TITLE
moving features to mcData (step towards mineflayer issue #1392)

### DIFF
--- a/data/bedrock/common/features.json
+++ b/data/bedrock/common/features.json
@@ -3,14 +3,6 @@
     "name": "newRecipeSchema",
     "description": "New recipe schema",
     "versions": ["1.16_major", "latest"]
-  },
-  {
-    "name": "usesBlockStates",
-    "versions": ["0.14", "1.19"]
-  },
-  {
-    "name": "effectNamesMatchRegistryName",
-    "versions": ["1.17", "1.19"]
   }
 ]
 

--- a/data/bedrock/common/features.json
+++ b/data/bedrock/common/features.json
@@ -3,6 +3,14 @@
     "name": "newRecipeSchema",
     "description": "New recipe schema",
     "versions": ["1.16_major", "latest"]
+  },
+  {
+    "name": "usesBlockStates",
+    "version": ["0.14", "1.19"]
+  },
+  {
+    "name": "effectNamesMatchRegistryName",
+    "version": ["1.17", "1.19"]
   }
 ]
 

--- a/data/bedrock/common/features.json
+++ b/data/bedrock/common/features.json
@@ -6,11 +6,11 @@
   },
   {
     "name": "usesBlockStates",
-    "version": ["0.14", "1.19"]
+    "versions": ["0.14", "1.19"]
   },
   {
     "name": "effectNamesMatchRegistryName",
-    "version": ["1.17", "1.19"]
+    "versions": ["1.17", "1.19"]
   }
 ]
 

--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -348,6 +348,18 @@
     "version": ["1.17", "1.19"]
   },
   {
+    "name": "shieldSlot",
+    "version": ["1.9", "1.19"]
+  },
+  {
+    "name": "village&pillageInventoryWindows",
+    "version": ["1.14", "1.19"]
+  },
+  {
+    "name": "netherUpdateInventoryWindows",
+    "version": ["1.16","1.19"]
+  },
+  {
     "name": "unloadChunkByEmptyChunk",
     "description": "Chunk unloading is done by sending an empty chunk",
     "versions": ["1.8", "1.8"]

--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -370,26 +370,6 @@
     "versions": ["1.9", "1.16"]
   },
   {
-    "name": "fixedPointPosition",
-    "description": "Entity positions are represented with fixed point numbers",
-    "versions": ["1.8", "1.8"]
-  },
-  {
-    "name": "doublePosition",
-    "description": "Entity positions are represented with double",
-    "versions": ["1.9", "1.16"]
-  },
-  {
-    "name": "fixedPointDelta",
-    "description": "Delta of position are represented with fixed point numbers",
-    "versions": ["1.8", "1.8"]
-  },
-  {
-    "name": "fixedPointDelta128",
-    "description": "Delta of position are represented with fixed point numbers times 128",
-    "versions": ["1.9", "1.16"]
-  },
-  {
     "name": "entityCamelCase",
     "description": "entity names are in camel case",
     "versions": ["1.8", "1.10"]
@@ -467,11 +447,6 @@
   {
     "name": "allEntityEquipmentInOne",
     "description": "entity equipment packet contains all equipment slots instead of just one",
-    "versions": ["1.16", "1.16"]
-  },
-  {
-    "name": "dimensionIsAString",
-    "description": "dimension identifier is a string instead of an id",
     "versions": ["1.16", "1.16"]
   },
   {

--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -341,23 +341,23 @@
   },
   {
     "name": "usesBlockStates",
-    "version": ["1.13", "1.19"]
+    "versions": ["1.13", "1.19"]
   },
   {
     "name": "effectNamesMatchRegistryName",
-    "version": ["1.17", "1.19"]
+    "versions": ["1.17", "1.19"]
   },
   {
     "name": "shieldSlot",
-    "version": ["1.9", "1.19"]
+    "versions": ["1.9", "1.19"]
   },
   {
     "name": "village&pillageInventoryWindows",
-    "version": ["1.14", "1.19"]
+    "versions": ["1.14", "1.19"]
   },
   {
     "name": "netherUpdateInventoryWindows",
-    "version": ["1.16","1.19"]
+    "versions": ["1.16","1.19"]
   },
   {
     "name": "unloadChunkByEmptyChunk",
@@ -507,11 +507,11 @@
       },
       {
         "value": 5,
-        "version": "1.9_major"
+        "versions": "1.9_major"
       },
       {
         "value": 8,
-        "version": "1.8_major"
+        "versions": "1.8_major"
       }
     ]
   },

--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -340,6 +340,144 @@
     "versions": ["1.8", "1.8.9"]
   },
   {
+    "name": "usesBlockStates",
+    "version": ["1.13", "1.19"]
+  },
+  {
+    "name": "effectNamesMatchRegistryName",
+    "version": ["1.17", "1.19"]
+  },
+  {
+    "name": "unloadChunkByEmptyChunk",
+    "description": "Chunk unloading is done by sending an empty chunk",
+    "versions": ["1.8", "1.8"]
+  },
+  {
+    "name": "unloadChunkDirect",
+    "description": "Chunk unloading is done by sending directly an unload chunk packet",
+    "versions": ["1.9", "1.16"]
+  },
+  {
+    "name": "fixedPointPosition",
+    "description": "Entity positions are represented with fixed point numbers",
+    "versions": ["1.8", "1.8"]
+  },
+  {
+    "name": "doublePosition",
+    "description": "Entity positions are represented with double",
+    "versions": ["1.9", "1.16"]
+  },
+  {
+    "name": "fixedPointDelta",
+    "description": "Delta of position are represented with fixed point numbers",
+    "versions": ["1.8", "1.8"]
+  },
+  {
+    "name": "fixedPointDelta128",
+    "description": "Delta of position are represented with fixed point numbers times 128",
+    "versions": ["1.9", "1.16"]
+  },
+  {
+    "name": "entityCamelCase",
+    "description": "entity names are in camel case",
+    "versions": ["1.8", "1.10"]
+  },
+  {
+    "name": "entitySnakeCase",
+    "description": "entity name are in snake case",
+    "versions": ["1.11", "1.16"]
+  },
+  {
+    "name": "respawnIsPayload",
+    "description": "respawn field is payload",
+    "versions": ["1.8", "1.8"]
+  },
+  {
+    "name": "respawnIsActionId",
+    "description": "respawn field is action id",
+    "versions": ["1.9", "1.16"]
+  },
+  {
+    "name": "attachStackEntity",
+    "description": "attach is used to stack entities",
+    "versions": ["1.8", "1.8"]
+  },
+  {
+    "name": "setPassengerStackEntity",
+    "description": "set passengers is used to stack entities",
+    "versions": ["1.9", "1.16"]
+  },
+  {
+    "name": "theFlattening",
+    "description": "many items got merged, separated or renamed",
+    "versions": ["1.13",  "1.16"]
+  },
+  {
+    "name": "blockPlaceHasIntCursor",
+    "description": "block_place packet has int cursor",
+    "versions": ["1.8", "1.10"]
+  },
+  {
+    "name": "updateViewPosition",
+    "description": "the client's chunk position must be updated to render chunks correctly",
+    "versions": ["1.14", "1.16"]
+  },
+  {
+    "name": "lightSentSeparately",
+    "description": "chunk light data is sent in a separate packet",
+    "versions": ["1.14", "1.16"]
+  },
+  {
+    "name": "difficultySentSeparately",
+    "description": "game difficulty is sent separately from the login packet",
+    "versions": ["1.14", "1.16"]
+  },
+  {
+    "name": "acknowledgePlayerDigging",
+    "description": "player digging packets should be responded to",
+    "versions": ["1.14", "1.16"]
+  },
+  {
+    "name": "multiTypeSigns",
+    "description": "there are 6 types of signs based on the different trees",
+    "versions": ["1.14", "1.16"]
+  },
+  {
+    "name": "entityMetadataSentSeparately",
+    "description": "entity metadata is sent separately from the spawn packets",
+    "versions": ["1.15", "1.16"]
+  },
+  {
+    "name": "attributeSnakeCase",
+    "description": "entity attributes are in snake case",
+    "versions": ["1.16", "1.16"]
+  },
+  {
+    "name": "allEntityEquipmentInOne",
+    "description": "entity equipment packet contains all equipment slots instead of just one",
+    "versions": ["1.16", "1.16"]
+  },
+  {
+    "name": "dimensionIsAString",
+    "description": "dimension identifier is a string instead of an id",
+    "versions": ["1.16", "1.16"]
+  },
+  {
+    "name": "entityMCPrefixed",
+    "description": "entity prefixed with minecraft: on this versions",
+    "versions": ["1.12", "1.16"]
+  },
+  {
+    "name": "nbtOnMetadata",
+    "description": "in never versions its nbt but in 1.8 its on metadata",
+    "versions": ["1.8", "1.8"]
+  },
+  {
+    "name": "theShulkerBoxes",
+    "description": "added shulker boxes to the game",
+    "versions": ["1.13", "1.16"]
+  },
+  {
     "name": "metadataIxOfItem",
     "description": "item.metadata[this_ix] will be the item that was dropped on the ground",
     "values": [

--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -482,11 +482,11 @@
       },
       {
         "value": 5,
-        "versions": "1.9_major"
+        "version": "1.9_major"
       },
       {
         "value": 8,
-        "versions": "1.8_major"
+        "version": "1.8_major"
       }
     ]
   },


### PR DESCRIPTION
https://github.com/PrismarineJS/mineflayer/issues/1392
I've copied these features from pblock, pwindow and flying squid to mcData so that we can just check registry.supportFeature instead of having stray feature check implementations throughout Prismarine.