### PR TITLE
Update attributes schema, add bedrock data

### DIFF
--- a/data/bedrock/1.16.201/attributes.json
+++ b/data/bedrock/1.16.201/attributes.json
@@ -60,7 +60,7 @@
     "resource": "health",
     "default": 20,
     "min": 0,
-    "max": 1024
+    "max": 20
   },
   {
     "name": "absorption",

--- a/data/bedrock/1.16.201/attributes.json
+++ b/data/bedrock/1.16.201/attributes.json
@@ -1,12 +1,5 @@
 [
   {
-    "name": "maxHealth",
-    "resource": "generic.max_health",
-    "default": 20,
-    "min": 1,
-    "max": 1024
-  },
-  {
     "name": "followRange",
     "resource": "generic.follow_range",
     "default": 32,
@@ -49,13 +42,6 @@
     "max": 1
   },
   {
-    "name": "attackSpeed",
-    "resource": "generic.attack_speed",
-    "default": 4,
-    "min": 0,
-    "max": 1024
-  },
-  {
     "name": "flyingSpeed",
     "resource": "generic.flying_speed",
     "default": 0.4,
@@ -63,31 +49,59 @@
     "max": 1024
   },
   {
-    "name": "attackKnockback",
-    "resource": "generic.attack_knockback",
-    "default": 0,
-    "min": 0,
-    "max": 5
-  },
-  {
-    "name": "armorHealth",
-    "resource": "generic.armor",
-    "default": 0,
-    "min": 0,
-    "max": 30
-  },
-  {
-    "name": "armorToughness",
-    "resource": "generic.armor_toughness",
-    "default": 0,
-    "min": 0,
-    "max": 20
-  },
-  {
     "name": "luck",
     "resource": "generic.luck",
     "default": 0,
     "min": -1024,
     "max": 1024
+  },
+  {
+    "name": "health",
+    "resource": "health",
+    "default": 20,
+    "min": 0,
+    "max": 1024
+  },
+  {
+    "name": "absorption",
+    "resource": "absorption",
+    "default": 0,
+    "min": 0,
+    "max": 1024
+  },
+  {
+    "name": "exhaustion",
+    "resource": "player.exhaustion",
+    "default": 0,
+    "min": 0,
+    "max": 5
+  },
+  {
+    "name": "experienceProgress",
+    "resource": "player.experience",
+    "default": 0,
+    "min": 0,
+    "max": 1
+  },
+  {
+    "name": "experienceLevel",
+    "resource": "player.level",
+    "default": 0,
+    "min": 0,
+    "max": 24791
+  },
+  {
+    "name": "hunger",
+    "resource": "player.hunger",
+    "default": 20,
+    "min": 0,
+    "max": 20
+  },
+  {
+    "name": "saturation",
+    "resource": "player.saturation",
+    "default": 20,
+    "min": 0,
+    "max": 20
   }
 ]

--- a/data/dataPaths.json
+++ b/data/dataPaths.json
@@ -1200,6 +1200,7 @@
       "version": "bedrock/1.0"
     },
     "1.16.201": {
+      "attributes": "bedrock/1.16.201",
       "protocol": "bedrock/1.16.201",
       "steve": "bedrock/1.16.201",
       "proto": "bedrock/1.17.0",
@@ -1209,6 +1210,7 @@
       "version": "bedrock/1.16.201"
     },
     "1.16.210": {
+      "attributes": "bedrock/1.16.201",
       "protocol": "bedrock/1.16.210",
       "steve": "bedrock/1.16.201",
       "proto": "bedrock/1.17.0",
@@ -1217,6 +1219,7 @@
       "version": "bedrock/1.16.210"
     },
     "1.16.220": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.16.220",
       "blockStates": "bedrock/1.16.220",
       "biomes": "bedrock/1.17.0",
@@ -1229,6 +1232,7 @@
       "version": "bedrock/1.16.220"
     },
     "1.17.0": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.17.0",
       "blockStates": "bedrock/1.17.0",
       "blockCollisionShapes": "bedrock/1.17.0",
@@ -1248,6 +1252,7 @@
       "version": "bedrock/1.17.0"
     },
     "1.17.10": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.17.10",
       "blockStates": "bedrock/1.17.10",
       "blockCollisionShapes": "bedrock/1.17.10",
