### PR TITLE
Update bedrock packet_command_request.version comment

### DIFF
--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -1780,7 +1780,8 @@ packet_command_request:
    # Internal specifies if the command request internal. Setting it to false seems to work and the usage of
    # this field is not known.
    internal: bool
-   # Version is the version of the command that is being executed. This field currently has no purpose or functionality.
+   # Version is the version of the command that is being executed. This field currently has no known purpose
+   # or functionality but should be set to 52 as of 1.19.62.
    version: varint
 
 

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -1780,8 +1780,8 @@ packet_command_request:
    # Internal specifies if the command request internal. Setting it to false seems to work and the usage of
    # this field is not known.
    internal: bool
-   # Version is the version of the command that is being executed. This field currently has no known purpose
-   # or functionality but should be set to 52 as of 1.19.62.
+   # Specifies the version of the command to run, relative to the current Minecraft version. Should be set
+   # to 52 as of 1.19.62
    version: varint
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "minecraft-data",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "minecraft-data",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Determined via relay. Commands are not executed when set to 0, 1, or 51.

This may be a new field that needs to be added to `common/protocolVersions.json` but its probably too soon to say for sure.