### PR TITLE
Bedrock protocol changes for 1.17.0 to 1.20.0

### DIFF
--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -2271,7 +2271,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -772,7 +772,7 @@
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -7229,7 +7229,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -7242,7 +7242,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -7255,7 +7255,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -7268,7 +7268,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -7281,7 +7281,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.16.210/types.yml
+++ b/data/bedrock/1.16.210/types.yml
@@ -416,7 +416,7 @@ TransactionUseItem:
    block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -2723,7 +2723,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -936,11 +936,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8072,7 +8072,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8085,7 +8085,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8098,7 +8098,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8111,7 +8111,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8124,7 +8124,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.16.220/types.yml
+++ b/data/bedrock/1.16.220/types.yml
@@ -465,10 +465,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -2725,7 +2725,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -939,11 +939,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8151,7 +8151,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8164,7 +8164,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8177,7 +8177,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8190,7 +8190,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8203,7 +8203,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.17.0/types.yml
+++ b/data/bedrock/1.17.0/types.yml
@@ -468,10 +468,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -2822,7 +2822,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -939,11 +939,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8267,7 +8267,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8280,7 +8280,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8293,7 +8293,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8306,7 +8306,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8319,7 +8319,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.17.10/types.yml
+++ b/data/bedrock/1.17.10/types.yml
@@ -468,10 +468,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -2851,7 +2851,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -939,11 +939,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8467,7 +8467,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8480,7 +8480,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8493,7 +8493,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8506,7 +8506,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8519,7 +8519,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.17.30/types.yml
+++ b/data/bedrock/1.17.30/types.yml
@@ -468,10 +468,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -2851,7 +2851,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -939,11 +939,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8468,7 +8468,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8481,7 +8481,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8494,7 +8494,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8507,7 +8507,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8520,7 +8520,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.17.40/types.yml
+++ b/data/bedrock/1.17.40/types.yml
@@ -468,10 +468,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -2858,7 +2858,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -939,11 +939,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8513,7 +8513,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8526,7 +8526,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8539,7 +8539,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8552,7 +8552,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8565,7 +8565,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.18.0/types.yml
+++ b/data/bedrock/1.18.0/types.yml
@@ -468,10 +468,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -2865,7 +2865,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -3301,9 +3301,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3323,9 +3323,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3364,9 +3364,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 packet_client_start_item_cooldown:
    !id: 0xb0

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -9283,15 +9283,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9361,15 +9361,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9496,15 +9496,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -939,11 +939,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8571,7 +8571,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8584,7 +8584,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8597,7 +8597,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8610,7 +8610,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8623,7 +8623,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.18.11/types.yml
+++ b/data/bedrock/1.18.11/types.yml
@@ -472,10 +472,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -3319,9 +3319,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3341,9 +3341,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3384,9 +3384,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -2879,7 +2879,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -9392,15 +9392,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9470,15 +9470,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9605,15 +9605,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -943,11 +943,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8660,7 +8660,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8673,7 +8673,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8686,7 +8686,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8699,7 +8699,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8712,7 +8712,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.18.30/types.yml
+++ b/data/bedrock/1.18.30/types.yml
@@ -480,10 +480,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -2898,7 +2898,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -3338,9 +3338,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3360,9 +3360,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3403,9 +3403,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -943,11 +943,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8725,7 +8725,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8738,7 +8738,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8751,7 +8751,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8764,7 +8764,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8777,7 +8777,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -9457,15 +9457,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9535,15 +9535,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9670,15 +9670,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.1/types.yml
+++ b/data/bedrock/1.19.1/types.yml
@@ -480,10 +480,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -3389,9 +3389,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3411,9 +3411,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3454,9 +3454,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -2949,7 +2949,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -943,11 +943,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8793,7 +8793,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8806,7 +8806,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8819,7 +8819,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8832,7 +8832,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8845,7 +8845,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -9525,15 +9525,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9603,15 +9603,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9738,15 +9738,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.10/types.yml
+++ b/data/bedrock/1.19.10/types.yml
@@ -480,10 +480,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -2986,7 +2986,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -3426,9 +3426,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3448,9 +3448,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3491,9 +3491,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -9690,15 +9690,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9768,15 +9768,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9903,15 +9903,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -981,11 +981,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8958,7 +8958,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8971,7 +8971,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8984,7 +8984,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8997,7 +8997,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9010,7 +9010,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.20/types.yml
+++ b/data/bedrock/1.19.20/types.yml
@@ -487,10 +487,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -2986,7 +2986,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -3426,9 +3426,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3448,9 +3448,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3491,9 +3491,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -9690,15 +9690,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9768,15 +9768,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9903,15 +9903,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -981,11 +981,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -8958,7 +8958,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8971,7 +8971,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8984,7 +8984,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -8997,7 +8997,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9010,7 +9010,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.21/types.yml
+++ b/data/bedrock/1.19.21/types.yml
@@ -487,10 +487,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -3441,9 +3441,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3463,9 +3463,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3506,9 +3506,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -3001,7 +3001,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -981,11 +981,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -9087,7 +9087,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9100,7 +9100,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9113,7 +9113,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9126,7 +9126,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9139,7 +9139,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -9819,15 +9819,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9897,15 +9897,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10032,15 +10032,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.30/types.yml
+++ b/data/bedrock/1.19.30/types.yml
@@ -487,10 +487,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -3011,7 +3011,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -3451,9 +3451,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3473,9 +3473,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3516,9 +3516,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -1030,11 +1030,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -9156,7 +9156,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9169,7 +9169,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9182,7 +9182,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9195,7 +9195,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9208,7 +9208,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -9888,15 +9888,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9966,15 +9966,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10101,15 +10101,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.40/types.yml
+++ b/data/bedrock/1.19.40/types.yml
@@ -495,10 +495,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -3013,7 +3013,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -3453,9 +3453,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3475,9 +3475,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3518,9 +3518,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -9906,15 +9906,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -9984,15 +9984,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10119,15 +10119,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -1030,11 +1030,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -9174,7 +9174,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9187,7 +9187,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9200,7 +9200,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9213,7 +9213,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9226,7 +9226,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.50/types.yml
+++ b/data/bedrock/1.19.50/types.yml
@@ -499,10 +499,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -3460,9 +3460,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3482,9 +3482,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3525,9 +3525,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -3019,7 +3019,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -9960,15 +9960,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10038,15 +10038,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10173,15 +10173,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -1030,11 +1030,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -9228,7 +9228,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9241,7 +9241,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9254,7 +9254,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9267,7 +9267,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9280,7 +9280,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.60/types.yml
+++ b/data/bedrock/1.19.60/types.yml
@@ -499,10 +499,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -3020,7 +3020,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -3461,9 +3461,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3483,9 +3483,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3526,9 +3526,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -1030,11 +1030,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -9232,7 +9232,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9245,7 +9245,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9258,7 +9258,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9271,7 +9271,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9284,7 +9284,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -9964,15 +9964,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10042,15 +10042,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10177,15 +10177,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.62/types.yml
+++ b/data/bedrock/1.19.62/types.yml
@@ -499,10 +499,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -3465,9 +3465,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3487,9 +3487,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3530,9 +3530,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -3020,7 +3020,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -9986,15 +9986,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10064,15 +10064,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10199,15 +10199,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -1030,11 +1030,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -9250,7 +9250,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9263,7 +9263,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9276,7 +9276,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9289,7 +9289,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9302,7 +9302,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.70/types.yml
+++ b/data/bedrock/1.19.70/types.yml
@@ -503,10 +503,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -3033,7 +3033,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -3478,9 +3478,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3500,9 +3500,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3543,9 +3543,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -1030,11 +1030,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -9313,7 +9313,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9326,7 +9326,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9339,7 +9339,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9352,7 +9352,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9365,7 +9365,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -10049,15 +10049,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10127,15 +10127,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10262,15 +10262,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.19.80/types.yml
+++ b/data/bedrock/1.19.80/types.yml
@@ -503,10 +503,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -10068,15 +10068,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10146,15 +10146,15 @@
           [
             {
               "name": "dx",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dy",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "dz",
-              "type": "u8"
+              "type": "i8"
             },
             {
               "name": "result",
@@ -10281,15 +10281,15 @@
                 [
                   {
                     "name": "dx",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dy",
-                    "type": "u8"
+                    "type": "i8"
                   },
                   {
                     "name": "dz",
-                    "type": "u8"
+                    "type": "i8"
                   }
                 ]
               ]

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -1030,11 +1030,11 @@
         },
         {
           "name": "block_position",
-          "type": "vec3i"
+          "type": "BlockCoordinates"
         },
         {
           "name": "face",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "hotbar_slot",
@@ -9332,7 +9332,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9345,7 +9345,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9358,7 +9358,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9371,7 +9371,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",
@@ -9384,7 +9384,7 @@
                                   [
                                     {
                                       "name": "position",
-                                      "type": "BlockCoordinates"
+                                      "type": "vec3i"
                                     },
                                     {
                                       "name": "face",

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3044,7 +3044,7 @@ packet_player_auth_input:
             if start_break or abort_break or crack_break or predict_break or continue_break:
                # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
                # block. If that is not the case, the block position will be zero.
-               position: BlockCoordinates
+               position: vec3i
                # BlockFace is the face of the target block that was touched. If the action with the ActionType set
                # concerned a block. If not, the face is always 0.
                face: zigzag32

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3489,9 +3489,9 @@ packet_photo_info_request:
    photo_id: zigzag64
 
 SubChunkEntryWithoutCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3511,9 +3511,9 @@ SubChunkEntryWithoutCaching: []lu32
       if has_data: '["buffer", { "count": 256 }]'
 
 SubChunkEntryWithCaching: []lu32
-   dx: u8
-   dy: u8
-   dz: u8
+   dx: i8
+   dy: i8
+   dz: i8
    result: u8 =>
       0: undefined
       1: success
@@ -3554,9 +3554,9 @@ packet_subchunk_request:
    # Origin point
    origin: vec3i
    requests: []lu32
-      dx: u8
-      dy: u8
-      dz: u8
+      dx: i8
+      dy: i8
+      dz: i8
 
 # ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
 # packet isn't entirely clear.

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -503,10 +503,10 @@ TransactionUseItem:
       2: break_block
    # BlockPosition is the position of the block that was interacted with. This is only really a correct
    # block position if ActionType is not UseItemActionClickAir.
-   block_position: vec3i
+   block_position: BlockCoordinates
    # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
    # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-   face: varint
+   face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
    hotbar_slot: varint


### PR DESCRIPTION

The following changes affects all versions of bedrock, and is needed for breaking blocks, interacting with containers, etc. when server authoritative movement is enabled.

### TransactionUseItem

The `block_position.y` value in`packet_player_auth_input.transaction.data` needs to be a `varint`, and `packet_player_auth_input.transaction.data.face` needs to be `zigzag32` 
- The type for `block_position` was changed from `vec3i` to `BlockCoordinates`  in `types.yml`
- The type for `face` was changed from `varint` to `zigzag32` in `types.yml`

### Action

The `position.y` value in `packet_player_auth_input.block_action[]` needs to be `zigzag32` for all actions
- The type for `position` was changed from `BlockCoordinates` to `vec3i` in `proto.yml`

The updates was tested for for all supported 1.17.0+ versions against vanilla bedrock servers.

The 1.16.x versions was skipped due to issues that needs to be resolved first:

- 1.16.201 - Broken block palette, protocol runtime errors. Relay gets kicked due to `packet_violation_warning`
- 1.16.210 - Broken block palette, protocol runtime errors. 
- 1.16.220 - This version actually works, but guess there is no point in including just this one.
