### PR TITLE
pc: add entity metadata

### DIFF
--- a/data/pc/1.19.4/entities.json
+++ b/data/pc/1.19.4/entities.json
@@ -11,6 +11,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -22,6 +23,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "dancing",
       "can_duplicate"
@@ -39,6 +41,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -62,6 +65,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -73,6 +77,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "client_flags",
       "head_pose",
       "body_pose",
@@ -94,6 +99,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -116,6 +122,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -127,6 +134,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "variant",
@@ -146,6 +154,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -157,6 +166,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "flags"
     ]
@@ -173,6 +183,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -184,6 +195,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
@@ -202,6 +214,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -213,6 +226,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "flags"
     ]
@@ -229,11 +243,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
       "ticks_frozen",
+      "interpolation_start_delta_ticks",
       "interpolation_duration",
       "translation",
       "scale",
@@ -246,7 +262,8 @@
       "shadow_strength",
       "width",
       "height",
-      "glow_color_override"
+      "glow_color_override",
+      "block_state"
     ]
   },
   {
@@ -261,6 +278,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -287,6 +305,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -298,6 +317,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
@@ -317,6 +337,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -328,9 +349,11 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
+      "owneruuid",
       "variant",
       "is_lying",
       "relax_state_one",
@@ -349,6 +372,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -360,6 +384,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "flags"
     ]
@@ -376,6 +401,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -402,6 +428,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -427,6 +454,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -438,6 +466,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby"
     ]
@@ -454,6 +483,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -465,6 +495,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "from_bucket"
     ]
@@ -481,6 +512,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -508,6 +540,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -519,6 +552,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby"
     ]
@@ -535,6 +569,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -546,6 +581,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "swell_dir",
       "is_powered",
@@ -564,6 +600,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -575,6 +612,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "treasure_pos",
       "got_fish",
@@ -593,6 +631,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -604,6 +643,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
@@ -622,6 +662,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -641,6 +682,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -652,6 +694,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "special_type",
@@ -670,11 +713,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
-      "ticks_frozen"
+      "ticks_frozen",
+      "item_stack"
     ]
   },
   {
@@ -689,6 +734,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -700,6 +746,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "moving",
       "attack_target"
@@ -717,11 +764,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
       "ticks_frozen",
+      "beam_target",
       "show_bottom"
     ]
   },
@@ -737,6 +786,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -748,6 +798,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "phase"
     ]
@@ -764,11 +815,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
-      "ticks_frozen"
+      "ticks_frozen",
+      "item_stack"
     ]
   },
   {
@@ -783,6 +836,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -794,7 +848,9 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
+      "carry_state",
       "creepy",
       "stared_at"
     ]
@@ -811,6 +867,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -822,6 +879,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags"
     ]
   },
@@ -837,6 +895,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -848,6 +907,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "is_celebrating",
       "spell_casting"
@@ -865,6 +925,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -884,11 +945,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
-      "ticks_frozen"
+      "ticks_frozen",
+      "item_stack"
     ]
   },
   {
@@ -903,6 +966,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -922,6 +986,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -942,6 +1007,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -962,11 +1028,14 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
       "ticks_frozen",
+      "fireworks_item",
+      "attached_to_target",
       "shot_at_angle"
     ]
   },
@@ -982,6 +1051,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -993,6 +1063,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "type",
@@ -1013,6 +1084,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1024,9 +1096,11 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
-      "variant"
+      "variant",
+      "tongue_target"
     ]
   },
   {
@@ -1041,6 +1115,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1067,6 +1142,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1078,6 +1154,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "is_charging"
     ]
@@ -1094,6 +1171,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1105,6 +1183,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags"
     ]
   },
@@ -1120,6 +1199,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1141,6 +1221,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1152,6 +1233,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "dark_ticks_remaining"
     ]
@@ -1168,6 +1250,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1179,6 +1262,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "is_screaming_goat",
@@ -1198,6 +1282,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1209,6 +1294,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "moving",
       "attack_target"
@@ -1226,6 +1312,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1237,6 +1324,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "immune_to_zombification"
@@ -1254,6 +1342,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1279,6 +1368,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1290,6 +1380,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
@@ -1308,6 +1399,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1319,6 +1411,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "special_type",
@@ -1337,6 +1430,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1348,6 +1442,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "is_celebrating",
       "spell_casting"
@@ -1365,6 +1460,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1387,6 +1483,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1398,6 +1495,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "flags"
     ]
@@ -1414,6 +1512,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1434,11 +1533,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
       "ticks_frozen",
+      "interpolation_start_delta_ticks",
       "interpolation_duration",
       "translation",
       "scale",
@@ -1452,6 +1553,7 @@
       "width",
       "height",
       "glow_color_override",
+      "item_stack",
       "item_display"
     ]
   },
@@ -1467,6 +1569,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1488,6 +1591,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1508,6 +1612,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1527,6 +1632,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1546,6 +1652,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1557,6 +1664,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
@@ -1578,6 +1686,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1597,6 +1706,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1608,6 +1718,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "size"
     ]
@@ -1624,6 +1735,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1643,6 +1755,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1668,6 +1781,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1679,6 +1793,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "type"
@@ -1696,6 +1811,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1707,6 +1823,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
@@ -1725,6 +1842,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1736,6 +1854,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "trusting"
@@ -1753,11 +1872,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
-      "ticks_frozen"
+      "ticks_frozen",
+      "painting_variant"
     ]
   },
   {
@@ -1772,6 +1893,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1783,6 +1905,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "unhappy_counter",
@@ -1805,6 +1928,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1816,9 +1940,11 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
+      "owneruuid",
       "variant"
     ]
   },
@@ -1834,6 +1960,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1845,6 +1972,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "size"
     ]
@@ -1861,6 +1989,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1872,6 +2001,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "saddle",
@@ -1890,6 +2020,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1901,7 +2032,9 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
+      "immune_to_zombification",
       "baby",
       "is_charging_crossbow",
       "is_dancing"
@@ -1919,6 +2052,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1930,7 +2064,9 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
-      "mob_flags"
+      "sleeping_pos",
+      "mob_flags",
+      "immune_to_zombification"
     ]
   },
   {
@@ -1945,6 +2081,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1956,6 +2093,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "is_celebrating",
       "is_charging_crossbow"
@@ -1973,6 +2111,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -1984,6 +2123,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "standing"
@@ -2001,11 +2141,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
-      "ticks_frozen"
+      "ticks_frozen",
+      "item_stack"
     ]
   },
   {
@@ -2020,6 +2162,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2031,6 +2174,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "from_bucket",
       "puff_state"
@@ -2048,6 +2192,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2059,6 +2204,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "type"
@@ -2076,6 +2222,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2087,6 +2234,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "is_celebrating"
     ]
