### PR TITLE
Changes to 1.19.3, 1.19.4 and 1.20 protocols

### DIFF
--- a/data/pc/1.19.3/protocol.json
+++ b/data/pc/1.19.3/protocol.json
@@ -4377,6 +4377,34 @@
               "type": "varint"
             },
             {
+              "name": "soundEvent",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "soundId",
+                  "fields": {
+                    "0": [
+                      "container",
+                      [
+                        {
+                          "name": "resource",
+                          "type": "string"
+                        },
+                        {
+                          "name": "range",
+                          "type": [
+                            "option",
+                            "f32"
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
               "name": "soundCategory",
               "type": "varint"
             },
@@ -4441,6 +4469,34 @@
             {
               "name": "soundId",
               "type": "varint"
+            },
+            {
+              "name": "soundEvent",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "soundId",
+                  "fields": {
+                    "0": [
+                      "container",
+                      [
+                        {
+                          "name": "resource",
+                          "type": "string"
+                        },
+                        {
+                          "name": "range",
+                          "type": [
+                            "option",
+                            "f32"
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  "default": "void"
+                }
+              ]
             },
             {
               "name": "soundCategory",

--- a/data/pc/1.19.4/protocol.json
+++ b/data/pc/1.19.4/protocol.json
@@ -4563,6 +4563,34 @@
               "type": "varint"
             },
             {
+              "name": "soundEvent",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "soundId",
+                  "fields": {
+                    "0": [
+                      "container",
+                      [
+                        {
+                          "name": "resource",
+                          "type": "string"
+                        },
+                        {
+                          "name": "range",
+                          "type": [
+                            "option",
+                            "f32"
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
               "name": "soundCategory",
               "type": "varint"
             },
@@ -4627,6 +4655,34 @@
             {
               "name": "soundId",
               "type": "varint"
+            },
+            {
+              "name": "soundEvent",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "soundId",
+                  "fields": {
+                    "0": [
+                      "container",
+                      [
+                        {
+                          "name": "resource",
+                          "type": "string"
+                        },
+                        {
+                          "name": "range",
+                          "type": [
+                            "option",
+                            "f32"
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  "default": "void"
+                }
+              ]
             },
             {
               "name": "soundCategory",

--- a/data/pc/1.20/protocol.json
+++ b/data/pc/1.20/protocol.json
@@ -4559,6 +4559,34 @@
               "type": "varint"
             },
             {
+              "name": "soundEvent",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "soundId",
+                  "fields": {
+                    "0": [
+                      "container",
+                      [
+                        {
+                          "name": "resource",
+                          "type": "string"
+                        },
+                        {
+                          "name": "range",
+                          "type": [
+                            "option",
+                            "f32"
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  "default": "void"
+                }
+              ]
+            },
+            {
               "name": "soundCategory",
               "type": "varint"
             },
@@ -4623,6 +4651,34 @@
             {
               "name": "soundId",
               "type": "varint"
+            },
+            {
+              "name": "soundEvent",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "soundId",
+                  "fields": {
+                    "0": [
+                      "container",
+                      [
+                        {
+                          "name": "resource",
+                          "type": "string"
+                        },
+                        {
+                          "name": "range",
+                          "type": [
+                            "option",
+                            "f32"
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  "default": "void"
+                }
+              ]
             },
             {
               "name": "soundCategory",


### PR DESCRIPTION
Changes to 1.19.3, 1.19.4 and 1.20 protocols to fix `packet_entity_sound_effect` and `packet_sound_effect` to include optional `soundEvent` argument

In short, this fixes an issue where regular `sound_effect` packets get parsed correctly, but there is an issue when you use `/playsound`, something like this:
```
Chunk size is 74 but only 31 was read ; partial packet : {"name":"sound_effect","params":{"soundId":0,"soundCategory":41,"x":1835626085,"y":1668440422,"z":1949983085,"volume":1.0763500371048986e+21,"pitch":5.526458829699596e+31,"seed":[1935764596,1600415084]}}; buffer :6200296d696e6563726166743a616d6269656e742e626173616c745f64656c7461732e6164646974696f6e730008fffffdca000001e80000000f3f8000003f80000084749d88a17d3b21
```

This change is similar to the one made by frej4189 https://github.com/PrismarineJS/minecraft-data/pull/685
However, it undoes the data type changes and implements the `soundEvent` argument for 1.19.3, 1.19.4 and 1.20, instead of just 1.19.3

This change was confirmed to work by me, if there's any issues, absolutely notify me and I will make the changes required!