### PR TITLE
Particle data fixes

### DIFF
--- a/data/pc/1.19.2/protocol.json
+++ b/data/pc/1.19.2/protocol.json
@@ -175,6 +175,15 @@
               }
             ]
           ],
+          "30": [
+            "container",
+            [
+              {
+                "name": "rotation",
+                "type": "f32"
+              }
+            ]
+          ],
           "39": [
             "container",
             [
@@ -190,10 +199,6 @@
               {
                 "name": "positionType",
                 "type": "string"
-              },
-              {
-                "name": "origin",
-                "type": "position"
               },
               {
                 "name": "entityId",

--- a/data/pc/1.19.3/protocol.json
+++ b/data/pc/1.19.3/protocol.json
@@ -176,6 +176,15 @@
               }
             ]
           ],
+          "30": [
+            "container",
+            [
+              {
+                "name": "rotation",
+                "type": "f32"
+              }
+            ]
+          ],
           "39": [
             "container",
             [
@@ -191,10 +200,6 @@
               {
                 "name": "positionType",
                 "type": "string"
-              },
-              {
-                "name": "origin",
-                "type": "position"
               },
               {
                 "name": "entityId",

--- a/data/pc/1.19.4/protocol.json
+++ b/data/pc/1.19.4/protocol.json
@@ -231,6 +231,15 @@
               }
             ]
           ],
+          "33": [
+            "container",
+            [
+              {
+                "name": "rotation",
+                "type": "f32"
+              }
+            ]
+          ],
           "42": [
             "container",
             [
@@ -246,10 +255,6 @@
               {
                 "name": "positionType",
                 "type": "string"
-              },
-              {
-                "name": "origin",
-                "type": "position"
               },
               {
                 "name": "entityId",

--- a/data/pc/1.19/protocol.json
+++ b/data/pc/1.19/protocol.json
@@ -175,6 +175,15 @@
               }
             ]
           ],
+          "30": [
+            "container",
+            [
+              {
+                "name": "rotation",
+                "type": "f32"
+              }
+            ]
+          ],
           "39": [
             "container",
             [
@@ -190,10 +199,6 @@
               {
                 "name": "positionType",
                 "type": "string"
-              },
-              {
-                "name": "origin",
-                "type": "position"
               },
               {
                 "name": "entityId",

--- a/data/pc/1.20/protocol.json
+++ b/data/pc/1.20/protocol.json
@@ -231,7 +231,16 @@
               }
             ]
           ],
-          "42": [
+          "31": [
+            "container",
+            [
+              {
+                "name": "rotation",
+                "type": "f32"
+              }
+            ]
+          ],
+          "40": [
             "container",
             [
               {
@@ -240,16 +249,12 @@
               }
             ]
           ],
-          "43": [
+          "41": [
             "container",
             [
               {
                 "name": "positionType",
                 "type": "string"
-              },
-              {
-                "name": "origin",
-                "type": "position"
               },
               {
                 "name": "entityId",
@@ -296,7 +301,7 @@
               }
             ]
           ],
-          "95": [
+          "93": [
             "container",
             [
               {


### PR DESCRIPTION
As of 1.19 the `sculk_charge` particle was introduced, which this PR adds data for.

Additionally as of 1.19 the sculk sensor `vibration` particle uses the particle coordinates as it's origin, without having a special value for them now.

Also the particle IDs changed a bit in 1.20

I imagine this would fix https://github.com/PrismarineJS/node-minecraft-protocol/issues/1240