@@ -2103,6 +2251,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2114,6 +2263,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "from_bucket"
     ]
@@ -2130,6 +2280,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2141,6 +2292,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "wool"
@@ -2158,6 +2310,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2169,6 +2322,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "attach_face",
       "peek",
@@ -2187,6 +2341,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2206,6 +2361,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2217,6 +2373,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags"
     ]
   },
@@ -2232,6 +2389,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2243,6 +2401,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "stray_conversion"
     ]
@@ -2259,6 +2418,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2270,6 +2430,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags"
@@ -2287,6 +2448,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2298,6 +2460,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "size"
     ]
@@ -2314,6 +2477,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2334,6 +2498,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2345,6 +2510,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "state",
@@ -2363,6 +2529,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2374,6 +2541,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "pumpkin"
     ]
@@ -2390,11 +2558,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
-      "ticks_frozen"
+      "ticks_frozen",
+      "item_stack"
     ]
   },
   {
@@ -2409,6 +2579,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2434,6 +2605,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2455,6 +2627,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2466,6 +2639,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "flags"
     ]
@@ -2482,6 +2656,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2493,6 +2668,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags"
     ]
   },
@@ -2508,6 +2684,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2519,6 +2696,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags"
     ]
   },
@@ -2534,6 +2712,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2545,6 +2724,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "boost_time",
@@ -2564,6 +2744,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2575,6 +2756,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "from_bucket"
     ]
@@ -2591,11 +2773,13 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
       "pose",
       "ticks_frozen",
+      "interpolation_start_delta_ticks",
       "interpolation_duration",
       "translation",
       "scale",
@@ -2611,6 +2795,7 @@
       "glow_color_override",
       "text",
       "line_width",
+      "background_color",
       "text_opacity",
       "style_flags"
     ]
@@ -2627,6 +2812,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2647,6 +2833,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2672,6 +2859,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2683,6 +2871,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
@@ -2704,6 +2893,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2727,6 +2917,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2738,6 +2929,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "from_bucket",
       "type_variant"
@@ -2755,6 +2947,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2766,6 +2959,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "home_pos",
@@ -2788,6 +2982,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2799,6 +2994,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "flags"
     ]
@@ -2815,6 +3011,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2826,6 +3023,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "unhappy_counter",
@@ -2844,6 +3042,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2855,6 +3054,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "is_celebrating"
     ]
@@ -2871,6 +3071,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2882,6 +3083,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "unhappy_counter"
@@ -2899,6 +3101,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2910,6 +3113,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "client_anger_level"
     ]
@@ -2926,6 +3130,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2937,6 +3142,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "is_celebrating",
       "using_item"
@@ -2954,6 +3160,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2965,6 +3172,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "target_a",
       "target_b",
@@ -2984,6 +3192,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -2995,6 +3204,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags"
     ]
   },
@@ -3010,6 +3220,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -3030,6 +3241,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -3041,9 +3253,11 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags",
+      "owneruuid",
       "interested",
       "collar_color",
       "remaining_anger_time"
@@ -3061,6 +3275,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -3072,6 +3287,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby"
     ]
@@ -3088,6 +3304,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -3099,6 +3316,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "special_type",
@@ -3117,6 +3335,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -3128,6 +3347,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "flags"
@@ -3145,6 +3365,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -3156,11 +3377,13 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "special_type",
       "drowned_conversion",