@@ -1269,6 +1274,7 @@
       "version": "bedrock/1.17.10"
     },
     "1.17.30": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.17.10",
       "blockStates": "bedrock/1.17.10",
       "blockCollisionShapes": "bedrock/1.17.10",
@@ -1290,6 +1296,7 @@
       "version": "bedrock/1.17.30"
     },
     "1.17.40": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.17.40",
       "blockStates": "bedrock/1.17.40",
       "blockCollisionShapes": "bedrock/1.17.40",
@@ -1311,6 +1318,7 @@
       "version": "bedrock/1.17.40"
     },
     "1.18.0": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.17.40",
       "blockStates": "bedrock/1.17.40",
       "blockCollisionShapes": "bedrock/1.17.40",
@@ -1334,6 +1342,7 @@
       "blockLoot": "bedrock/1.18.0"
     },
     "1.18.11": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.18.11",
       "blockStates": "bedrock/1.18.11",
       "blockCollisionShapes": "bedrock/1.18.11",
@@ -1355,6 +1364,7 @@
       "version": "bedrock/1.18.11"
     },
     "1.18.30": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.18.30",
       "blockStates": "bedrock/1.18.30",
       "blockCollisionShapes": "bedrock/1.18.30",
@@ -1376,6 +1386,7 @@
       "version": "bedrock/1.18.30"
     },
     "1.19.1": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",
@@ -1398,6 +1409,7 @@
       "version": "bedrock/1.19.1"
     },
     "1.19.10": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",
@@ -1419,6 +1431,7 @@
       "version": "bedrock/1.19.10"
     },
     "1.19.20": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",
@@ -1440,6 +1453,7 @@
       "version": "bedrock/1.19.20"
     },
     "1.19.21": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",
@@ -1461,6 +1475,7 @@
       "version": "bedrock/1.19.21"
     },
     "1.19.30": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",
@@ -1482,6 +1497,7 @@
       "version": "bedrock/1.19.30"
     },
     "1.19.40": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",
@@ -1503,6 +1519,7 @@
       "version": "bedrock/1.19.40"
     },
     "1.19.50": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",
@@ -1524,6 +1541,7 @@
       "version": "bedrock/1.19.50"
     },
     "1.19.60": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",
@@ -1545,6 +1563,7 @@
       "version": "bedrock/1.19.60"
     },
     "1.19.62": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",
