### PR TITLE
Fixed typo in dataPaths.json for bedrock 1.19.21

### DIFF
--- a/data/dataPaths.json
+++ b/data/dataPaths.json
@@ -1524,7 +1524,7 @@
       "materials": "pc/1.17",
       "enchantments": "bedrock/1.19.1",
       "effects": "pc/1.17",
-      "protocol": "bedrock/1.19.20",
+      "protocol": "bedrock/1.19.21",
       "windows": "bedrock/1.16.201",
       "steve": "bedrock/1.16.201",
       "blocksB2J": "bedrock/1.19.1",


### PR DESCRIPTION

Fixed a typo that causes `1.19.21` to use the `protocol.json` of `1.19.20`.

This is somewhat pointless since the compiled `protocol.json` files for `1.19.20` and `1.19.21` are identical
