### PR TITLE
Fixed some issues & improved data documentation

### DIFF
--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -55,7 +55,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1162,7 +1162,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -1601,9 +1605,14 @@ packet_show_store_offer:
    unknown0: string
    unknown1: bool
 
+# PurchaseReceipt is sent by the client to the server to notify the server it purchased an item from the
+# Marketplace store that was offered by the server. The packet is only used for partnered servers.
 packet_purchase_receipt:
    !id: 0x5c
    !bound: server
+   # Receipts is a list of receipts, or proofs of purchases, for the offers that have been purchased by the
+   # player.
+   receipts: string[]varint
 
 packet_player_skin:
    !id: 0x5d
@@ -1614,9 +1623,18 @@ packet_player_skin:
    old_skin_name: string
    is_verified: bool
 
+# SubClientLogin is sent when a sub-client joins the server while another client is already connected to it.
+# The packet is sent as a result of split-screen game play, and allows up to four players to play using the
+# same network connection. After an initial Login packet from the 'main' client, each sub-client that
+# connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
+   # ConnectionRequest is a string containing information about the player and JWTs that may be used to
+   # verify if the player is connected to XBOX Live. The connection request also contains the necessary
+   # client public key to initiate encryption.
+   # The ConnectionRequest in this packet is identical to the one found in the Login packet.
+   tokens: LoginTokens
 
 packet_initiate_web_socket_connection:
    !id: 0x5f
@@ -1628,9 +1646,11 @@ packet_set_last_hurt_by:
    !bound: client
    unknown: varint
 
+# BookEdit is sent by the client when it edits a book. It is sent each time a modification was made and the
+# player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -1701,7 +1721,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -1889,7 +1909,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -1945,7 +1965,7 @@ packet_map_create_locked_copy:
 
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
 
 packet_structure_template_data_export_response:
    !id: 0x85
@@ -1960,7 +1980,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2224,7 +2244,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -2399,7 +2419,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.

--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -55,7 +55,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1634,7 +1634,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 packet_initiate_web_socket_connection:
    !id: 0x5f
