### PR TITLE
damage_event packet fix

### DIFF
--- a/data/pc/1.19.4/protocol.json
+++ b/data/pc/1.19.4/protocol.json
@@ -5378,17 +5378,11 @@
             },
             {
               "name": "sourceCauseId",
-              "type": [
-                "option",
-                "varint"
-              ]
+              "type": "varint"
             },
             {
               "name": "sourceDirectId",
-              "type": [
-                "option",
-                "varint"
-              ]
+              "type": "varint"
             },
             {
               "name": "sourcePosition",

--- a/data/pc/1.20/protocol.json
+++ b/data/pc/1.20/protocol.json
@@ -5357,17 +5357,11 @@
             },
             {
               "name": "sourceCauseId",
-              "type": [
-                "option",
-                "varint"
-              ]
+              "type": "varint"
             },
             {
               "name": "sourceDirectId",
-              "type": [
-                "option",
-                "varint"
-              ]
+              "type": "varint"
             },
             {
               "name": "sourcePosition",


### PR DESCRIPTION
As can be seen here https://wiki.vg/Protocol#Damage_Event, `sourceCauseId` and `sourceDirectId` are not optional, they are always sent, just if not present set to 0.

This applies to both 1.20 and 1.19.4 when the packet was introduced. It caused node-minecraft-protocol to display a PartialReadError whenever the client was hit
