### PR TITLE
Fix bedrock-protocol relay crashing when emoting

### DIFF
--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -8997,7 +8997,7 @@
         },
         {
           "name": "platform_id",
-          "type": "DeviceOS"
+          "type": "string"
         },
         {
           "name": "flags",

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -2867,7 +2867,7 @@ packet_emote:
    xuid: string
    # PlatformID is an identifier only set for particular platforms when using an emote (presumably only for Nintendo
    # Switch). It is otherwise an empty string, and is used to decide which players are able to emote with each other.
-   platform_id: DeviceOS
+   platform_id: string
    # Flags is a combination of flags that change the way the Emote packet operates. When the server sends
    # this packet to other players, EmoteFlagServerSide must be present.
    flags: u8 =>


### PR DESCRIPTION
Emote Packet's platform_id is set to be a DeviceOS, however this crashes the relay as it should've been a string. 

After changing this, I was able to emote without the relay crashing