@@ -1980,7 +1980,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -707,7 +707,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -753,6 +756,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -1756,6 +1760,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -1925,7 +1930,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -4992,7 +4992,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -5889,7 +5900,18 @@
     ],
     "packet_purchase_receipt": [
       "container",
-      []
+      [
+        {
+          "name": "receipts",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "string"
+            }
+          ]
+        }
+      ]
     ],
     "packet_player_skin": [
       "container",
@@ -5918,7 +5940,18 @@
     ],
     "packet_sub_client_login": [
       "container",
-      []
+      [
+        {
+          "name": "tokens",
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
+        }
+      ]
     ],
     "packet_initiate_web_socket_connection": [
       "container",

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -4231,7 +4231,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -4339,6 +4349,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -6234,7 +6245,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -6574,7 +6586,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -2993,7 +2993,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -5937,7 +5943,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -2993,13 +2993,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -5943,13 +5937,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -55,7 +55,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1702,7 +1702,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 packet_initiate_web_socket_connection:
    !id: 0x5f
@@ -2071,7 +2071,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -55,7 +55,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1194,7 +1194,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -1669,9 +1673,14 @@ packet_show_store_offer:
    unknown0: string
    unknown1: bool
 
+# PurchaseReceipt is sent by the client to the server to notify the server it purchased an item from the
+# Marketplace store that was offered by the server. The packet is only used for partnered servers.
 packet_purchase_receipt:
    !id: 0x5c
    !bound: server
+   # Receipts is a list of receipts, or proofs of purchases, for the offers that have been purchased by the
+   # player.
+   receipts: string[]varint
 
 packet_player_skin:
    !id: 0x5d
@@ -1682,9 +1691,18 @@ packet_player_skin:
    old_skin_name: string
    is_verified: bool
 
+# SubClientLogin is sent when a sub-client joins the server while another client is already connected to it.
+# The packet is sent as a result of split-screen game play, and allows up to four players to play using the
+# same network connection. After an initial Login packet from the 'main' client, each sub-client that
+# connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
+   # ConnectionRequest is a string containing information about the player and JWTs that may be used to
+   # verify if the player is connected to XBOX Live. The connection request also contains the necessary
+   # client public key to initiate encryption.
+   # The ConnectionRequest in this packet is identical to the one found in the Login packet.
+   tokens: LoginTokens
 
 packet_initiate_web_socket_connection:
    !id: 0x5f
@@ -1696,9 +1714,11 @@ packet_set_last_hurt_by:
    !bound: client
    unknown: varint
 
+# BookEdit is sent by the client when it edits a book. It is sent each time a modification was made and the
+# player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -1769,7 +1789,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -1980,7 +2000,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2036,7 +2056,7 @@ packet_map_create_locked_copy:
 
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
 
 packet_structure_template_data_export_response:
    !id: 0x85
@@ -2051,7 +2071,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2351,7 +2371,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -2531,7 +2551,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -746,7 +746,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -796,6 +799,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -1824,6 +1828,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2016,7 +2021,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -4415,7 +4415,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -4523,6 +4533,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -6445,7 +6456,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -6795,7 +6807,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -5156,7 +5156,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -6100,7 +6111,18 @@
     ],
     "packet_purchase_receipt": [
       "container",
-      []
+      [
+        {
+          "name": "receipts",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "string"
+            }
+          ]
+        }
+      ]
     ],
     "packet_player_skin": [
       "container",
@@ -6129,7 +6151,18 @@
     ],
     "packet_sub_client_login": [
       "container",
-      []
+      [
+        {
+          "name": "tokens",
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
+        }
+      ]
     ],
     "packet_initiate_web_socket_connection": [
       "container",

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -3169,13 +3169,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -6154,13 +6148,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -3169,7 +3169,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -6148,7 +6154,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1918,7 +1918,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2523,7 +2523,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1231,7 +1231,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -1909,12 +1913,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -1939,7 +1943,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -1982,6 +1986,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2068,7 +2073,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2400,7 +2405,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2478,7 +2483,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2518,7 +2523,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2841,7 +2846,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3021,7 +3026,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -776,7 +776,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -826,6 +829,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2145,6 +2149,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2422,7 +2427,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -5578,7 +5578,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -3620,7 +3620,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -6768,7 +6774,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -4845,7 +4845,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -4953,6 +4963,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7172,7 +7183,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -7562,7 +7574,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -3620,13 +3620,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -6774,13 +6768,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -6931,7 +6919,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -777,7 +777,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -827,6 +830,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2147,6 +2151,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2424,7 +2429,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1920,7 +1920,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2525,7 +2525,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1232,7 +1232,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -1911,12 +1915,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -1941,7 +1945,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -1984,6 +1988,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2070,7 +2075,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2402,7 +2407,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2480,7 +2485,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2520,7 +2525,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2843,7 +2848,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3023,7 +3028,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -5656,7 +5656,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -3694,7 +3694,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -6847,7 +6853,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -4923,7 +4923,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5031,6 +5041,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7251,7 +7262,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -7641,7 +7653,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -3694,13 +3694,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -6853,13 +6847,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7010,7 +6998,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2008,7 +2008,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2622,7 +2622,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -860,7 +860,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -910,6 +913,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2244,6 +2248,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2521,7 +2526,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1315,7 +1315,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -1999,12 +2003,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2029,7 +2033,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2072,6 +2076,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2083,7 +2088,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2167,7 +2172,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2499,7 +2504,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2577,7 +2582,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2617,7 +2622,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2940,7 +2945,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3120,7 +3125,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3186,6 +3191,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -5746,7 +5746,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7097,7 +7108,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7119,7 +7131,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -5013,7 +5013,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5121,6 +5131,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7367,7 +7378,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -7757,7 +7769,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -3700,13 +3700,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -6951,13 +6945,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -3700,7 +3700,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -6945,7 +6951,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2021,7 +2021,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2638,7 +2638,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1327,7 +1327,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2012,12 +2016,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2042,7 +2046,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2085,6 +2089,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2096,7 +2101,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2188,7 +2193,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2515,7 +2520,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2593,7 +2598,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2633,7 +2638,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2969,7 +2974,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3151,7 +3156,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3218,6 +3223,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3241,6 +3247,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3251,6 +3258,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3262,4 +3270,5 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -861,7 +861,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -911,6 +914,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2265,6 +2269,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2537,7 +2542,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -3802,13 +3802,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7079,13 +7073,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -3802,7 +3802,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7073,7 +7079,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -5119,7 +5119,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5227,6 +5237,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7511,7 +7522,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -7901,7 +7913,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -5874,7 +5874,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7225,7 +7236,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7247,7 +7259,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2021,7 +2021,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2638,7 +2638,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1327,7 +1327,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2012,12 +2016,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2042,7 +2046,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2085,6 +2089,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2096,7 +2101,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2188,7 +2193,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2515,7 +2520,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2593,7 +2598,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2633,7 +2638,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2969,7 +2974,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3151,7 +3156,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3218,6 +3223,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3241,6 +3247,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3251,6 +3258,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3262,6 +3270,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 packet_subchunk:

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -864,7 +864,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -914,6 +917,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2265,6 +2269,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2537,7 +2542,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -3830,13 +3830,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7080,13 +7074,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -5150,7 +5150,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5258,6 +5268,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7512,7 +7523,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -7902,7 +7914,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -3830,7 +3830,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7074,7 +7080,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -5875,7 +5875,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7226,7 +7237,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7248,7 +7260,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1333,7 +1333,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2019,12 +2023,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2049,7 +2053,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2092,6 +2096,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2103,7 +2108,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2195,7 +2200,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2522,7 +2527,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2600,7 +2605,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2640,7 +2645,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2976,7 +2981,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3159,7 +3164,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3226,6 +3231,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3249,6 +3255,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3259,6 +3266,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3270,6 +3278,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 packet_subchunk:

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -867,7 +867,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -917,6 +920,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2272,6 +2276,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2544,7 +2549,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2028,7 +2028,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2645,7 +2645,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -5165,7 +5165,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5273,6 +5283,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7557,7 +7568,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -7947,7 +7959,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -3840,13 +3840,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7125,13 +7119,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -5920,7 +5920,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7271,7 +7282,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7293,7 +7305,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -3840,7 +3840,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7119,7 +7125,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2035,7 +2035,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2652,7 +2652,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1338,7 +1338,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2026,12 +2030,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2056,7 +2060,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2099,6 +2103,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2110,7 +2115,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2202,7 +2207,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2529,7 +2534,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2607,7 +2612,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2647,7 +2652,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2983,7 +2988,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3166,7 +3171,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3238,6 +3243,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3261,6 +3267,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3271,6 +3278,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3282,6 +3290,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3373,6 +3382,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -867,7 +867,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -917,6 +920,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2279,6 +2283,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2551,7 +2556,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -5200,7 +5200,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5308,6 +5318,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7615,7 +7626,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8005,7 +8017,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -3875,13 +3875,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7183,13 +7177,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -3875,7 +3875,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7177,7 +7183,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -5968,7 +5968,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7329,7 +7340,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7351,7 +7363,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1346,7 +1346,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2036,12 +2040,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2066,7 +2070,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2109,6 +2113,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2120,7 +2125,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2212,7 +2217,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2543,7 +2548,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2621,7 +2626,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2661,7 +2666,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -2997,7 +3002,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3180,7 +3185,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3256,6 +3261,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3279,6 +3285,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3289,6 +3296,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3300,6 +3308,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3395,7 +3404,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -875,7 +875,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -925,6 +928,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2289,6 +2293,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2565,7 +2570,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2045,7 +2045,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2666,7 +2666,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -3939,7 +3939,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7262,7 +7268,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -3939,13 +3939,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7268,13 +7262,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -6051,7 +6051,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7414,7 +7425,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7436,7 +7448,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -5283,7 +5283,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5391,6 +5401,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7700,7 +7711,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8094,7 +8106,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2059,7 +2059,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2680,7 +2680,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1352,7 +1352,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2050,12 +2054,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2080,7 +2084,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2123,6 +2127,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2134,7 +2139,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2226,7 +2231,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2557,7 +2562,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2635,7 +2640,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2675,7 +2680,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3016,7 +3021,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3199,7 +3204,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3275,6 +3280,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3298,6 +3304,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3308,6 +3315,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3319,6 +3327,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3414,7 +3423,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3503,6 +3512,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -882,7 +882,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -932,6 +935,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2303,6 +2307,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2579,7 +2584,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -6094,7 +6094,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7465,7 +7476,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7487,7 +7499,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -3980,7 +3980,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7313,7 +7319,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -5333,7 +5333,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5441,6 +5451,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7751,7 +7762,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8145,7 +8157,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -3980,13 +3980,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7319,13 +7313,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -938,7 +938,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -988,6 +991,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2354,6 +2358,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2630,7 +2635,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1403,7 +1403,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2101,12 +2105,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2131,7 +2135,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2174,6 +2178,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2185,7 +2190,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2277,7 +2282,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2608,7 +2613,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2686,7 +2691,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2726,7 +2731,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3067,7 +3072,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3250,7 +3255,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3326,6 +3331,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3349,6 +3355,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3359,6 +3366,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3370,6 +3378,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3465,7 +3474,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3554,6 +3563,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2110,7 +2110,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2731,7 +2731,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -6162,7 +6162,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7533,7 +7544,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7555,7 +7567,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -4055,13 +4055,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7387,13 +7381,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -5413,7 +5413,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5521,6 +5531,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7819,7 +7830,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8213,7 +8225,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -4055,7 +4055,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7381,7 +7387,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1417,7 +1417,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2122,12 +2126,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2152,7 +2156,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2195,6 +2199,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2206,7 +2211,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2308,7 +2313,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2645,7 +2650,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2723,7 +2728,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2763,7 +2768,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3104,7 +3109,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3287,7 +3292,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3363,6 +3368,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3386,6 +3392,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3396,6 +3403,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3407,6 +3415,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3502,7 +3511,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3591,6 +3600,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2131,7 +2131,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2768,7 +2768,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -952,7 +952,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1002,6 +1005,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2385,6 +2389,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2667,7 +2672,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -5483,7 +5483,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5591,6 +5601,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7962,7 +7973,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8378,7 +8390,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -4095,13 +4095,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7483,13 +7477,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -4095,7 +4095,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7477,7 +7483,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -6232,7 +6232,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7629,7 +7640,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7651,7 +7663,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1417,7 +1417,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2122,12 +2126,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2152,7 +2156,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2195,6 +2199,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2206,7 +2211,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2308,7 +2313,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2645,7 +2650,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2723,7 +2728,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2763,7 +2768,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3104,7 +3109,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3287,7 +3292,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3363,6 +3368,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3386,6 +3392,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3396,6 +3403,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3407,6 +3415,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3502,7 +3511,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3591,6 +3600,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2131,7 +2131,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2768,7 +2768,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -952,7 +952,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1002,6 +1005,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2385,6 +2389,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2667,7 +2672,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -5483,7 +5483,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5591,6 +5601,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -7962,7 +7973,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8378,7 +8390,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -4095,13 +4095,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7483,13 +7477,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -4095,7 +4095,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7477,7 +7483,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -6232,7 +6232,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7629,7 +7640,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7651,7 +7663,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2134,7 +2134,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2771,7 +2771,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -953,7 +953,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1003,6 +1006,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2388,6 +2392,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2670,7 +2675,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1418,7 +1418,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2125,12 +2129,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2155,7 +2159,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2198,6 +2202,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2209,7 +2214,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2311,7 +2316,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2648,7 +2653,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2726,7 +2731,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2766,7 +2771,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3119,7 +3124,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3302,7 +3307,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3378,6 +3383,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3401,6 +3407,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3411,6 +3418,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3422,6 +3430,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3517,7 +3526,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3606,6 +3615,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.
@@ -3767,6 +3777,7 @@ packet_request_network_settings:
 
 packet_game_test_request:
    !id: 0xc2
+   !bound: server
    # MaxTestsPerBatch ...
    max_tests_per_batch: varint
    # Repetitions represents the amount of times the test will be run.
@@ -3791,6 +3802,7 @@ packet_game_test_request:
 # test was successful or not, and an error string if the test failed.
 packet_game_test_results:
    !id: 0xc3
+   !bound: client
    # Succeeded indicates whether the test succeeded or not.
    succeeded: bool
    # Error is the error that occurred. If Succeeded is true, this field is empty.

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -4185,7 +4185,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7581,7 +7587,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -5583,7 +5583,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5691,6 +5701,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -8066,7 +8077,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8482,7 +8494,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -6332,7 +6332,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7733,7 +7744,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7755,7 +7767,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -4185,13 +4185,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7587,13 +7581,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1428,7 +1428,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2135,12 +2139,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2165,7 +2169,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2208,6 +2212,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2219,7 +2224,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2321,7 +2326,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2658,7 +2663,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2736,7 +2741,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2776,7 +2781,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3129,7 +3134,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3312,7 +3317,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3388,6 +3393,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3411,6 +3417,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3421,6 +3428,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3432,6 +3440,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3527,7 +3536,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3616,6 +3625,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.
@@ -3777,6 +3787,7 @@ packet_request_network_settings:
 
 packet_game_test_request:
    !id: 0xc2
+   !bound: server
    # MaxTestsPerBatch ...
    max_tests_per_batch: varint
    # Repetitions represents the amount of times the test will be run.
@@ -3801,6 +3812,7 @@ packet_game_test_request:
 # test was successful or not, and an error string if the test failed.
 packet_game_test_results:
    !id: 0xc3
+   !bound: client
    # Succeeded indicates whether the test succeeded or not.
    succeeded: bool
    # Error is the error that occurred. If Succeeded is true, this field is empty.

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2144,7 +2144,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2781,7 +2781,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -960,7 +960,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1010,6 +1013,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2398,6 +2402,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2680,7 +2685,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -4241,7 +4241,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7650,7 +7656,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -4241,13 +4241,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7656,13 +7650,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -5648,7 +5648,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5756,6 +5766,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -8135,7 +8146,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8551,7 +8563,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -6401,7 +6401,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7802,7 +7813,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7824,7 +7836,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2144,7 +2144,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2783,7 +2783,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -960,7 +960,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1010,6 +1013,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2398,6 +2402,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2680,7 +2685,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1428,7 +1428,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2135,12 +2139,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2165,7 +2169,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2208,6 +2212,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2219,7 +2224,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2321,7 +2326,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2658,7 +2663,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2736,7 +2741,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2778,7 +2783,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3131,7 +3136,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3314,7 +3319,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3390,6 +3395,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3413,6 +3419,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3423,6 +3430,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3434,6 +3442,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3529,7 +3538,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3618,6 +3627,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.
@@ -3779,6 +3789,7 @@ packet_request_network_settings:
 
 packet_game_test_request:
    !id: 0xc2
+   !bound: server
    # MaxTestsPerBatch ...
    max_tests_per_batch: varint
    # Repetitions represents the amount of times the test will be run.
@@ -3803,6 +3814,7 @@ packet_game_test_request:
 # test was successful or not, and an error string if the test failed.
 packet_game_test_results:
    !id: 0xc3
+   !bound: client
    # Succeeded indicates whether the test succeeded or not.
    succeeded: bool
    # Error is the error that occurred. If Succeeded is true, this field is empty.

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -5664,7 +5664,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5772,6 +5782,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -8151,7 +8162,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8567,7 +8579,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -4257,13 +4257,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7672,13 +7666,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -6417,7 +6417,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7818,7 +7829,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7840,7 +7852,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -4257,7 +4257,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7666,7 +7672,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2148,7 +2148,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2787,7 +2787,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1430,7 +1430,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2139,12 +2143,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2169,7 +2173,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2212,6 +2216,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2223,7 +2228,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2325,7 +2330,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2662,7 +2667,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2740,7 +2745,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2782,7 +2787,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3138,7 +3143,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3321,7 +3326,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3397,6 +3402,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3420,6 +3426,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3430,6 +3437,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3441,6 +3449,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3536,7 +3545,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3625,6 +3634,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.
@@ -3786,6 +3796,7 @@ packet_request_network_settings:
 
 packet_game_test_request:
    !id: 0xc2
+   !bound: server
    # MaxTestsPerBatch ...
    max_tests_per_batch: varint
    # Repetitions represents the amount of times the test will be run.
@@ -3810,6 +3821,7 @@ packet_game_test_request:
 # test was successful or not, and an error string if the test failed.
 packet_game_test_results:
    !id: 0xc3
+   !bound: client
    # Succeeded indicates whether the test succeeded or not.
    succeeded: bool
    # Error is the error that occurred. If Succeeded is true, this field is empty.

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -962,7 +962,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1012,6 +1015,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2402,6 +2406,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2684,7 +2689,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -5705,7 +5705,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5813,6 +5823,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -8196,7 +8207,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8612,7 +8624,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -4294,13 +4294,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7717,13 +7711,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -4294,7 +4294,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7711,7 +7717,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -6458,7 +6458,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7863,7 +7874,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7885,7 +7897,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -962,7 +962,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1012,6 +1015,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2403,6 +2407,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2685,7 +2690,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2149,7 +2149,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2788,7 +2788,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1430,7 +1430,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2140,12 +2144,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2170,7 +2174,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2213,6 +2217,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2224,7 +2229,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2326,7 +2331,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2663,7 +2668,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2741,7 +2746,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2783,7 +2788,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3139,7 +3144,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3322,7 +3327,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3398,6 +3403,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3421,6 +3427,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3431,6 +3438,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3442,6 +3450,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3537,7 +3546,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3626,6 +3635,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.
@@ -3787,6 +3797,7 @@ packet_request_network_settings:
 
 packet_game_test_request:
    !id: 0xc2
+   !bound: server
    # MaxTestsPerBatch ...
    max_tests_per_batch: varint
    # Repetitions represents the amount of times the test will be run.
@@ -3811,6 +3822,7 @@ packet_game_test_request:
 # test was successful or not, and an error string if the test failed.
 packet_game_test_results:
    !id: 0xc3
+   !bound: client
    # Succeeded indicates whether the test succeeded or not.
    succeeded: bool
    # Error is the error that occurred. If Succeeded is true, this field is empty.

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -4298,13 +4298,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7721,13 +7715,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -4298,7 +4298,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7715,7 +7721,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -6462,7 +6462,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7867,7 +7878,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7889,7 +7901,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -5709,7 +5709,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5817,6 +5827,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -8200,7 +8211,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8616,7 +8628,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1430,7 +1430,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2140,12 +2144,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2170,7 +2174,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2213,6 +2217,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2224,7 +2229,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2326,7 +2331,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2663,7 +2668,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2741,7 +2746,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2783,7 +2788,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3143,7 +3148,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3326,7 +3331,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3402,6 +3407,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3425,6 +3431,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3435,6 +3442,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3446,6 +3454,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3541,7 +3550,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3630,6 +3639,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.
@@ -3791,6 +3801,7 @@ packet_request_network_settings:
 
 packet_game_test_request:
    !id: 0xc2
+   !bound: server
    # MaxTestsPerBatch ...
    max_tests_per_batch: varint
    # Repetitions represents the amount of times the test will be run.
@@ -3815,6 +3826,7 @@ packet_game_test_request:
 # test was successful or not, and an error string if the test failed.
 packet_game_test_results:
    !id: 0xc3
+   !bound: client
    # Succeeded indicates whether the test succeeded or not.
    succeeded: bool
    # Error is the error that occurred. If Succeeded is true, this field is empty.

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -962,7 +962,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1012,6 +1015,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2403,6 +2407,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2685,7 +2690,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2149,7 +2149,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2788,7 +2788,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -6480,7 +6480,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7885,7 +7896,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7907,7 +7919,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -4316,7 +4316,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7733,7 +7739,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -5727,7 +5727,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5835,6 +5845,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -8218,7 +8229,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8634,7 +8646,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -4316,13 +4316,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7739,13 +7733,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1441,7 +1441,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2152,12 +2156,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2182,7 +2186,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2225,6 +2229,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2236,7 +2241,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2338,7 +2343,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2676,7 +2681,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2754,7 +2759,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2796,7 +2801,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3156,7 +3161,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3339,7 +3344,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3415,6 +3420,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3438,6 +3444,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3448,6 +3455,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3459,6 +3467,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3554,7 +3563,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3643,6 +3652,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.
@@ -3804,6 +3814,7 @@ packet_request_network_settings:
 
 packet_game_test_request:
    !id: 0xc2
+   !bound: server
    # MaxTestsPerBatch ...
    max_tests_per_batch: varint
    # Repetitions represents the amount of times the test will be run.
@@ -3828,6 +3839,7 @@ packet_game_test_request:
 # test was successful or not, and an error string if the test failed.
 packet_game_test_results:
    !id: 0xc3
+   !bound: client
    # Succeeded indicates whether the test succeeded or not.
    succeeded: bool
    # Error is the error that occurred. If Succeeded is true, this field is empty.

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2161,7 +2161,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2801,7 +2801,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -973,7 +973,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1023,6 +1026,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2415,6 +2419,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2698,7 +2703,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -4357,13 +4357,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7802,13 +7796,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -5786,7 +5786,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5894,6 +5904,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -8281,7 +8292,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8697,7 +8709,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -6539,7 +6539,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7948,7 +7959,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7970,7 +7982,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -4357,7 +4357,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7796,7 +7802,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -4363,7 +4363,13 @@
         },
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],
@@ -7807,7 +7813,13 @@
       [
         {
           "name": "tokens",
-          "type": "LoginTokens"
+          "type": [
+            "encapsulated",
+            {
+              "lengthType": "varint",
+              "type": "LoginTokens"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -4363,13 +4363,7 @@
         },
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],
@@ -7813,13 +7807,7 @@
       [
         {
           "name": "tokens",
-          "type": [
-            "encapsulated",
-            {
-              "lengthType": "varint",
-              "type": "LoginTokens"
-            }
-          ]
+          "type": "LoginTokens"
         }
       ]
     ],

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -5796,7 +5796,17 @@
         },
         {
           "name": "event_id",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "add",
+                "2": "update",
+                "3": "remove"
+              }
+            }
+          ]
         },
         {
           "name": "effect_id",
@@ -5904,6 +5914,7 @@
               "mappings": {
                 "3": "leave_vehicle",
                 "4": "mouse_over_entity",
+                "5": "npc_open",
                 "6": "open_inventory"
               }
             }