@@ -1566,6 +1585,7 @@
       "version": "bedrock/1.19.62"
     },
     "1.19.63": {
+      "attributes": "bedrock/1.16.201",
       "blocks": "bedrock/1.19.1",
       "blockStates": "bedrock/1.19.1",
       "blockCollisionShapes": "bedrock/1.19.1",

--- a/data/pc/1.10/attributes.json
+++ b/data/pc/1.10/attributes.json
@@ -1,54 +1,93 @@
 [
   {
     "name": "maxHealth",
-    "resource": "generic.maxHealth"
+    "resource": "generic.maxHealth",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "generic.followRange"
+    "resource": "generic.followRange",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "generic.knockbackResistance"
+    "resource": "generic.knockbackResistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "generic.movementSpeed"
+    "resource": "generic.movementSpeed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "generic.attackDamage"
+    "resource": "generic.attackDamage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "horse.jumpStrength"
+    "resource": "horse.jumpStrength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "zombie.spawnReinforcements"
+    "resource": "zombie.spawnReinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "attackSpeed",
-    "resource": "generic.attackSpeed"
+    "resource": "generic.attackSpeed",
+    "default": 4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "flyingSpeed",
-    "resource": "generic.flyingSpeed"
+    "resource": "generic.flyingSpeed",
+    "default": 0.4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackKnockback",
-    "resource": "generic.attackKnockback"
+    "resource": "generic.attackKnockback",
+    "default": 0,
+    "min": 0,
+    "max": 5
   },
   {
-    "name": "armor",
-    "resource": "generic.armor"
+    "name": "armorHealth",
+    "resource": "generic.armor",
+    "default": 0,
+    "min": 0,
+    "max": 30
   },
   {
     "name": "armorToughness",
-    "resource": "generic.armorToughness"
+    "resource": "generic.armorToughness",
+    "default": 0,
+    "min": 0,
+    "max": 20
   },
   {
     "name": "luck",
-    "resource": "generic.luck"
+    "resource": "generic.luck",
+    "default": 0,
+    "min": -1024,
+    "max": 1024
   }
 ]

--- a/data/pc/1.11/attributes.json
+++ b/data/pc/1.11/attributes.json
@@ -1,54 +1,93 @@
 [
   {
     "name": "maxHealth",
-    "resource": "generic.maxHealth"
+    "resource": "generic.maxHealth",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "generic.followRange"
+    "resource": "generic.followRange",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "generic.knockbackResistance"
+    "resource": "generic.knockbackResistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "generic.movementSpeed"
+    "resource": "generic.movementSpeed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "generic.attackDamage"
+    "resource": "generic.attackDamage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "horse.jumpStrength"
+    "resource": "horse.jumpStrength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "zombie.spawnReinforcements"
+    "resource": "zombie.spawnReinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "attackSpeed",
-    "resource": "generic.attackSpeed"
+    "resource": "generic.attackSpeed",
+    "default": 4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "flyingSpeed",
-    "resource": "generic.flyingSpeed"
+    "resource": "generic.flyingSpeed",
+    "default": 0.4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackKnockback",
-    "resource": "generic.attackKnockback"
+    "resource": "generic.attackKnockback",
+    "default": 0,
+    "min": 0,
+    "max": 5
   },
   {
-    "name": "armor",
-    "resource": "generic.armor"
+    "name": "armorHealth",
+    "resource": "generic.armor",
+    "default": 0,
+    "min": 0,
+    "max": 30
   },
   {
     "name": "armorToughness",
-    "resource": "generic.armorToughness"
+    "resource": "generic.armorToughness",
+    "default": 0,
+    "min": 0,
+    "max": 20
   },
   {
     "name": "luck",
-    "resource": "generic.luck"
+    "resource": "generic.luck",
+    "default": 0,
+    "min": -1024,
+    "max": 1024
   }
 ]

--- a/data/pc/1.12/attributes.json
+++ b/data/pc/1.12/attributes.json
@@ -1,54 +1,93 @@
 [
   {
     "name": "maxHealth",
-    "resource": "generic.maxHealth"
+    "resource": "generic.maxHealth",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "generic.followRange"
+    "resource": "generic.followRange",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "generic.knockbackResistance"
+    "resource": "generic.knockbackResistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "generic.movementSpeed"
+    "resource": "generic.movementSpeed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "generic.attackDamage"
+    "resource": "generic.attackDamage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "horse.jumpStrength"
+    "resource": "horse.jumpStrength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "zombie.spawnReinforcements"
+    "resource": "zombie.spawnReinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "attackSpeed",
-    "resource": "generic.attackSpeed"
+    "resource": "generic.attackSpeed",
+    "default": 4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "flyingSpeed",
-    "resource": "generic.flyingSpeed"
+    "resource": "generic.flyingSpeed",
+    "default": 0.4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackKnockback",
-    "resource": "generic.attackKnockback"
+    "resource": "generic.attackKnockback",
+    "default": 0,
+    "min": 0,
+    "max": 5
   },
   {
-    "name": "armor",
-    "resource": "generic.armor"
+    "name": "armorHealth",
+    "resource": "generic.armor",
+    "default": 0,
+    "min": 0,
+    "max": 30
   },
   {
     "name": "armorToughness",
-    "resource": "generic.armorToughness"
+    "resource": "generic.armorToughness",
+    "default": 0,
+    "min": 0,
+    "max": 20
   },
   {
     "name": "luck",
-    "resource": "generic.luck"
+    "resource": "generic.luck",
+    "default": 0,
+    "min": -1024,
+    "max": 1024
   }
 ]

--- a/data/pc/1.13/attributes.json
+++ b/data/pc/1.13/attributes.json
@@ -1,54 +1,93 @@
 [
   {
     "name": "maxHealth",
-    "resource": "generic.maxHealth"
+    "resource": "generic.maxHealth",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "generic.followRange"
+    "resource": "generic.followRange",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "generic.knockbackResistance"
+    "resource": "generic.knockbackResistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "generic.movementSpeed"
+    "resource": "generic.movementSpeed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "generic.attackDamage"
+    "resource": "generic.attackDamage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "horse.jumpStrength"
+    "resource": "horse.jumpStrength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "zombie.spawnReinforcements"
+    "resource": "zombie.spawnReinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "attackSpeed",
-    "resource": "generic.attackSpeed"
+    "resource": "generic.attackSpeed",
+    "default": 4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "flyingSpeed",
-    "resource": "generic.flyingSpeed"
+    "resource": "generic.flyingSpeed",
+    "default": 0.4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackKnockback",
-    "resource": "generic.attackKnockback"
+    "resource": "generic.attackKnockback",
+    "default": 0,
+    "min": 0,
+    "max": 5
   },
   {
-    "name": "armor",
-    "resource": "generic.armor"
+    "name": "armorHealth",
+    "resource": "generic.armor",
+    "default": 0,
+    "min": 0,
+    "max": 30
   },
   {
     "name": "armorToughness",
-    "resource": "generic.armorToughness"
+    "resource": "generic.armorToughness",
+    "default": 0,
+    "min": 0,
+    "max": 20
   },
   {
     "name": "luck",
-    "resource": "generic.luck"
+    "resource": "generic.luck",
+    "default": 0,
+    "min": -1024,
+    "max": 1024
   }
 ]

--- a/data/pc/1.14/attributes.json
+++ b/data/pc/1.14/attributes.json
@@ -1,54 +1,93 @@
 [
   {
     "name": "maxHealth",
-    "resource": "generic.maxHealth"
+    "resource": "generic.maxHealth",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "generic.followRange"
+    "resource": "generic.followRange",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "generic.knockbackResistance"
+    "resource": "generic.knockbackResistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "generic.movementSpeed"
+    "resource": "generic.movementSpeed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "generic.attackDamage"
+    "resource": "generic.attackDamage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "horse.jumpStrength"
+    "resource": "horse.jumpStrength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "zombie.spawnReinforcements"
+    "resource": "zombie.spawnReinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "attackSpeed",
-    "resource": "generic.attackSpeed"
+    "resource": "generic.attackSpeed",
+    "default": 4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "flyingSpeed",
-    "resource": "generic.flyingSpeed"
+    "resource": "generic.flyingSpeed",
+    "default": 0.4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackKnockback",
-    "resource": "generic.attackKnockback"
+    "resource": "generic.attackKnockback",
+    "default": 0,
+    "min": 0,
+    "max": 5
   },
   {
-    "name": "armor",
-    "resource": "generic.armor"
+    "name": "armorHealth",
+    "resource": "generic.armor",
+    "default": 0,
+    "min": 0,
+    "max": 30
   },
   {
     "name": "armorToughness",
-    "resource": "generic.armorToughness"
+    "resource": "generic.armorToughness",
+    "default": 0,
+    "min": 0,
+    "max": 20
   },
   {
     "name": "luck",
-    "resource": "generic.luck"
+    "resource": "generic.luck",
+    "default": 0,
+    "min": -1024,
+    "max": 1024
   }
 ]

--- a/data/pc/1.15/attributes.json
+++ b/data/pc/1.15/attributes.json
@@ -1,54 +1,93 @@
 [
   {
     "name": "maxHealth",
-    "resource": "generic.maxHealth"
+    "resource": "generic.maxHealth",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "generic.followRange"
+    "resource": "generic.followRange",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "generic.knockbackResistance"
+    "resource": "generic.knockbackResistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "generic.movementSpeed"
+    "resource": "generic.movementSpeed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "generic.attackDamage"
+    "resource": "generic.attackDamage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "horse.jumpStrength"
+    "resource": "horse.jumpStrength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "zombie.spawnReinforcements"
+    "resource": "zombie.spawnReinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "attackSpeed",
-    "resource": "generic.attackSpeed"
+    "resource": "generic.attackSpeed",
+    "default": 4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "flyingSpeed",
-    "resource": "generic.flyingSpeed"
+    "resource": "generic.flyingSpeed",
+    "default": 0.4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackKnockback",
-    "resource": "generic.attackKnockback"
+    "resource": "generic.attackKnockback",
+    "default": 0,
+    "min": 0,
+    "max": 5
   },
   {
-    "name": "armor",
-    "resource": "generic.armor"
+    "name": "armorHealth",
+    "resource": "generic.armor",
+    "default": 0,
+    "min": 0,
+    "max": 30
   },
   {
     "name": "armorToughness",
-    "resource": "generic.armorToughness"
+    "resource": "generic.armorToughness",
+    "default": 0,
+    "min": 0,
+    "max": 20
   },
   {
     "name": "luck",
-    "resource": "generic.luck"
+    "resource": "generic.luck",
+    "default": 0,
+    "min": -1024,
+    "max": 1024
   }
 ]

--- a/data/pc/1.17/attributes.json
+++ b/data/pc/1.17/attributes.json
@@ -1,54 +1,93 @@
 [
   {
     "name": "maxHealth",
-    "resource": "minecraft:generic.max_health"
+    "resource": "generic.max_health",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "minecraft:generic.follow_range"
+    "resource": "generic.follow_range",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "minecraft:generic.knockback_resistance"
+    "resource": "generic.knockback_resistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "minecraft:generic.movement_speed"
+    "resource": "generic.movement_speed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "minecraft:generic.attack_damage"
+    "resource": "generic.attack_damage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "minecraft:horse.jump_strength"
+    "resource": "horse.jump_strength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "minecraft:zombie.spawn_reinforcements"
+    "resource": "zombie.spawn_reinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "attackSpeed",
-    "resource": "minecraft:generic.attack_speed"
+    "resource": "generic.attack_speed",
+    "default": 4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "flyingSpeed",
-    "resource": "minecraft:generic.flying_speed"
+    "resource": "generic.flying_speed",
+    "default": 0.4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackKnockback",
-    "resource": "minecraft:generic.attack_knockback"
+    "resource": "generic.attack_knockback",
+    "default": 0,
+    "min": 0,
+    "max": 5
   },
   {
-    "name": "armor",
-    "resource": "minecraft:generic.armor"
+    "name": "armorHealth",
+    "resource": "generic.armor",
+    "default": 0,
+    "min": 0,
+    "max": 30
   },
   {
     "name": "armorToughness",
-    "resource": "minecraft:generic.armor_toughness"
+    "resource": "generic.armor_toughness",
+    "default": 0,
+    "min": 0,
+    "max": 20
   },
   {
     "name": "luck",
-    "resource": "minecraft:generic.luck"
+    "resource": "generic.luck",
+    "default": 0,
+    "min": -1024,
+    "max": 1024
   }
 ]

--- a/data/pc/1.7/attributes.json
+++ b/data/pc/1.7/attributes.json
@@ -1,30 +1,51 @@
 [
   {
     "name": "maxHealth",
-    "resource": "generic.maxHealth"
+    "resource": "generic.maxHealth",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "generic.followRange"
+    "resource": "generic.followRange",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "generic.knockbackResistance"
+    "resource": "generic.knockbackResistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "generic.movementSpeed"
+    "resource": "generic.movementSpeed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "generic.attackDamage"
+    "resource": "generic.attackDamage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "horse.jumpStrength"
+    "resource": "horse.jumpStrength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "zombie.spawnReinforcements"
+    "resource": "zombie.spawnReinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   }
 ]

--- a/data/pc/1.8/attributes.json
+++ b/data/pc/1.8/attributes.json
@@ -1,50 +1,86 @@
 [
   {
     "name": "maxHealth",
-    "resource": "generic.maxHealth"
+    "resource": "generic.maxHealth",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "generic.followRange"
+    "resource": "generic.followRange",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "generic.knockbackResistance"
+    "resource": "generic.knockbackResistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "generic.movementSpeed"
+    "resource": "generic.movementSpeed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "generic.attackDamage"
+    "resource": "generic.attackDamage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "horse.jumpStrength"
+    "resource": "horse.jumpStrength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "zombie.spawnReinforcements"
+    "resource": "zombie.spawnReinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "attackSpeed",
-    "resource": "generic.attackSpeed"
+    "resource": "generic.attackSpeed",
+    "default": 4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "flyingSpeed",
-    "resource": "generic.flyingSpeed"
+    "resource": "generic.flyingSpeed",
+    "default": 0.4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackKnockback",
-    "resource": "generic.attackKnockback"
+    "resource": "generic.attackKnockback",
+    "default": 0,
+    "min": 0,
+    "max": 5
   },
   {
-    "name": "armor",
-    "resource": "generic.armor"
+    "name": "armorHealth",
+    "resource": "generic.armor",
+    "default": 0,
+    "min": 0,
+    "max": 30
   },
   {
     "name": "armorToughness",
-    "resource": "generic.armorToughness"
+    "resource": "generic.armorToughness",
+    "default": 0,
+    "min": 0,
+    "max": 20
   }
 ]

--- a/data/pc/1.9/attributes.json
+++ b/data/pc/1.9/attributes.json
@@ -1,54 +1,93 @@
 [
   {
     "name": "maxHealth",
-    "resource": "generic.maxHealth"
+    "resource": "generic.maxHealth",
+    "default": 20,
+    "min": 1,
+    "max": 1024
   },
   {
     "name": "followRange",
-    "resource": "generic.followRange"
+    "resource": "generic.followRange",
+    "default": 32,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "knockbackResistance",
-    "resource": "generic.knockbackResistance"
+    "resource": "generic.knockbackResistance",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "movementSpeed",
-    "resource": "generic.movementSpeed"
+    "resource": "generic.movementSpeed",
+    "default": 0.7,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackDamage",
-    "resource": "generic.attackDamage"
+    "resource": "generic.attackDamage",
+    "default": 2,
+    "min": 0,
+    "max": 2048
   },
   {
     "name": "horseJumpStrength",
-    "resource": "horse.jumpStrength"
+    "resource": "horse.jumpStrength",
+    "default": 0.7,
+    "min": 0,
+    "max": 2
   },
   {
     "name": "zombieSpawnReinforcements",
-    "resource": "zombie.spawnReinforcements"
+    "resource": "zombie.spawnReinforcements",
+    "default": 0,
+    "min": 0,
+    "max": 1
   },
   {
     "name": "attackSpeed",
-    "resource": "generic.attackSpeed"
+    "resource": "generic.attackSpeed",
+    "default": 4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "flyingSpeed",
-    "resource": "generic.flyingSpeed"
+    "resource": "generic.flyingSpeed",
+    "default": 0.4,
+    "min": 0,
+    "max": 1024
   },
   {
     "name": "attackKnockback",
-    "resource": "generic.attackKnockback"
+    "resource": "generic.attackKnockback",
+    "default": 0,
+    "min": 0,
+    "max": 5
   },
   {
-    "name": "armor",
-    "resource": "generic.armor"
+    "name": "armorHealth",
+    "resource": "generic.armor",
+    "default": 0,
+    "min": 0,
+    "max": 30
   },
   {
     "name": "armorToughness",
-    "resource": "generic.armorToughness"
+    "resource": "generic.armorToughness",
+    "default": 0,
+    "min": 0,
+    "max": 20
   },
   {
     "name": "luck",
-    "resource": "generic.luck"
+    "resource": "generic.luck",
+    "default": 0,
+    "min": -1024,
+    "max": 1024
   }
 ]

--- a/schemas/attributes_schema.json
+++ b/schemas/attributes_schema.json
@@ -14,9 +14,21 @@
         "description": "The name of an attribute",
         "type": "string",
         "pattern": "\\S+"
+      },
+      "min": {
+        "description": "The minimum value of an attribute",
+        "type": "number"
+      },
+      "max": {
+        "description": "The maximum value of an attribute",
+        "type": "number"
+      },
+      "default": {
+        "description": "The default value of an attribute",
+        "type": "number"
       }
     },
-    "required": ["resource", "name"],
+    "required": ["resource", "name", "min", "max", "default"],
     "additionalProperties":false
   }
 }


### PR DESCRIPTION
* adds `min`, `max` and `default` values to attributes, from [source code](https://github.dev/extremeheat/extracted_minecraft_data/blob/client1.19.3/client/net/minecraft/world/entity/ai/attributes/Attributes.java#L8)
* remove `minecraft:` prefix in 1.16/1.17 pc "resource" names to match vanilla and the other versions' data
* add bedrock data for attributes
* rename `armor` -> `armorHealth` in pc's name for clarity