-      "converting"
+      "converting",
+      "villager_data"
     ]
   },
   {
@@ -3175,6 +3398,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -3186,6 +3410,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "mob_flags",
       "baby",
       "special_type",
@@ -3204,6 +3429,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",
@@ -3215,6 +3441,7 @@
       "effect_ambience",
       "arrow_count",
       "stinger_count",
+      "sleeping_pos",
       "player_absorption",
       "score",
       "player_mode_customisation",
@@ -3235,6 +3462,7 @@
     "metadataKeys": [
       "shared_flags",
       "air_supply",
+      "custom_name",
       "custom_name_visible",
       "silent",
       "no_gravity",

--- a/data/pc/1.19.4/entities.json
+++ b/data/pc/1.19.4/entities.json
@@ -7,17 +7,48 @@
     "width": 0.35,
     "height": 0.6,
     "type": "mob",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "dancing",
+      "can_duplicate"
+    ]
   },
   {
     "id": 1,
     "internalId": 1,
     "name": "area_effect_cloud",
     "displayName": "Area Effect Cloud",
-    "width": 6.0,
+    "width": 6,
     "height": 0.5,
     "type": "other",
-    "category": "UNKNOWN"
+    "category": "UNKNOWN",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "radius",
+      "color",
+      "waiting",
+      "particle"
+    ]
   },
   {
     "id": 2,
@@ -27,7 +58,29 @@
     "width": 0.5,
     "height": 1.975,
     "type": "living",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "client_flags",
+      "head_pose",
+      "body_pose",
+      "left_arm_pose",
+      "right_arm_pose",
+      "left_leg_pose",
+      "right_leg_pose"
+    ]
   },
   {
     "id": 3,
@@ -37,7 +90,19 @@
     "width": 0.5,
     "height": 0.5,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "flags",
+      "pierce_level",
+      "effect_color"
+    ]
   },
   {
     "id": 4,
@@ -47,7 +112,27 @@
     "width": 0.75,
     "height": 0.42,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "variant",
+      "playing_dead",
+      "from_bucket"
+    ]
   },
   {
     "id": 5,
@@ -57,7 +142,24 @@
     "width": 0.5,
     "height": 0.9,
     "type": "ambient",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "flags"
+    ]
   },
   {
     "id": 6,
@@ -67,7 +169,26 @@
     "width": 0.7,
     "height": 0.6,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "remaining_anger_time"
+    ]
   },
   {
     "id": 7,
@@ -77,17 +198,56 @@
     "width": 0.6,
     "height": 1.8,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "flags"
+    ]
   },
   {
     "id": 8,
     "internalId": 8,
     "name": "block_display",
     "displayName": "Block Display",
-    "width": 0.0,
-    "height": 0.0,
+    "width": 0,
+    "height": 0,
     "type": "other",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "interpolation_duration",
+      "translation",
+      "scale",
+      "left_rotation",
+      "right_rotation",
+      "billboard_render_constraints",
+      "brightness_override",
+      "view_range",
+      "shadow_radius",
+      "shadow_strength",
+      "width",
+      "height",
+      "glow_color_override"
+    ]
   },
   {
     "id": 9,
@@ -97,7 +257,23 @@
     "width": 1.375,
     "height": 0.5625,
     "type": "other",
-    "category": "Vehicles"
+    "category": "Vehicles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hurt",
+      "hurtdir",
+      "damage",
+      "type",
+      "paddle_left",
+      "paddle_right",
+      "bubble_time"
+    ]
   },
   {
     "id": 10,
@@ -107,7 +283,27 @@
     "width": 1.7,
     "height": 2.375,
     "type": "player",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "dash",
+      "last_pose_change_tick"
+    ]
   },
   {
     "id": 11,
@@ -117,7 +313,29 @@
     "width": 0.6,
     "height": 0.7,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "variant",
+      "is_lying",
+      "relax_state_one",
+      "collar_color"
+    ]
   },
   {
     "id": 12,
@@ -127,7 +345,24 @@
     "width": 0.7,
     "height": 0.5,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "flags"
+    ]
   },
   {
     "id": 13,
@@ -137,7 +372,23 @@
     "width": 1.375,
     "height": 0.5625,
     "type": "other",
-    "category": "Vehicles"
+    "category": "Vehicles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hurt",
+      "hurtdir",
+      "damage",
+      "type",
+      "paddle_left",
+      "paddle_right",
+      "bubble_time"
+    ]
   },
   {
     "id": 14,
@@ -147,7 +398,22 @@
     "width": 0.98,
     "height": 0.7,
     "type": "other",
-    "category": "Vehicles"
+    "category": "Vehicles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hurt",
+      "hurtdir",
+      "damage",
+      "display_block",
+      "display_offset",
+      "custom_display"
+    ]
   },
   {
     "id": 15,
@@ -157,7 +423,24 @@
     "width": 0.4,
     "height": 0.7,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby"
+    ]
   },
   {
     "id": 16,
@@ -167,7 +450,24 @@
     "width": 0.5,
     "height": 0.3,
     "type": "water_creature",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "from_bucket"
+    ]
   },
   {
     "id": 17,
@@ -177,7 +477,24 @@
     "width": 0.98,
     "height": 0.7,
     "type": "other",
-    "category": "Vehicles"
+    "category": "Vehicles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hurt",
+      "hurtdir",
+      "damage",
+      "display_block",
+      "display_offset",
+      "custom_display",
+      "command_name",
+      "last_output"
+    ]
   },
   {
     "id": 18,
@@ -187,7 +504,24 @@
     "width": 0.9,
     "height": 1.4,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby"
+    ]
   },
   {
     "id": 19,
@@ -197,7 +531,26 @@
     "width": 0.6,
     "height": 1.7,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "swell_dir",
+      "is_powered",
+      "is_ignited"
+    ]
   },
   {
     "id": 20,
@@ -207,7 +560,26 @@
     "width": 0.9,
     "height": 0.6,
     "type": "water_creature",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "treasure_pos",
+      "got_fish",
+      "moistness_level"
+    ]
   },
   {
     "id": 21,
@@ -217,17 +589,45 @@
     "width": 1.3964844,
     "height": 1.5,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "chest"
+    ]
   },
   {
     "id": 22,
     "internalId": 22,
     "name": "dragon_fireball",
     "displayName": "Dragon Fireball",
-    "width": 1.0,
-    "height": 1.0,
+    "width": 1,
+    "height": 1,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 23,
@@ -237,7 +637,26 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "special_type",
+      "drowned_conversion"
+    ]
   },
   {
     "id": 24,
@@ -247,7 +666,16 @@
     "width": 0.25,
     "height": 0.25,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 25,
@@ -257,27 +685,72 @@
     "width": 1.9975,
     "height": 1.9975,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "moving",
+      "attack_target"
+    ]
   },
   {
     "id": 26,
     "internalId": 26,
     "name": "end_crystal",
     "displayName": "End Crystal",
-    "width": 2.0,
-    "height": 2.0,
+    "width": 2,
+    "height": 2,
     "type": "other",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "show_bottom"
+    ]
   },
   {
     "id": 27,
     "internalId": 27,
     "name": "ender_dragon",
     "displayName": "Ender Dragon",
-    "width": 16.0,
-    "height": 8.0,
+    "width": 16,
+    "height": 8,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "phase"
+    ]
   },
   {
     "id": 28,
@@ -287,7 +760,16 @@
     "width": 0.25,
     "height": 0.25,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 29,
@@ -297,7 +779,25 @@
     "width": 0.6,
     "height": 2.9,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "creepy",
+      "stared_at"
+    ]
   },
   {
     "id": 30,
@@ -307,7 +807,23 @@
     "width": 0.4,
     "height": 0.3,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags"
+    ]
   },
   {
     "id": 31,
@@ -317,7 +833,25 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "is_celebrating",
+      "spell_casting"
+    ]
   },
   {
     "id": 32,
@@ -327,7 +861,16 @@
     "width": 0.5,
     "height": 0.8,
     "type": "other",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 33,
@@ -337,7 +880,16 @@
     "width": 0.25,
     "height": 0.25,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 34,
@@ -347,7 +899,16 @@
     "width": 0.5,
     "height": 0.5,
     "type": "other",
-    "category": "UNKNOWN"
+    "category": "UNKNOWN",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 35,
@@ -357,7 +918,17 @@
     "width": 0.25,
     "height": 0.25,
     "type": "other",
-    "category": "UNKNOWN"
+    "category": "UNKNOWN",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "item_stack"
+    ]
   },
   {
     "id": 36,
@@ -367,7 +938,17 @@
     "width": 0.98,
     "height": 0.98,
     "type": "other",
-    "category": "UNKNOWN"
+    "category": "UNKNOWN",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "start_pos"
+    ]
   },
   {
     "id": 37,
@@ -377,7 +958,17 @@
     "width": 0.25,
     "height": 0.25,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "shot_at_angle"
+    ]
   },
   {
     "id": 38,
@@ -387,7 +978,28 @@
     "width": 0.6,
     "height": 0.7,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "type",
+      "flags",
+      "trusted_0",
+      "trusted_1"
+    ]
   },
   {
     "id": 39,
@@ -397,7 +1009,25 @@
     "width": 0.5,
     "height": 0.5,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "variant"
+    ]
   },
   {
     "id": 40,
@@ -407,17 +1037,50 @@
     "width": 0.98,
     "height": 0.7,
     "type": "other",
-    "category": "Vehicles"
+    "category": "Vehicles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hurt",
+      "hurtdir",
+      "damage",
+      "display_block",
+      "display_offset",
+      "custom_display",
+      "fuel"
+    ]
   },
   {
     "id": 41,
     "internalId": 41,
     "name": "ghast",
     "displayName": "Ghast",
-    "width": 4.0,
-    "height": 4.0,
+    "width": 4,
+    "height": 4,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "is_charging"
+    ]
   },
   {
     "id": 42,
@@ -425,9 +1088,25 @@
     "name": "giant",
     "displayName": "Giant",
     "width": 3.6,
-    "height": 12.0,
+    "height": 12,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags"
+    ]
   },
   {
     "id": 43,
@@ -437,7 +1116,18 @@
     "width": 0.5,
     "height": 0.5,
     "type": "other",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "item",
+      "rotation"
+    ]
   },
   {
     "id": 44,
@@ -447,7 +1137,24 @@
     "width": 0.8,
     "height": 0.8,
     "type": "water_creature",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "dark_ticks_remaining"
+    ]
   },
   {
     "id": 45,
@@ -457,7 +1164,27 @@
     "width": 0.9,
     "height": 1.3,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "is_screaming_goat",
+      "has_left_horn",
+      "has_right_horn"
+    ]
   },
   {
     "id": 46,
@@ -467,7 +1194,25 @@
     "width": 0.85,
     "height": 0.85,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "moving",
+      "attack_target"
+    ]
   },
   {
     "id": 47,
@@ -477,7 +1222,25 @@
     "width": 1.3964844,
     "height": 1.4,
     "type": "animal",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "immune_to_zombification"
+    ]
   },
   {
     "id": 48,
@@ -487,7 +1250,22 @@
     "width": 0.98,
     "height": 0.7,
     "type": "other",
-    "category": "Vehicles"
+    "category": "Vehicles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hurt",
+      "hurtdir",
+      "damage",
+      "display_block",
+      "display_offset",
+      "custom_display"
+    ]
   },
   {
     "id": 49,
@@ -497,7 +1275,26 @@
     "width": 1.3964844,
     "height": 1.6,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "type_variant"
+    ]
   },
   {
     "id": 50,
@@ -507,7 +1304,26 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "special_type",
+      "drowned_conversion"
+    ]
   },
   {
     "id": 51,
@@ -517,17 +1333,47 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "is_celebrating",
+      "spell_casting"
+    ]
   },
   {
     "id": 52,
     "internalId": 52,
     "name": "interaction",
     "displayName": "Interaction",
-    "width": 0.0,
-    "height": 0.0,
+    "width": 0,
+    "height": 0,
     "type": "other",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "width",
+      "height",
+      "response"
+    ]
   },
   {
     "id": 53,
@@ -537,7 +1383,24 @@
     "width": 1.4,
     "height": 2.7,
     "type": "mob",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "flags"
+    ]
   },
   {
     "id": 54,
@@ -547,17 +1410,50 @@
     "width": 0.25,
     "height": 0.25,
     "type": "other",
-    "category": "UNKNOWN"
+    "category": "UNKNOWN",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "item"
+    ]
   },
   {
     "id": 55,
     "internalId": 55,
     "name": "item_display",
     "displayName": "Item Display",
-    "width": 0.0,
-    "height": 0.0,
+    "width": 0,
+    "height": 0,
     "type": "other",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "interpolation_duration",
+      "translation",
+      "scale",
+      "left_rotation",
+      "right_rotation",
+      "billboard_render_constraints",
+      "brightness_override",
+      "view_range",
+      "shadow_radius",
+      "shadow_strength",
+      "width",
+      "height",
+      "glow_color_override",
+      "item_display"
+    ]
   },
   {
     "id": 56,
@@ -567,17 +1463,38 @@
     "width": 0.5,
     "height": 0.5,
     "type": "other",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "item",
+      "rotation"
+    ]
   },
   {
     "id": 57,
     "internalId": 57,
     "name": "fireball",
     "displayName": "Fireball",
-    "width": 1.0,
-    "height": 1.0,
+    "width": 1,
+    "height": 1,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "item_stack"
+    ]
   },
   {
     "id": 58,
@@ -587,17 +1504,35 @@
     "width": 0.375,
     "height": 0.5,
     "type": "other",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 59,
     "internalId": 59,
     "name": "lightning_bolt",
     "displayName": "Lightning Bolt",
-    "width": 0.0,
-    "height": 0.0,
+    "width": 0,
+    "height": 0,
     "type": "other",
-    "category": "UNKNOWN"
+    "category": "UNKNOWN",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 60,
@@ -607,7 +1542,29 @@
     "width": 0.9,
     "height": 1.87,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "chest",
+      "strength",
+      "swag",
+      "variant"
+    ]
   },
   {
     "id": 61,
@@ -617,7 +1574,16 @@
     "width": 0.25,
     "height": 0.25,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 62,
@@ -627,17 +1593,43 @@
     "width": 2.04,
     "height": 2.04,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "size"
+    ]
   },
   {
     "id": 63,
     "internalId": 63,
     "name": "marker",
     "displayName": "Marker",
-    "width": 0.0,
-    "height": 0.0,
+    "width": 0,
+    "height": 0,
     "type": "other",
-    "category": "UNKNOWN"
+    "category": "UNKNOWN",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 64,
@@ -647,7 +1639,22 @@
     "width": 0.98,
     "height": 0.7,
     "type": "other",
-    "category": "Vehicles"
+    "category": "Vehicles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hurt",
+      "hurtdir",
+      "damage",
+      "display_block",
+      "display_offset",
+      "custom_display"
+    ]
   },
   {
     "id": 65,
@@ -657,7 +1664,25 @@
     "width": 0.9,
     "height": 1.4,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "type"
+    ]
   },
   {
     "id": 66,
@@ -667,7 +1692,26 @@
     "width": 1.3964844,
     "height": 1.6,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "chest"
+    ]
   },
   {
     "id": 67,
@@ -677,7 +1721,25 @@
     "width": 0.6,
     "height": 0.7,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "trusting"
+    ]
   },
   {
     "id": 68,
@@ -687,7 +1749,16 @@
     "width": 0.5,
     "height": 0.5,
     "type": "other",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 69,
@@ -697,7 +1768,30 @@
     "width": 1.3,
     "height": 1.25,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "unhappy_counter",
+      "sneeze_counter",
+      "eat_counter",
+      "main_gene",
+      "hidden_gene",
+      "flags"
+    ]
   },
   {
     "id": 70,
@@ -707,7 +1801,26 @@
     "width": 0.5,
     "height": 0.9,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "variant"
+    ]
   },
   {
     "id": 71,
@@ -717,7 +1830,24 @@
     "width": 0.9,
     "height": 0.5,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "size"
+    ]
   },
   {
     "id": 72,
@@ -727,7 +1857,26 @@
     "width": 0.9,
     "height": 0.9,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "saddle",
+      "boost_time"
+    ]
   },
   {
     "id": 73,
@@ -737,7 +1886,26 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "is_charging_crossbow",
+      "is_dancing"
+    ]
   },
   {
     "id": 74,
@@ -747,7 +1915,23 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags"
+    ]
   },
   {
     "id": 75,
@@ -757,7 +1941,25 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "is_celebrating",
+      "is_charging_crossbow"
+    ]
   },
   {
     "id": 76,
@@ -767,7 +1969,25 @@
     "width": 1.4,
     "height": 1.4,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "standing"
+    ]
   },
   {
     "id": 77,
@@ -777,7 +1997,16 @@
     "width": 0.25,
     "height": 0.25,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 78,
@@ -787,7 +2016,25 @@
     "width": 0.7,
     "height": 0.7,
     "type": "water_creature",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "from_bucket",
+      "puff_state"
+    ]
   },
   {
     "id": 79,
@@ -797,7 +2044,25 @@
     "width": 0.4,
     "height": 0.5,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "type"
+    ]
   },
   {
     "id": 80,
@@ -807,7 +2072,24 @@
     "width": 1.95,
     "height": 2.2,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "is_celebrating"
+    ]
   },
   {
     "id": 81,
@@ -817,7 +2099,24 @@
     "width": 0.7,
     "height": 0.4,
     "type": "water_creature",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "from_bucket"
+    ]
   },
   {
     "id": 82,
@@ -827,17 +2126,54 @@
     "width": 0.9,
     "height": 1.3,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "wool"
+    ]
   },
   {
     "id": 83,
     "internalId": 83,
     "name": "shulker",
     "displayName": "Shulker",
-    "width": 1.0,
-    "height": 1.0,
+    "width": 1,
+    "height": 1,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "attach_face",
+      "peek",
+      "color"
+    ]
   },
   {
     "id": 84,
@@ -847,7 +2183,16 @@
     "width": 0.3125,
     "height": 0.3125,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 85,
@@ -857,7 +2202,23 @@
     "width": 0.4,
     "height": 0.3,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags"
+    ]
   },
   {
     "id": 86,
@@ -867,7 +2228,24 @@
     "width": 0.6,
     "height": 1.99,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "stray_conversion"
+    ]
   },
   {
     "id": 87,
@@ -877,7 +2255,25 @@
     "width": 1.3964844,
     "height": 1.6,
     "type": "animal",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags"
+    ]
   },
   {
     "id": 88,
@@ -887,7 +2283,24 @@
     "width": 2.04,
     "height": 2.04,
     "type": "mob",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "size"
+    ]
   },
   {
     "id": 89,
@@ -897,7 +2310,17 @@
     "width": 0.3125,
     "height": 0.3125,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "item_stack"
+    ]
   },
   {
     "id": 90,
@@ -907,7 +2330,26 @@
     "width": 1.9,
     "height": 1.75,
     "type": "player",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "state",
+      "drop_seed_at_tick"
+    ]
   },
   {
     "id": 91,
@@ -917,7 +2359,24 @@
     "width": 0.7,
     "height": 1.9,
     "type": "mob",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "pumpkin"
+    ]
   },
   {
     "id": 92,
@@ -927,7 +2386,16 @@
     "width": 0.25,
     "height": 0.25,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen"
+    ]
   },
   {
     "id": 93,
@@ -937,7 +2405,22 @@
     "width": 0.98,
     "height": 0.7,
     "type": "other",
-    "category": "Vehicles"
+    "category": "Vehicles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hurt",
+      "hurtdir",
+      "damage",
+      "display_block",
+      "display_offset",
+      "custom_display"
+    ]
   },
   {
     "id": 94,
@@ -947,7 +2430,18 @@
     "width": 0.5,
     "height": 0.5,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "flags",
+      "pierce_level"
+    ]
   },
   {
     "id": 95,
@@ -957,7 +2451,24 @@
     "width": 1.4,
     "height": 0.9,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "flags"
+    ]
   },
   {
     "id": 96,
@@ -967,7 +2478,23 @@
     "width": 0.8,
     "height": 0.8,
     "type": "water_creature",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags"
+    ]
   },
   {
     "id": 97,
@@ -977,7 +2504,23 @@
     "width": 0.6,
     "height": 1.99,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags"
+    ]
   },
   {
     "id": 98,
@@ -987,7 +2530,27 @@
     "width": 0.9,
     "height": 1.7,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "boost_time",
+      "suffocating",
+      "saddle"
+    ]
   },
   {
     "id": 99,
@@ -997,17 +2560,60 @@
     "width": 0.4,
     "height": 0.3,
     "type": "water_creature",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "from_bucket"
+    ]
   },
   {
     "id": 100,
     "internalId": 100,
     "name": "text_display",
     "displayName": "Text Display",
-    "width": 0.0,
-    "height": 0.0,
+    "width": 0,
+    "height": 0,
     "type": "other",
-    "category": "Immobile"
+    "category": "Immobile",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "interpolation_duration",
+      "translation",
+      "scale",
+      "left_rotation",
+      "right_rotation",
+      "billboard_render_constraints",
+      "brightness_override",
+      "view_range",
+      "shadow_radius",
+      "shadow_strength",
+      "width",
+      "height",
+      "glow_color_override",
+      "text",
+      "line_width",
+      "text_opacity",
+      "style_flags"
+    ]
   },
   {
     "id": 101,
@@ -1017,7 +2623,17 @@
     "width": 0.98,
     "height": 0.98,
     "type": "other",
-    "category": "UNKNOWN"
+    "category": "UNKNOWN",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "fuse"
+    ]
   },
   {
     "id": 102,
@@ -1027,7 +2643,22 @@
     "width": 0.98,
     "height": 0.7,
     "type": "other",
-    "category": "Vehicles"
+    "category": "Vehicles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hurt",
+      "hurtdir",
+      "damage",
+      "display_block",
+      "display_offset",
+      "custom_display"
+    ]
   },
   {
     "id": 103,
@@ -1037,7 +2668,29 @@
     "width": 0.9,
     "height": 1.87,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "chest",
+      "strength",
+      "swag",
+      "variant"
+    ]
   },
   {
     "id": 104,
@@ -1047,7 +2700,20 @@
     "width": 0.5,
     "height": 0.5,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "flags",
+      "pierce_level",
+      "loyalty",
+      "foil"
+    ]
   },
   {
     "id": 105,
@@ -1057,7 +2723,25 @@
     "width": 0.5,
     "height": 0.4,
     "type": "water_creature",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "from_bucket",
+      "type_variant"
+    ]
   },
   {
     "id": 106,
@@ -1067,7 +2751,30 @@
     "width": 1.2,
     "height": 0.4,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "home_pos",
+      "has_egg",
+      "laying_egg",
+      "travel_pos",
+      "going_home",
+      "travelling"
+    ]
   },
   {
     "id": 107,
@@ -1077,7 +2784,24 @@
     "width": 0.4,
     "height": 0.8,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "flags"
+    ]
   },
   {
     "id": 108,
@@ -1087,7 +2811,26 @@
     "width": 0.6,
     "height": 1.95,
     "type": "passive",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "unhappy_counter",
+      "villager_data"
+    ]
   },
   {
     "id": 109,
@@ -1097,7 +2840,24 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "is_celebrating"
+    ]
   },
   {
     "id": 110,
@@ -1107,7 +2867,25 @@
     "width": 0.6,
     "height": 1.95,
     "type": "passive",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "unhappy_counter"
+    ]
   },
   {
     "id": 111,
@@ -1117,7 +2895,24 @@
     "width": 0.9,
     "height": 2.9,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "client_anger_level"
+    ]
   },
   {
     "id": 112,
@@ -1127,7 +2922,25 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "is_celebrating",
+      "using_item"
+    ]
   },
   {
     "id": 113,
@@ -1137,7 +2950,27 @@
     "width": 0.9,
     "height": 3.5,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "target_a",
+      "target_b",
+      "target_c",
+      "inv"
+    ]
   },
   {
     "id": 114,
@@ -1147,7 +2980,23 @@
     "width": 0.7,
     "height": 2.4,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags"
+    ]
   },
   {
     "id": 115,
@@ -1157,7 +3006,17 @@
     "width": 0.3125,
     "height": 0.3125,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "dangerous"
+    ]
   },
   {
     "id": 116,
@@ -1167,7 +3026,28 @@
     "width": 0.6,
     "height": 0.85,
     "type": "animal",
-    "category": "Passive mobs"
+    "category": "Passive mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags",
+      "interested",
+      "collar_color",
+      "remaining_anger_time"
+    ]
   },
   {
     "id": 117,
@@ -1177,7 +3057,24 @@
     "width": 1.3964844,
     "height": 1.4,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby"
+    ]
   },
   {
     "id": 118,
@@ -1187,7 +3084,26 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "special_type",
+      "drowned_conversion"
+    ]
   },
   {
     "id": 119,
@@ -1197,7 +3113,25 @@
     "width": 1.3964844,
     "height": 1.6,
     "type": "animal",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "flags"
+    ]
   },
   {
     "id": 120,
@@ -1207,7 +3141,27 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "special_type",
+      "drowned_conversion",
+      "converting"
+    ]
   },
   {
     "id": 121,
@@ -1217,7 +3171,26 @@
     "width": 0.6,
     "height": 1.95,
     "type": "hostile",
-    "category": "Hostile mobs"
+    "category": "Hostile mobs",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "mob_flags",
+      "baby",
+      "special_type",
+      "drowned_conversion"
+    ]
   },
   {
     "id": 122,
@@ -1227,7 +3200,28 @@
     "width": 0.6,
     "height": 1.8,
     "type": "player",
-    "category": "UNKNOWN"
+    "category": "UNKNOWN",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "living_entity_flags",
+      "health",
+      "effect_color",
+      "effect_ambience",
+      "arrow_count",
+      "stinger_count",
+      "player_absorption",
+      "score",
+      "player_mode_customisation",
+      "player_main_hand",
+      "shoulder_left",
+      "shoulder_right"
+    ]
   },
   {
     "id": 123,
@@ -1237,6 +3231,17 @@
     "width": 0.25,
     "height": 0.25,
     "type": "projectile",
-    "category": "Projectiles"
+    "category": "Projectiles",
+    "metadataKeys": [
+      "shared_flags",
+      "air_supply",
+      "custom_name_visible",
+      "silent",
+      "no_gravity",
+      "pose",
+      "ticks_frozen",
+      "hooked_entity",
+      "biting"
+    ]
   }
 ]