@@ -8292,7 +8303,8 @@
               "type": "u8",
               "mappings": {
                 "0": "combine",
-                "1": "react"
+                "1": "react",
+                "2": "reset"
               }
             }
           ]
@@ -8708,7 +8720,16 @@
         },
         {
           "name": "action",
-          "type": "u8"
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "none",
+                "2": "close"
+              }
+            }
+          ]
         },
         {
           "name": "resolution_x",

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -6549,7 +6549,18 @@
       [
         {
           "name": "event_type",
-          "type": "lu16"
+          "type": [
+            "mapper",
+            {
+              "type": "lu16",
+              "mappings": {
+                "0": "uninitialized_subtype",
+                "1": "enable_commands",
+                "2": "disable_commands",
+                "3": "unlock_world_template_settings"
+              }
+            }
+          ]
         }
       ]
     ],
@@ -7959,7 +7970,8 @@
                 "2": "execute_closing_commands",
                 "3": "set_name",
                 "4": "set_skin",
-                "5": "set_interaction_text"
+                "5": "set_interaction_text",
+                "6": "execute_opening_commands"
               }
             }
           ]
@@ -7981,7 +7993,7 @@
                 "3": "set_name",
                 "4": "set_skin",
                 "5": "set_interact_text",
-                "6": "execute_openining_commands"
+                "6": "execute_opening_commands"
               }
             }
           ]

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -1445,7 +1445,11 @@ packet_player_list:
 packet_simple_event:
    !id: 0x40
    !bound: client
