### PR TITLE
Add helper bot to update protocol versions

### DIFF
--- a/.github/helper-bot/github-helper.js
+++ b/.github/helper-bot/github-helper.js
@@ -1,0 +1,59 @@
+if (!process.env.CI) {
+  // mock a bunch of things for testing locally -- https://github.com/actions/toolkit/issues/71
+  process.env.GITHUB_REPOSITORY = 'PrismarineJS/minecraft-data'
+  process.env.GITHUB_EVENT_NAME = 'issue_comment'
+  process.env.GITHUB_SHA = 'cb2fd97b6eae9f2c7fee79d5a86eb9c3b4ac80d8'
+  process.env.GITHUB_REF = 'refs/heads/master'
+  process.env.GITHUB_WORKFLOW = 'Issue comments'
+  process.env.GITHUB_ACTION = 'run1'
+  process.env.GITHUB_ACTOR = 'test-user'
+  module.exports = { getIssueStatus: () => ({}), updateIssue: () => {}, createIssue: () => {} }
+  return
+}
+
+// const { Octokit } = require('@octokit/rest') // https://github.com/octokit/rest.js
+const github = require('@actions/github')
+
+const token = process.env.GITHUB_TOKEN
+const octokit = github.getOctokit(token)
+const context = github.context
+
+async function getIssueStatus (title) {
+  // https://docs.github.com/en/rest/reference/search#search-issues-and-pull-requests
+  const existingIssues = await octokit.rest.search.issuesAndPullRequests({
+    q: `is:issue repo:${process.env.GITHUB_REPOSITORY} in:title ${title}`
+  })
+  // console.log('Existing issues', existingIssues)
+  const existingIssue = existingIssues.data.items.find(issue => issue.title === title)
+
+  if (!existingIssue) return {}
+
+  return { open: existingIssue.state === 'open', closed: existingIssue.state === 'closed', id: existingIssue.number }
+}
+
+async function updateIssue (id, payload) {
+  const issue = await octokit.rest.issues.update({
+    ...context.repo,
+    issue_number: id,
+    body: payload.body
+  })
+  console.log(`Updated issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
+}
+
+async function createIssue (payload) {
+  const issue = await octokit.rest.issues.create({
+    ...context.repo,
+    ...payload
+  })
+  console.log(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
+}
+
+async function close (id, reason) {
+  if (reason) await octokit.rest.issues.createComment({ ...context.repo, issue_number: id, body: reason })
+  const issue = await octokit.rest.issues.update({ ...context.repo, issue_number: id, state: 'closed' })
+  console.log(`Closed issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
+}
+
+if (process.env.CI) {
+  module.exports = { getIssueStatus, updateIssue, createIssue, close }
+}

--- a/.github/helper-bot/index.js
+++ b/.github/helper-bot/index.js
@@ -104,6 +104,8 @@ async function updateManifestPC() {
     // Log the byte size of the client jar
     const clientJarSize = fs.statSync(`./${latestRelease}.jar`).size
     console.log(`Downloaded client jar ${latestRelease}.jar (${clientJarSize} bytes)`)
+    if (process.platform === 'linux') cp.execSync('ls -lh', { stdio: 'inherit' })
+    else if (process.platform === 'win32') cp.execSync('dir', { stdio: 'inherit' })
     console.log(`Unzipping client jar ./${latestRelease}.jar's version.json data`)
     // unzip with tar / unzip
     if (process.platform === 'win32') cp.execSync(`tar -xf ./${latestRelease}.jar version.json`)

--- a/.github/helper-bot/index.js
+++ b/.github/helper-bot/index.js
@@ -108,7 +108,7 @@ async function updateManifestPC() {
     else if (process.platform === 'win32') cp.execSync('dir', { stdio: 'inherit' })
     console.log(`Unzipping client jar ./${latestRelease}.jar's version.json data`)
     // unzip with tar / unzip, Actions image uses 7z
-    if (process.env.CI) cp.execSync(`chmod +777 ./${latestRelease}.jar && 7z -y e ./${latestRelease}.jar version.json`)
+    if (process.env.CI) cp.execSync(`sha1sum 1.19.4.jar && chmod +777 ./${latestRelease}.jar && 7z -y e ./${latestRelease}.jar version.json`, { stdio: 'inherit' })
     else cp.execSync(`tar -xf ./${latestRelease}.jar version.json`)
     const versionJson = require('./version.json')
 

--- a/.github/helper-bot/index.js
+++ b/.github/helper-bot/index.js
@@ -108,7 +108,7 @@ async function updateManifestPC() {
     else if (process.platform === 'win32') cp.execSync('dir', { stdio: 'inherit' })
     console.log(`Unzipping client jar ./${latestRelease}.jar's version.json data`)
     // unzip with tar / unzip, Actions image uses 7z
-    if (process.env.CI) cp.execSync(`7z -y e ./${latestRelease}.jar version.json`)
+    if (process.env.CI) cp.execSync(`chmod +777 ./${latestRelease}.jar && 7z -y e ./${latestRelease}.jar version.json`)
     else cp.execSync(`tar -xf ./${latestRelease}.jar version.json`)
     const versionJson = require('./version.json')
 
@@ -141,13 +141,15 @@ async function updateManifestPC() {
       cp.execSync(`git commit -m "Add ${versionJson.id} to pc protocolVersions.json"`)
     }
 
-    console.log('Opening issue', versionJson)
-    const issuePayload = buildFirstIssue(title, latestReleaseData, versionJson)
-
-    helper.createIssue(issuePayload)
-
-    fs.writeFileSync('./issue.md', issuePayload.body)
-    console.log('OK, wrote to ./issue.md', issuePayload)
+    if (!issueStatus.open && !issueStatus.closed) {
+      console.log('Opening issue', versionJson)
+      const issuePayload = buildFirstIssue(title, latestReleaseData, versionJson)
+  
+      helper.createIssue(issuePayload)
+  
+      fs.writeFileSync('./issue.md', issuePayload.body)
+      console.log('OK, wrote to ./issue.md', issuePayload)
+    }
   } catch (e) {
     console.error(e)
 

--- a/.github/helper-bot/index.js
+++ b/.github/helper-bot/index.js
@@ -107,9 +107,9 @@ async function updateManifestPC() {
     if (process.platform === 'linux') cp.execSync('ls -lh', { stdio: 'inherit' })
     else if (process.platform === 'win32') cp.execSync('dir', { stdio: 'inherit' })
     console.log(`Unzipping client jar ./${latestRelease}.jar's version.json data`)
-    // unzip with tar / unzip
-    if (process.platform === 'win32') cp.execSync(`tar -xf ./${latestRelease}.jar version.json`)
-    else cp.execSync(`unzip -o ./${latestRelease}.jar version.json`)
+    // unzip with tar / unzip, Actions image uses 7z
+    if (process.env.CI) cp.execSync(`7z -y e ./${latestRelease}.jar version.json`)
+    else cp.execSync(`tar -xf ./${latestRelease}.jar version.json`)
     const versionJson = require('./version.json')
 
     let majorVersion

--- a/.github/helper-bot/index.js
+++ b/.github/helper-bot/index.js
@@ -1,0 +1,157 @@
+const fs = require('fs')
+const cp = require('child_process')
+const https = require('https')
+const helper = require('./github-helper')
+const pcManifestURL = 'https://launchermeta.mojang.com/mc/game/version_manifest.json'
+const changelogURL = 'https://feedback.minecraft.net/hc/en-us/sections/360001186971-Release-Changelogs'
+
+function fetch(url, filePathIfOnDisk) {
+  return new Promise((resolve, reject) => {
+    https.get(url, (res) => {
+      let data = filePathIfOnDisk ? fs.createWriteStream(filePathIfOnDisk) : ''
+      const expectedContentLength = res.headers['content-length']
+      let readSoFar = 0
+      res.on('data', (chunk) => {
+        if (filePathIfOnDisk) {
+          data.write(chunk)
+          readSoFar += chunk.length
+          if (readSoFar === chunk.length) console.log(`Downloaded ${readSoFar} of ${expectedContentLength} bytes for ${filePathIfOnDisk}`)
+        }
+        else data += chunk
+      })
+      res.on('end', () => {
+        if (filePathIfOnDisk) resolve(data.end())
+        else resolve({
+          ok: true,
+          text: () => Promise.resolve(data),
+          json: () => Promise.resolve(JSON.parse(data))
+        })
+      })
+    }).on('error', reject)
+  })
+}
+
+function buildFirstIssue (title, result, jarData) {
+  let protocolVersion = jarData?.protocol_version || 'Failed to obtain from JAR'
+  const name = jarData?.name || result.id
+  const date = result.releaseTime
+
+  return {
+    title,
+    body: `
+A new Minecraft Java Edition version is available (as of ${date}), version **${result.id}**
+## Official Changelog
+* ${changelogURL}
+## Protocol Details
+(I will close this issue automatically if "${result.id}" is added to data/pc/common/versions.json on "master")
+<table>
+  <tr><td><b>Name</b></td><td>${name}</td>
+  <tr><td><b>Protocol ID</b></td><td>${protocolVersion}</td>
+  <tr><td><b>Release Date</b></td><td>${date}</td>
+  <tr><td><b>Release Type</b></td><td>${result.type}</td>
+  <tr><td><b>Data Version</b></td><td>${jarData?.world_version}</td>
+  <tr><td><b>Java Version</b></td><td>${jarData?.java_version}</td>
+</table>
+<hr/>
+🤖 I am a bot, I check for updates every 2 hours without a trigger. You can close this issue to prevent any further updates.
+    `
+  }
+}
+
+const protocolVersions = {
+  pc: require('../../data/pc/common/protocolVersions.json'),
+  bedrock: require('../../data/bedrock/common/protocolVersions.json')
+}
+const supportedVersions = {
+  pc: require('../../data/pc/common/versions.json'),
+  bedrock: require('../../data/bedrock/common/versions.json')
+}
+
+async function updateManifestPC() {
+  const manifest = await fetch(pcManifestURL).then(res => res.json())
+  // fs.writeFileSync('./manifest.json', JSON.stringify(manifest, null, 2))
+  const knownVersions = protocolVersions.pc.reduce((acc, cur) => (acc[cur.minecraftVersion] = cur, acc), {})
+  const latestRelease = manifest.latest.release
+
+  const title = `Support Minecraft PC ${latestRelease}`
+  const issueStatus = await helper.getIssueStatus(title)
+
+  if (supportedVersions.pc.includes(latestRelease)) {
+    if (issueStatus.open) {
+      helper.close(issueStatus.id, `Closing as PC ${latestRelease} is now supported`)
+    }
+    console.log('Latest PC version is supported.')
+    return
+  } else if (knownVersions[latestRelease]) {
+    console.log(`Latest PC version ${latestRelease} is known in protocolVersions.json, but not in versions.json (protocol version ${knownVersions[latestRelease].version})`)
+    return
+  } else {
+    console.log(`Latest PC version ${latestRelease} is not known in protocolVersions.json, adding and making issue`)
+  }
+  const latestReleaseData = manifest.versions.find(v => v.id === latestRelease)
+
+  // Note: We don't use the below check to track if the version is supported properly or not
+  // (data like protocol/blocks/items/etc is present), just to make sure the known protocol version is correct.
+  try {
+    const latestReleaseManifest = await fetch(latestReleaseData.url).then(res => res.json())
+    // fs.writeFileSync(`./${latestRelease}.json`, JSON.stringify(latestReleaseManifest, null, 2))
+    // Download client jar
+    if (!fs.existsSync(`./${latestRelease}.jar`)) {
+      const clientJarUrl = latestReleaseManifest.downloads.client.url
+      console.log('Downloading client jar', clientJarUrl)
+      await fetch(clientJarUrl, `./${latestRelease}.jar`)
+    }
+    console.log(`Unzipping client jar ./${latestRelease}.jar's version.json data`)
+    // unzip with tar (works on windows too)
+    cp.execSync(`tar -xf ${latestRelease}.jar version.json`)
+    const versionJson = require('./version.json')
+
+    let majorVersion
+    try {
+      majorVersion = versionJson.id.split('.', 2).join('.')
+    } catch (e) {
+      console.error('Failed to get major version from version.json.id', versionJson.id, ', falling back to protocolVersions.json latest (may be incorrect)')
+      majorVersion = protocolVersions.pc[0].majorVersion
+    }
+
+    const newEntry = {
+      minecraftVersion: versionJson.id,
+      version: versionJson.protocol_version,
+      dataVersion: versionJson.world_version,
+      usesNetty: true,
+      majorVersion,
+      releaseType: latestReleaseData.type
+    }
+    console.log('Adding new entry to pc protocolVersions.json', newEntry)
+    const updatedProtocolVersions = [newEntry, ...protocolVersions.pc]
+    fs.writeFileSync('../../data/pc/common/protocolVersions.json', JSON.stringify(updatedProtocolVersions, null, 2))
+
+    if (process.env.CI) {
+      console.log('Committing changes to protocolVersions.json')
+      // https://github.com/actions/checkout/pull/1184
+      cp.execSync('git config user.name "github-actions[bot]"')
+      cp.execSync('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"')
+      cp.execSync('git add ../../data/pc/common/protocolVersions.json')
+      cp.execSync(`git commit -m "Add ${versionJson.id} to pc protocolVersions.json"`)
+    }
+
+    console.log('Opening issue', versionJson)
+    const issuePayload = buildFirstIssue(title, latestReleaseData, versionJson)
+
+    helper.createIssue(issuePayload)
+
+    fs.writeFileSync('./issue.md', issuePayload.body)
+    console.log('OK, wrote to ./issue.md', issuePayload)
+  } catch (e) {
+    console.error(e)
+
+    console.log('Latest PC version is not supported and we failed to load data. Opening issue...')
+    const issuePayload = buildFirstIssue(title, latestReleaseData)
+    helper.createIssue(issuePayload)
+
+    fs.writeFileSync('./issue.md', issuePayload.body)
+    console.log('OK, wrote to ./issue.md', issuePayload)
+  }
+}
+
+updateManifestPC()

--- a/.github/helper-bot/index.js
+++ b/.github/helper-bot/index.js
@@ -102,8 +102,9 @@ async function updateManifestPC() {
       await fetch(clientJarUrl, `./${latestRelease}.jar`)
     }
     console.log(`Unzipping client jar ./${latestRelease}.jar's version.json data`)
-    // unzip with tar (works on windows too)
-    cp.execSync(`tar -xf ${latestRelease}.jar version.json`)
+    // unzip with tar / unzip
+    if (process.platform === 'win32') cp.execSync(`tar -xf ./${latestRelease}.jar version.json`)
+    else cp.execSync(`unzip -o ./${latestRelease}.jar version.json`)
     const versionJson = require('./version.json')
 
     let majorVersion

--- a/.github/helper-bot/index.js
+++ b/.github/helper-bot/index.js
@@ -101,6 +101,9 @@ async function updateManifestPC() {
       console.log('Downloading client jar', clientJarUrl)
       await fetch(clientJarUrl, `./${latestRelease}.jar`)
     }
+    // Log the byte size of the client jar
+    const clientJarSize = fs.statSync(`./${latestRelease}.jar`).size
+    console.log(`Downloaded client jar ${latestRelease}.jar (${clientJarSize} bytes)`)
     console.log(`Unzipping client jar ./${latestRelease}.jar's version.json data`)
     // unzip with tar / unzip
     if (process.platform === 'win32') cp.execSync(`tar -xf ./${latestRelease}.jar version.json`)

--- a/.github/helper-bot/index.js
+++ b/.github/helper-bot/index.js
@@ -5,7 +5,8 @@ const helper = require('./github-helper')
 const pcManifestURL = 'https://launchermeta.mojang.com/mc/game/version_manifest.json'
 const changelogURL = 'https://feedback.minecraft.net/hc/en-us/sections/360001186971-Release-Changelogs'
 
-function fetch (url) {
+// this is a polyfill for node <18
+const fetch = globalThis.fetch || function (url) {
   return new Promise((resolve, reject) => {
     https.get(url, (res) => {
       let data = ''

--- a/.github/workflows/update-helper.yml
+++ b/.github/workflows/update-helper.yml
@@ -1,0 +1,24 @@
+name: Update Helper
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */2 * * *"
+
+jobs:
+  helper:
+    name: update-checker
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@master
+    - name: Set up Node.js
+      uses: actions/setup-node@master
+      with:
+        node-version: 16.0.0
+    - name: Install Github Actions toolkit
+      run: npm i -g @actions/github
+    # The env vars contain the relevant trigger information, so we don't need to pass it
+    - name: Runs helper
+      run: cd .github/helper-bot && node index.js
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-helper.yml
+++ b/.github/workflows/update-helper.yml
@@ -16,7 +16,8 @@ jobs:
       with:
         node-version: 16.0.0
     - name: Install Github Actions toolkit
-      run: npm i -g @actions/github
+      run: npm i @actions/github
+      working-directory: .github/helper-bot
     # The env vars contain the relevant trigger information, so we don't need to pass it
     - name: Runs helper
       run: cd .github/helper-bot && node index.js

--- a/tools/js/package.json
+++ b/tools/js/package.json
@@ -6,6 +6,7 @@
     "test": "mocha --reporter spec",
     "lint": "standard",
     "fix": "standard --fix",
+    "fixActions": "standard --fix ../../.github/helper-bot",
     "pretest": "npm run lint",
     "build": "node ./compileProtocol.js",
     "version": "node ./incrementVersion.js"


### PR DESCRIPTION
Mostly mirrors bedrock-protocol's [helper-bot](https://github.com/PrismarineJS/bedrock-protocol/tree/master/.github/helper-bot) and adds a CRON action to add new pc updates to protocolVersions.json and open an issue

Commit action looks like https://github.com/extremeheat/minecraft-data/commit/d00fc09b0b4527ede022a85893c7bb1802eb924d
And issue looks like https://github.com/extremeheat/minecraft-data/issues/14