--- a/data/pc/1.19.4/protocol.json
+++ b/data/pc/1.19.4/protocol.json
@@ -374,19 +374,19 @@
       {
         "compareTo": "$compareTo",
         "fields": {
-          "0": "i8",
-          "1": "varint",
-          "2": "varlong",
-          "3": "f32",
-          "4": "string",
-          "5": "string",
-          "6": [
+          "byte": "i8",
+          "int": "varint",
+          "long": "varlong",
+          "float": "f32",
+          "string": "string",
+          "component": "string",
+          "optional_component": [
             "option",
             "string"
           ],
-          "7": "slot",
-          "8": "bool",
-          "9": [
+          "item_stack": "slot",
+          "boolean": "bool",
+          "rotations": [
             "container",
             [
               {
@@ -403,21 +403,21 @@
               }
             ]
           ],
-          "10": "position",
-          "11": [
+          "block_pos": "position",
+          "optional_block_pos": [
             "option",
             "position"
           ],
-          "12": "varint",
-          "13": [
+          "direction": "varint",
+          "optional_uuid": [
             "option",
             "UUID"
           ],
-          "14": "varint",
-          "15": "optvarint",
-          "16": "nbt",
-          "17": "particle",
-          "18": [
+          "block_state": "varint",
+          "optional_block_state": "optvarint",
+          "compound_tag": "nbt",
+          "particle": "particle",
+          "villager_data": [
             "container",
             [
               {
@@ -434,18 +434,18 @@
               }
             ]
           ],
-          "19": "optvarint",
-          "20": "varint",
-          "21": "varint",
-          "22": "varint",
-          "23": [
+          "optional_unsigned_int": "optvarint",
+          "pose": "varint",
+          "cat_variant": "varint",
+          "frog_variant": "varint",
+          "optional_global_pos": [
             "option",
             "string"
           ],
-          "24": "varint",
-          "25": "varint",
-          "26": "vec3f",
-          "27": "vec4f"
+          "painting_variant": "varint",
+          "sniffer_state": "varint",
+          "vector3": "vec3f",
+          "quaternion": "vec4f"
         }
       }
     ],
@@ -457,19 +457,46 @@
           "container",
           [
             {
-              "anon": true,
+              "name": "key",
+              "type": "u8"
+            },
+            {
+              "name": "type",
               "type": [
-                "container",
-                [
-                  {
-                    "name": "key",
-                    "type": "u8"
-                  },
-                  {
-                    "name": "type",
-                    "type": "varint"
+                "mapper",
+                {
+                  "type": "varint",
+                  "mappings": {
+                    "0": "byte",
+                    "1": "int",
+                    "2": "long",
+                    "3": "float",
+                    "4": "string",
+                    "5": "component",
+                    "6": "optional_component",
+                    "7": "item_stack",
+                    "8": "boolean",
+                    "9": "rotations",
+                    "10": "block_pos",
+                    "11": "optional_block_pos",
+                    "12": "direction",
+                    "13": "optional_uuid",
+                    "14": "block_state",
+                    "15": "optional_block_state",
+                    "16": "compound_tag",
+                    "17": "particle",
+                    "18": "villager_data",
+                    "19": "optional_unsigned_int",
+                    "20": "pose",
+                    "21": "cat_variant",
+                    "22": "frog_variant",
+                    "23": "optional_global_pos",
+                    "24": "painting_variant",
+                    "25": "sniffer_state",
+                    "26": "vector3",
+                    "27": "quaternion"
                   }
-                ]
+                }
               ]
             },
             {

--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -721,5 +721,10 @@
     "name": "hasBundlePacket",
     "description": "Has a Bundle Packet to group packets for processing at once",
     "versions": ["1.19.4", "latest"]
+  },
+  {
+    "name": "mcDataHasEntityMetadata",
+    "description": "Entity Metadata is defined in mcdata",
+    "versions": ["1.19.4", "latest"]
   }
 ]

--- a/schemas/entities_schema.json
+++ b/schemas/entities_schema.json
@@ -60,6 +60,13 @@
       "category": {
         "description": "The category of an entity : a semantic category",
         "type": "string"
+      },
+      "metadataKeys": {
+        "description": "The pc metadata tags of an entity. (Naming is via mc code, with data_ and id_ prefixes stripped)",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     },
     "required": [

--- a/tools/js/extractPcEntityMetadata.js
+++ b/tools/js/extractPcEntityMetadata.js
@@ -22,7 +22,6 @@ function getEntityTypes () {
       const regex = line.match(/EntityType<(.*)> (.*) = register\(\W+"([a-z0-9_]+)"/)
       if (regex) {
         const [, type, , name] = regex
-        // console.log('Type', type, 'Name', name)
         classNameTo[type] = name
       }
     }
@@ -56,10 +55,8 @@ const allEntityFileCodes = Object.fromEntries(allEntityFiles.map(file => [
   file.split(/\\|\//g).pop().replace('.java', ''),
   fs.readFileSync(file, 'utf8')
 ]))
-const entityPreTree = []
-// console.log('All Entity Files', allEntityFileCodes)
-// this is really bad code, but it's way easier to write
 
+const entityPreTree = []
 const inheritPairs = {}
 
 for (const file in allEntityFileCodes) {
@@ -120,10 +117,7 @@ for (const key in classNameToRegistryName) {
 function updateMcDataEntitiesJSON () {
   const presentMcDataPath = `../../data/pc/${version}/entities.json`
   const presentMcData = require(presentMcDataPath)
-  // const newMcData = []
   for (const entry of presentMcData) {
-    // newMcData.push(flat[entry.name].map(e => e[0].toLowerCase()))
-    // entry.metadataKeys = newMcData.length - 1
     entry.metadataKeys = flat[entry.name].map(e => e[0].replace('DATA_', '').replace('_ID', '').replace('ID_', '').toLowerCase())
   }
   fs.writeFileSync(presentMcDataPath, JSON.stringify(presentMcData, null, 2))
@@ -136,7 +130,6 @@ function updateMcDataProtocolJSON () {
   for (let i = 0; i < serializers.length; i++) {
     mapper.mappings[i] = serializers[i].toLowerCase()
   }
-  // const mcdata = require('../../data/pc/1.19.4/protocol.json')
   mcdata.types.entityMetadata[1].type[1] = [
     { name: 'key', type: 'u8' },
     { name: 'type', type: ['mapper', mapper] },
@@ -151,9 +144,6 @@ function updateMcDataProtocolJSON () {
   // mcdata.types.entityMetadataItem[1].fields = next
   fs.writeFileSync(presentMcDataPath, JSON.stringify(mcdata, null, 2))
 }
-
-// fs.writeFileSync('entityTree.json', JSON.stringify(tree, null, 2))
-// fs.writeFileSync('entityFlat.json', JSON.stringify(flat, null, 2))
 
 updateMcDataEntitiesJSON()
 updateMcDataProtocolJSON()

--- a/tools/js/extractPcEntityMetadata.js
+++ b/tools/js/extractPcEntityMetadata.js
@@ -1,0 +1,159 @@
+const fs = require('fs')
+const cp = require('child_process')
+const { globSync } = require('glob')
+const version = process.argv[2] || '1.19.4'
+if (!version) {
+  console.log('Usage: node extractEntityMetadata.js <version>')
+  process.exit(1)
+}
+
+if (!fs.existsSync(version)) {
+  cp.execSync(`git clone -b client${version} https://github.com/extremeheat/extracted_minecraft_data.git ${version} --depth 1`, { stdio: 'inherit' })
+}
+
+function getEntityTypes () {
+  const entityTypes = fs.readFileSync(`./${version}/client/net/minecraft/world/entity/EntityType.java`, 'utf8')
+  const entityTypesLines = entityTypes.split(';')
+  const classNameTo = {}
+  for (const line of entityTypesLines) {
+    if (line.includes('= register(')) {
+      // Given the line: public static final EntityType<Allay> ALLAY = register( "allay", EntityType.Builder.<Allay>of(Allay::new, MobCategory.CREATURE).sized(0.35F, 0.6F).clientTrackingRange(8).updateInterval(2) );
+      // we extract Allay and "allay"
+      const regex = line.match(/EntityType<(.*)> (.*) = register\(\W+"([a-z0-9_]+)"/)
+      if (regex) {
+        const [, type, , name] = regex
+        // console.log('Type', type, 'Name', name)
+        classNameTo[type] = name
+      }
+    }
+  }
+  return classNameTo
+}
+
+function getEntityMetadataSerializers () {
+  const output = []
+  const entityTypes = fs.readFileSync(`./${version}/client/net/minecraft/network/syncher/EntityDataSerializers.java`, 'utf8')
+  const entityTypesLines = entityTypes.split(';')
+  for (const line of entityTypesLines) {
+    if (line.includes('registerSerializer')) {
+      // From:       registerSerializer(BYTE);
+      // We extract: BYTE
+      const regex = line.match(/ {2}registerSerializer\((.*)\)/)
+      if (regex) {
+        const [, type] = regex
+        output.push(type)
+      }
+    }
+  }
+  return output.map(e => e.toLowerCase())
+}
+
+const serializers = getEntityMetadataSerializers()
+const classNameToRegistryName = getEntityTypes()
+
+const allEntityFiles = globSync(`${version}/**/entity/**/*.java`)
+const allEntityFileCodes = Object.fromEntries(allEntityFiles.map(file => [
+  file.split(/\\|\//g).pop().replace('.java', ''),
+  fs.readFileSync(file, 'utf8')
+]))
+const entityPreTree = []
+// console.log('All Entity Files', allEntityFileCodes)
+// this is really bad code, but it's way easier to write
+
+const inheritPairs = {}
+
+for (const file in allEntityFileCodes) {
+  const code = allEntityFileCodes[file]
+  const lines = code.split('\n')
+  let lastClass
+  for (const line of lines) {
+    let lineWithoutGenerics = line.replace(/<.*>/g, '')
+    const bloatMods = ['abstract', 'static']
+    for (const mod of bloatMods) lineWithoutGenerics = lineWithoutGenerics.replace(` ${mod} `, ' ')
+
+    if (lineWithoutGenerics.includes('public class ')) {
+      const className = lineWithoutGenerics.split('public class ')[1]?.split(' ')[0]
+      lastClass = className
+      const extend = lineWithoutGenerics.split('extends ')[1]?.split(' ')[0]
+      if (className === file) {
+        if (extend) entityPreTree.push([extend, file])
+        else entityPreTree.push([file])
+      } else if (extend === file) {
+        lastClass = `${file}.${className}`
+        entityPreTree.push([file, lastClass])
+      }
+    }
+
+    if (line.includes('SynchedEntityData.defineId(')) {
+      // from:    private static final EntityDataAccessor<Sniffer.State> DATA_STATE = SynchedEntityData.defineId(Sniffer.class, EntityDataSerializers.SNIFFER_STATE);
+      // extract: DATA_STATE, SNIFFER_STATE
+      const r = line.match(/> ([A-Z_0-9]+) = .*EntityDataSerializers.([A-Z_0-9]+)/)
+      if (r) {
+        const [, data, serializer] = r
+        ;(inheritPairs[lastClass] ??= []).push([data, serializer])
+      }
+    }
+  }
+}
+
+const tree = {}
+const flat = {}
+const handledNames = []
+function build (ele, root = tree, arr = []) {
+  const name = classNameToRegistryName[ele]
+  const metadata = inheritPairs[ele]
+  root[ele] = { children: {}, name, metadata }
+  if (name) flat[name] = arr.concat(metadata ?? [])
+  handledNames.push(ele)
+  for (const [key, val] of entityPreTree) {
+    if (key === ele) {
+      build(val, root[key].children, arr.concat(metadata ?? []))
+    }
+  }
+}
+build('Entity')
+
+for (const key in classNameToRegistryName) {
+  if (!handledNames.includes(key)) throw new Error('Unhandled entity ' + key)
+}
+
+function updateMcDataEntitiesJSON () {
+  const presentMcDataPath = `../../data/pc/${version}/entities.json`
+  const presentMcData = require(presentMcDataPath)
+  // const newMcData = []
+  for (const entry of presentMcData) {
+    // newMcData.push(flat[entry.name].map(e => e[0].toLowerCase()))
+    // entry.metadataKeys = newMcData.length - 1
+    entry.metadataKeys = flat[entry.name].map(e => e[0].replace('DATA_', '').replace('_ID', '').replace('ID_', '').toLowerCase())
+  }
+  fs.writeFileSync(presentMcDataPath, JSON.stringify(presentMcData, null, 2))
+}
+
+function updateMcDataProtocolJSON () {
+  const presentMcDataPath = `../../data/pc/${version}/protocol.json`
+  const mcdata = require(presentMcDataPath)
+  const mapper = { type: 'varint', mappings: {} }
+  for (let i = 0; i < serializers.length; i++) {
+    mapper.mappings[i] = serializers[i].toLowerCase()
+  }
+  // const mcdata = require('../../data/pc/1.19.4/protocol.json')
+  mcdata.types.entityMetadata[1].type[1] = [
+    { name: 'key', type: 'u8' },
+    { name: 'type', type: ['mapper', mapper] },
+    { name: 'value', type: ['entityMetadataItem', { compareTo: 'type' }] }
+  ]
+  // One time code to remap integers to strings in protocol.json for the entityMetadataItem type
+  // const metadataItems = mcdata.types.entityMetadataItem[1].fields
+  // const next = {}
+  // for (const key in metadataItems) {
+  //   next[serializers[key]] = metadataItems[key]
+  // }
+  // mcdata.types.entityMetadataItem[1].fields = next
+  fs.writeFileSync(presentMcDataPath, JSON.stringify(mcdata, null, 2))
+}
+
+// fs.writeFileSync('entityTree.json', JSON.stringify(tree, null, 2))
+// fs.writeFileSync('entityFlat.json', JSON.stringify(flat, null, 2))
+
+updateMcDataEntitiesJSON()
+updateMcDataProtocolJSON()

--- a/tools/js/package.json
+++ b/tools/js/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "ajv": "^6.5.4",
-    "mocha": "5.2.0",
+    "glob": "^10.2.6",
+    "mocha": "^10.2.0",
     "protodef-validator": "^1.2.2",
     "protodef-yaml": "^1.2.2",
     "standard": "^16.0.3"


### PR DESCRIPTION
Adds entity metadata keys to entities.json for pc, updates protocol.json to use string mapping for metadata item values

Addresses #72 a bit