-   event_type: lu16
+   event_type: lu16 =>
+      0: uninitialized_subtype
+      1: enable_commands
+      2: disable_commands
+      3: unlock_world_template_settings
 
 # Event is sent by the server to send an event with additional data. It is typically sent to the client for
 # telemetry reasons, much like the SimpleEvent packet.
@@ -2157,12 +2161,12 @@ packet_player_skin:
 # connects sends a SubClientLogin to request their own login.
 packet_sub_client_login:
    !id: 0x5e
-   !bound: client
+   !bound: server
    # ConnectionRequest is a string containing information about the player and JWTs that may be used to
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
+   tokens: LoginTokens
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2187,7 +2191,7 @@ packet_set_last_hurt_by:
 # player stops its typing 'session', rather than simply after closing the book.
 packet_book_edit:
    !id: 0x61
-   !bound: client
+   !bound: server
    type: u8 =>
       0: replace_page
       1: add_page
@@ -2230,6 +2234,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interaction_text
+      6: execute_opening_commands
    # CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
    # what the player set in it.
    command: string
@@ -2241,7 +2246,7 @@ packet_npc_request:
       3: set_name
       4: set_skin
       5: set_interact_text
-      6: execute_openining_commands
+      6: execute_opening_commands
    # SceneName is the name of the scene.
    scene_name: string
 
