### PR TITLE
Fix pages build failing due to bundle size

### DIFF
--- a/buildBundle.js
+++ b/buildBundle.js
@@ -1,0 +1,25 @@
+const fs = require('fs')
+const browserify = require('browserify')
+const through = require('through')
+
+const blockedFiles = ['steve.json', 'blockMappings.json', 'blockCollisionShapes.json', 'blocksJ2B.json', 'blocksB2J.json']
+const stubs = { 'blockCollisionShapes.json': '{"blocks":{},"shapes":{}}' }
+
+const bundle = fs.createWriteStream('bundle.js')
+const bundler = browserify()
+bundler.transform(function (file, options) {
+  for (const blockedFile of blockedFiles) {
+    if (file.endsWith(blockedFile)) {
+      console.log('Blocked', file)
+      return through(function write() {
+        // no op
+      }, function end () {
+        this.queue(stubs[blockedFile] || '[]')
+        this.queue(null)
+      })
+    }
+  }
+  return through()
+}, { global: true })
+bundler.add('./index.js')
+bundler.bundle().pipe(bundle)

--- a/buildBundle.js
+++ b/buildBundle.js
@@ -11,7 +11,7 @@ bundler.transform(function (file, options) {
   for (const blockedFile of blockedFiles) {
     if (file.endsWith(blockedFile)) {
       console.log('Blocked', file)
-      return through(function write() {
+      return through(function write () {
         // no op
       }, function end () {
         this.queue(stubs[blockedFile] || '[]')

--- a/loadProtocol.js
+++ b/loadProtocol.js
@@ -292,10 +292,13 @@ function eqs (compareTo, k) {
   }, compareTo + ' == ' + k[0])
 }
 
+const dataPaths = require('minecraft-data/minecraft-data/data/dataPaths.json')
+
 function loadProtocol (version) {
   if (version.startsWith('bedrock')) {
     const [, v] = version.split('_')
-    $j('#protocolTable').html(`<html-view src="protocol/bedrock/${v}"><a href="protocol/bedrock/${v}">Click here</a></html-view>`)
+    const path = dataPaths.bedrock[v].protocol
+    $j('#protocolTable').html(`<html-view src="protocol/${path}"><a href="protocol/${path}">Click here</a></html-view>`)
   } else {
     const data = require('minecraft-data')(version).protocol
     const comments = require('minecraft-data')(version).protocolComments

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run lint",
     "lint": "standard",
     "fix": "standard --fix",
-    "build": "browserify index.js -i **/blocks_models.json -i **/steve.json -i **/blockMappings.json -i **/blockCollisionShapes.json -i **/blocksJ2B.json -i **/blocksB2J.json --full-paths -o bundle.js && node compileProtocol.js",
+    "build": "node buildBundle.js && node compileProtocol.js",
     "minify": "NODE_OPTIONS=--max_old_space_size=4096 uglifyjs bundle.js -o bundle.js",
     "start": "beefy index.js:bundle.js 9998",
     "prod-start": "http-server .",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "npm run lint",
     "lint": "standard",
-    "build": "browserify index.js -o bundle.js && node compileProtocol.js",
+    "fix": "standard --fix",
+    "build": "browserify index.js -i **/blocks_models.json -i **/steve.json -i **/blockMappings.json -i **/blockCollisionShapes.json -i **/blocksJ2B.json -i **/blocksB2J.json --full-paths -o bundle.js && node compileProtocol.js",
     "minify": "NODE_OPTIONS=--max_old_space_size=4096 uglifyjs bundle.js -o bundle.js",
     "start": "beefy index.js:bundle.js 9998",
     "prod-start": "http-server .",

--- a/showValues.js
+++ b/showValues.js
@@ -78,7 +78,7 @@ function loadBiomes (version) {
   loadData(version, 'biomes',
     function (e) {
       return [e['id'], '<a href="#' + e['name'] + '">' + e['name'] + '</a>',
-        e['color'] === undefined ? '' : e['color'], e['temperature'], e['rainfall']]
+        e['color'] === undefined ? '' : e['color'], e['temperature'], e['rainfall'] ?? 'N/A']
     },
     ['id', 'name', 'color', 'temperature', 'rainfall'],
     []

--- a/showValues.js
+++ b/showValues.js
@@ -78,7 +78,7 @@ function loadBiomes (version) {
   loadData(version, 'biomes',
     function (e) {
       return [e['id'], '<a href="#' + e['name'] + '">' + e['name'] + '</a>',
-        e['color'] === undefined ? '' : e['color'], e['temperature'], e['rainfall'] ?? 'N/A']
+        e['color'] === undefined ? '' : e['color'], e['temperature'], e.rainfall == null ? 'N/A' : e.rainfall]
     },
     ['id', 'name', 'color', 'temperature', 'rainfall'],
     []


### PR DESCRIPTION
Shrinks the uncompressed bundle size ~2x by removing big `['steve.json', 'blockMappings.json', 'blockCollisionShapes.json', 'blocksJ2B.json', 'blocksB2J.json']` files which are not currently used in the pages build via a browserify transform. In a production web server with compression the bundle size is now 8MB

`-rw-r--r--   1 gitpod gitpod 131M Jun 10 02:20 bundle.js` old with all JSON data
`-rw-r--r--   1 gitpod gitpod  75M Jun 10 02:41 bundle3.js` new stripped
`-rw-r--r--   1 gitpod gitpod  47M Jun 10 02:45 bundle3.min.js` new minified, safely storable in repo (<100mb)
`-rw-r--r--   1 gitpod gitpod   8M Jun 10 02:46 bundle3.zip` new with gzip

Also fixes an issue with pc 1.19.4 biomes causing table gen errors and some bedrock protocol links being 404