### PR TITLE
Add 1.19 block mappings with new schema

### DIFF
--- a/data/dataPaths.json
+++ b/data/dataPaths.json
@@ -1365,6 +1365,7 @@
       "steve": "bedrock/1.16.201",
       "blocksB2J": "bedrock/1.19.1",
       "blocksJ2B": "bedrock/1.19.1",
+      "blockMappings": "bedrock/1.19.1",
       "proto": "bedrock/1.19.1",
       "types": "bedrock/1.19.1",
       "version": "bedrock/1.19.1"

--- a/doc/bedrock.md
+++ b/doc/bedrock.md
@@ -6,6 +6,7 @@
 |-|-|-|-|
 | blockStates.json | Contains the global block palette for a Minecraft version. <br>Contains all of the possible block states. <br><br><br>The index of a Block State instance here is the paletted ID, <br>which can be used to idenfify this block state<br>instead of a string. | [bedrock-extractor][1] ("BlockStates.json" file) |  |
 | steve.json | Skin data for clients connecting to BE servers, for default Steve character | [bedrock-protocol][2] (capture from proxy) |  |
+| blockMappings.json | Output of bedrock-extractor |
 
 ### Updating protocol data
 

--- a/schemas/blockMappings_schema.json
+++ b/schemas/blockMappings_schema.json
@@ -1,0 +1,44 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "pc": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "states": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "name",
+            "states"
+          ]
+        },
+        "pe": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "states": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "name",
+            "states"
+          ]
+        }
+      },
+      "required": [
+        "pc",
+        "pe"
+      ]
+    }
+  ]
+}

--- a/tools/js/test/test.js
+++ b/tools/js/test/test.js
@@ -11,7 +11,7 @@ const Validator = require('protodef-validator')
 
 Error.stackTraceLimit = 0
 
-const data = ['attributes', 'biomes', 'commands', 'instruments', 'items', 'materials', 'blocks', 'blockCollisionShapes', 'recipes', 'windows', 'entities', 'protocol', 'version', 'effects', 'enchantments', 'language', 'foods', 'particles', 'blockLoot', 'entityLoot', 'mapIcons', 'tints']
+const data = ['attributes', 'biomes', 'commands', 'instruments', 'items', 'materials', 'blocks', 'blockCollisionShapes', 'recipes', 'windows', 'entities', 'protocol', 'version', 'effects', 'enchantments', 'language', 'foods', 'particles', 'blockLoot', 'entityLoot', 'mapIcons', 'tints', 'blockMappings']
 
 require('./version_iterator')(function (p, versionString) {
   describe('minecraft-data schemas ' + versionString, function () {


### PR DESCRIPTION
Replaces earlier PR to update schema https://github.com/PrismarineJS/minecraft-data/pull/532

The new 'flat' schema file size here is now ~8MB up from the previous 5MB which used string maps (2MB for the compact schema in #532)