### PR TITLE
Update bedrock subchunk_request.requests and packet_subchunk.entries for 1.18.11+

### DIFF
--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -3301,9 +3301,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3323,9 +3323,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3364,9 +3364,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 packet_client_start_item_cooldown:
    !id: 0xb0

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -9283,15 +9283,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9361,15 +9361,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9496,15 +9496,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -3319,9 +3319,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3341,9 +3341,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3384,9 +3384,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -9392,15 +9392,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9470,15 +9470,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9605,15 +9605,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -3338,9 +3338,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3360,9 +3360,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3403,9 +3403,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -9457,15 +9457,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9535,15 +9535,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9670,15 +9670,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -3389,9 +3389,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3411,9 +3411,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3454,9 +3454,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -9525,15 +9525,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9603,15 +9603,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9738,15 +9738,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -3426,9 +3426,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3448,9 +3448,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3491,9 +3491,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -9690,15 +9690,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9768,15 +9768,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9903,15 +9903,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -3426,9 +3426,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3448,9 +3448,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3491,9 +3491,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -9690,15 +9690,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9768,15 +9768,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9903,15 +9903,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -3441,9 +3441,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3463,9 +3463,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3506,9 +3506,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -9819,15 +9819,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9897,15 +9897,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10032,15 +10032,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -3451,9 +3451,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3473,9 +3473,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3516,9 +3516,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -9888,15 +9888,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9966,15 +9966,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10101,15 +10101,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -3453,9 +3453,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3475,9 +3475,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3518,9 +3518,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -9906,15 +9906,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9984,15 +9984,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10119,15 +10119,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -3460,9 +3460,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3482,9 +3482,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3525,9 +3525,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -9960,15 +9960,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10038,15 +10038,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10173,15 +10173,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -3461,9 +3461,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3483,9 +3483,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3526,9 +3526,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -9964,15 +9964,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10042,15 +10042,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10177,15 +10177,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -3465,9 +3465,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3487,9 +3487,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3530,9 +3530,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -9986,15 +9986,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10064,15 +10064,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10199,15 +10199,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -3478,9 +3478,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3500,9 +3500,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3543,9 +3543,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -10049,15 +10049,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10127,15 +10127,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10262,15 +10262,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -10068,15 +10068,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10146,15 +10146,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10281,15 +10281,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3489,9 +3489,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3511,9 +3511,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3554,9 +3554,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.


### PR DESCRIPTION

The type for `dx`, `dy`, `dz` for the client `subchunk_request` and server `subchunk` packets should be a signed byte. 

`u8` was changed to `i8` in `proto.yml`, compiled, and tested against vanilla bedrock servers for all supported versions.