@@ -2343,7 +2348,7 @@ packet_show_profile:
 # in the settings UI.
 packet_set_default_game_type:
    !id: 0x69
-   !bound: client
+   !bound: server
    # GameType is the new game type that is set. When sent by the client, this is the requested new default
    # game type.
    gamemode: GameMode
@@ -2681,7 +2686,7 @@ packet_level_event_generic:
 # or if the book should be removed from it.
 packet_lectern_update:
    !id: 0x7d
-   !bound: client
+   !bound: server
    # Page is the page number in the book that was opened by the player on the lectern.
    page: u8
    # PageCount is the number of pages that the book opened in the lectern has.
@@ -2759,7 +2764,7 @@ packet_map_create_locked_copy:
 # StructureTemplateDataRequest is sent by the client to request data of a structure.
 packet_structure_template_data_export_request:
    !id: 0x84
-   !bound: client
+   !bound: server
    # StructureName is the name of the structure that was set in the structure block's UI. This is the name
    # used to export the structure to a file.
    name: string
@@ -2801,7 +2806,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: client
+   !bound: serverbound
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet
@@ -3167,7 +3172,7 @@ ArmorDamageType: [ "bitflags",
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:
    !id: 0x97
-   !bound: server
+   !bound: client
    # GameType is the new game type of the player. It is one of the constants that can be found in
    # set_player_game_type.go. Some of these game types require additional flags to be set in an
    # AdventureSettings packet for the game mode to obtain its full functionality.
@@ -3350,7 +3355,7 @@ packet_item_component:
 # safer version of the text.
 packet_filter_text_packet:
    !id: 0xa3
-   !bound: client
+   !bound: both
    # Text is either the text from the client or the safer version of the text sent by the server.
    text: string
    # FromServer indicates if the packet was sent by the server or not.
@@ -3426,6 +3431,7 @@ packet_simulation_type:
 # NPCDialogue is a packet that allows the client to display dialog boxes for interacting with NPCs.
 packet_npc_dialogue:
    !id: 0xa9
+   !bound: client
    # ActorUniqueID is the ID of the NPC being requested.
    entity_id: lu64
    # ActionType is the type of action for the packet.
@@ -3449,6 +3455,7 @@ packet_edu_uri_resource_packet:
 # This packet only works on the Education Edition version of Minecraft.
 packet_create_photo:
    !id: 0xab
+   !bound: client
    # EntityUniqueID is the unique ID of the entity.
    entity_unique_id: li64
    # PhotoName is the name of the photo.
@@ -3459,6 +3466,7 @@ packet_create_photo:
 # UpdateSubChunkBlocks is essentially just UpdateBlock packet, however for a set of blocks in a sub chunk.
 packet_update_subchunk_blocks:
    !id: 0xac
+   !bound: client
    # SubChunkX, SubChunkY, and SubChunkZ help identify the sub chunk.
    x: zigzag32
    y: zigzag32
@@ -3470,6 +3478,7 @@ packet_update_subchunk_blocks:
 
 packet_photo_info_request:
    !id: 0xad
+   !bound: server
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
@@ -3565,7 +3574,7 @@ packet_script_message:
 # CodeBuilderSource is an Education Edition packet sent by the client to the server to run an operation with a
 packet_code_builder_source:
    !id: 0xb2
-   !bound: client
+   !bound: server
    # Operation is used to distinguish the operation performed. It is always one of the constants listed above.
    operation: u8 =>
    - none
@@ -3654,6 +3663,7 @@ packet_change_mob_property:
 # This packet only functions on the Minecraft: Education Edition version of the game.
 packet_lesson_progress:
    !id: 0xb7
+   !bound: client
    # Action is the action the client should perform to show progress. This is one of the constants defined above.
    action: u8
    # Score is the score the client should use when displaying the progress.
@@ -3815,6 +3825,7 @@ packet_request_network_settings:
 
 packet_game_test_request:
    !id: 0xc2
+   !bound: server
    # MaxTestsPerBatch ...
    max_tests_per_batch: varint
    # Repetitions represents the amount of times the test will be run.
@@ -3839,6 +3850,7 @@ packet_game_test_request:
 # test was successful or not, and an error string if the test failed.
 packet_game_test_results:
    !id: 0xc3
+   !bound: client
    # Succeeded indicates whether the test succeeded or not.
    succeeded: bool
    # Error is the error that occurred. If Succeeded is true, this field is empty.

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -57,7 +57,7 @@ packet_login:
    !bound: server
    # Protocol version (Big Endian!)
    protocol_version: i32
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 LoginTokens:
    # JSON array of JWT data: contains the display name, UUID and XUID
@@ -2166,7 +2166,7 @@ packet_sub_client_login:
    # verify if the player is connected to XBOX Live. The connection request also contains the necessary
    # client public key to initiate encryption.
    # The ConnectionRequest in this packet is identical to the one found in the Login packet.
-   tokens: LoginTokens
+   tokens: '["encapsulated", { "lengthType": "varint", "type": "LoginTokens" }]'
 
 # AutomationClientConnect is used to make the client connect to a websocket server. This websocket server has
 # the ability to execute commands on the behalf of the client and it can listen for certain events fired by
@@ -2806,7 +2806,7 @@ packet_update_block_properties:
 # what blobs it needs and which blobs it already has, in an ACK type system.
 packet_client_cache_blob_status:
    !id: 0x87
-   !bound: serverbound
+   !bound: server
    # The number of MISSes in this packet
    misses: varint
    # The number of HITs in this packet

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -977,7 +977,10 @@ packet_mob_effect:
    !id: 0x1c
    !bound: client
    runtime_entity_id: varint64
-   event_id: u8
+   event_id: u8 =>
+      1: add
+      2: update
+      3: remove
    effect_id: zigzag32
    amplifier: zigzag32
    particles: bool
@@ -1027,6 +1030,7 @@ packet_interact:
    action_id: u8 =>
       3: leave_vehicle
       4: mouse_over_entity
+      5: npc_open
       6: open_inventory
    # TargetEntityRuntimeID is the runtime ID of the entity that the player interacted with. This is empty
    # for the InteractActionOpenInventory action type.
@@ -2420,6 +2424,7 @@ packet_lab_table:
    action_type: u8 =>
       0: combine
       1: react
+      2: reset
    # Position is the position at which the lab table used was located.
    position: vec3i
    # ReactionType is the type of the reaction that took place as a result of the items put into the lab
@@ -2703,7 +2708,9 @@ packet_video_stream_connect:
    !bound: client
    server_uri: string
    frame_send_frequency: lf32
-   action: u8
+   action: u8 =>
+      1: none
+      2: close
    resolution_x: li32
    resolution_y: li32
 


### PR DESCRIPTION
- Added mappings to packet_simple_event, packet_mob_effect, packet_interact, packet_lab_table and packet_video_stream_connect
- Fixed packet_book_edit, packet_set_default_game_type, packet_lectern_update, packet_structure_template_data_export_request, packet_client_cache_blob_status, packet_update_player_game_type and packet_filter_text_packet having the wrong bound type
- Added bound to packet_npc_dialogue, packet_create_photo, packet_update_subchunk_blocks, packet_photo_info_request, packet_lesson_progress, packet_game_test_request and packet_game_test_results so they dont show up as a DataType
- Fixed spelling mistake with execute_opening_commands (matched with reverse engineered bds enums to verify its correct)