### PR TITLE
Fix values for enum type in available_commands packet

### DIFF
--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -1332,7 +1332,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -1352,9 +1352,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -5376,66 +5376,74 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "6": "target",
-                                        "14": "file_path",
-                                        "29": "string",
-                                        "37": "position",
-                                        "41": "message",
-                                        "43": "raw_text",
-                                        "46": "json",
-                                        "53": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "6": "target",
+                                              "14": "file_path",
+                                              "29": "string",
+                                              "37": "position",
+                                              "41": "message",
+                                              "43": "raw_text",
+                                              "46": "json",
+                                              "53": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -5418,9 +5418,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -1371,7 +1371,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -1391,9 +1391,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -5547,66 +5547,74 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "6": "target",
-                                        "16": "file_path",
-                                        "32": "string",
-                                        "40": "position",
-                                        "44": "message",
-                                        "46": "raw_text",
-                                        "50": "json",
-                                        "63": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "6": "target",
+                                              "16": "file_path",
+                                              "32": "string",
+                                              "40": "position",
+                                              "44": "message",
+                                              "46": "raw_text",
+                                              "50": "json",
+                                              "63": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -5589,9 +5589,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -1504,7 +1504,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -1524,9 +1524,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -6155,9 +6155,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -6113,66 +6113,74 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "6": "target",
-                                        "16": "file_path",
-                                        "32": "string",
-                                        "40": "position",
-                                        "44": "message",
-                                        "46": "raw_text",
-                                        "50": "json",
-                                        "63": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "6": "target",
+                                              "16": "file_path",
+                                              "32": "string",
+                                              "40": "position",
+                                              "44": "message",
+                                              "46": "raw_text",
+                                              "50": "json",
+                                              "63": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -1506,7 +1506,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -1526,9 +1526,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -6192,66 +6192,74 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "6": "target",
-                                        "16": "file_path",
-                                        "32": "string",
-                                        "40": "position",
-                                        "44": "message",
-                                        "46": "raw_text",
-                                        "50": "json",
-                                        "63": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "6": "target",
+                                              "16": "file_path",
+                                              "32": "string",
+                                              "40": "position",
+                                              "44": "message",
+                                              "46": "raw_text",
+                                              "50": "json",
+                                              "63": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -6234,9 +6234,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -1609,9 +1609,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -1589,7 +1589,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -6324,9 +6324,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -6282,66 +6282,74 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "6": "target",
-                                        "16": "file_path",
-                                        "32": "string",
-                                        "40": "position",
-                                        "44": "message",
-                                        "46": "raw_text",
-                                        "50": "json",
-                                        "63": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "6": "target",
+                                              "16": "file_path",
+                                              "32": "string",
+                                              "40": "position",
+                                              "44": "message",
+                                              "46": "raw_text",
+                                              "50": "json",
+                                              "63": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -1621,9 +1621,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -1601,7 +1601,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -6410,66 +6410,74 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "6": "target",
-                                        "16": "file_path",
-                                        "32": "string",
-                                        "40": "position",
-                                        "44": "message",
-                                        "46": "raw_text",
-                                        "50": "json",
-                                        "63": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "6": "target",
+                                              "16": "file_path",
+                                              "32": "string",
+                                              "40": "position",
+                                              "44": "message",
+                                              "46": "raw_text",
+                                              "50": "json",
+                                              "63": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -6452,9 +6452,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -1621,9 +1621,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -1601,7 +1601,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -6453,9 +6453,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -6411,66 +6411,74 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "6": "target",
-                                        "16": "file_path",
-                                        "32": "string",
-                                        "40": "position",
-                                        "44": "message",
-                                        "46": "raw_text",
-                                        "50": "json",
-                                        "63": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "6": "target",
+                                              "16": "file_path",
+                                              "32": "string",
+                                              "40": "position",
+                                              "44": "message",
+                                              "46": "raw_text",
+                                              "50": "json",
+                                              "63": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -1607,7 +1607,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -1627,9 +1627,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -6456,66 +6456,74 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "6": "target",
-                                        "16": "file_path",
-                                        "32": "string",
-                                        "40": "position",
-                                        "44": "message",
-                                        "46": "raw_text",
-                                        "50": "json",
-                                        "63": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "6": "target",
+                                              "16": "file_path",
+                                              "32": "string",
+                                              "40": "position",
+                                              "44": "message",
+                                              "46": "raw_text",
+                                              "50": "json",
+                                              "63": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -6498,9 +6498,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -1634,9 +1634,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -1614,7 +1614,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -6556,9 +6556,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -6514,66 +6514,74 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "6": "target",
-                                        "16": "file_path",
-                                        "32": "string",
-                                        "40": "position",
-                                        "44": "message",
-                                        "46": "raw_text",
-                                        "50": "json",
-                                        "63": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "6": "target",
+                                              "16": "file_path",
+                                              "32": "string",
+                                              "40": "position",
+                                              "44": "message",
+                                              "46": "raw_text",
+                                              "50": "json",
+                                              "63": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -1622,7 +1622,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -1644,9 +1644,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -6597,68 +6597,76 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "2": "float",
-                                        "3": "value",
-                                        "4": "wildcard_int",
-                                        "5": "operator",
-                                        "7": "target",
-                                        "9": "wildcard",
-                                        "16": "file_path",
-                                        "38": "string",
-                                        "46": "block_position",
-                                        "47": "position",
-                                        "50": "message",
-                                        "52": "raw_text",
-                                        "56": "json",
-                                        "69": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "2": "float",
+                                              "3": "value",
+                                              "4": "wildcard_int",
+                                              "5": "operator",
+                                              "7": "target",
+                                              "9": "wildcard",
+                                              "16": "file_path",
+                                              "38": "string",
+                                              "46": "block_position",
+                                              "47": "position",
+                                              "50": "message",
+                                              "52": "raw_text",
+                                              "56": "json",
+                                              "69": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -6641,9 +6641,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -1632,7 +1632,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -1658,9 +1658,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -6644,72 +6644,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -6692,9 +6692,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -1709,9 +1709,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -1683,7 +1683,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -6712,72 +6712,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -6760,9 +6760,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -1704,7 +1704,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -1730,9 +1730,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -6856,9 +6856,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -6808,72 +6808,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -1704,7 +1704,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -1730,9 +1730,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -6856,9 +6856,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -6808,72 +6808,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -1731,9 +1731,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -1705,7 +1705,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -6908,72 +6908,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -6956,9 +6956,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -1741,9 +1741,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -1715,7 +1715,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -7028,9 +7028,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -6980,72 +6980,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -1741,9 +1741,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -1715,7 +1715,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -7044,9 +7044,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -6996,72 +6996,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -1743,9 +1743,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -1717,7 +1717,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -7085,9 +7085,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -7037,72 +7037,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -1743,9 +1743,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -1717,7 +1717,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -7089,9 +7089,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -7041,72 +7041,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -1743,9 +1743,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -1717,7 +1717,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -7059,72 +7059,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "38": "equipment_slots",
-                                        "39": "string",
-                                        "47": "block_position",
-                                        "48": "position",
-                                        "51": "message",
-                                        "53": "raw_text",
-                                        "57": "json",
-                                        "67": "block_states",
-                                        "70": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "38": "equipment_slots",
+                                              "39": "string",
+                                              "47": "block_position",
+                                              "48": "position",
+                                              "51": "message",
+                                              "53": "raw_text",
+                                              "57": "json",
+                                              "67": "block_states",
+                                              "70": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -7107,9 +7107,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -1755,9 +1755,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -1729,7 +1729,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -7170,9 +7170,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -7122,72 +7122,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "43": "equipment_slots",
-                                        "44": "string",
-                                        "52": "block_position",
-                                        "53": "position",
-                                        "55": "message",
-                                        "58": "raw_text",
-                                        "62": "json",
-                                        "71": "block_states",
-                                        "74": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "43": "equipment_slots",
+                                              "44": "string",
+                                              "52": "block_position",
+                                              "53": "position",
+                                              "55": "message",
+                                              "58": "raw_text",
+                                              "62": "json",
+                                              "71": "block_states",
+                                              "74": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.20.0/proto.yml
+++ b/data/bedrock/1.20.0/proto.yml
@@ -1760,9 +1760,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)

--- a/data/bedrock/1.20.0/proto.yml
+++ b/data/bedrock/1.20.0/proto.yml
@@ -1734,7 +1734,7 @@ packet_available_commands:
       # The list of overload parameters for this command
       overloads: []varint
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -7133,72 +7133,80 @@
                       {
                         "countType": "varint",
                         "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
+                          "container",
+                          [
+                            {
+                              "name": "parameters",
+                              "type": [
+                                "array",
                                 {
-                                  "name": "parameter_name",
-                                  "type": "string"
-                                },
-                                {
-                                  "name": "value_type",
+                                  "countType": "varint",
                                   "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "1": "int",
-                                        "3": "float",
-                                        "4": "value",
-                                        "5": "wildcard_int",
-                                        "6": "operator",
-                                        "7": "command_operator",
-                                        "8": "target",
-                                        "10": "wildcard_target",
-                                        "17": "file_path",
-                                        "23": "integer_range",
-                                        "43": "equipment_slots",
-                                        "44": "string",
-                                        "52": "block_position",
-                                        "53": "position",
-                                        "55": "message",
-                                        "58": "raw_text",
-                                        "62": "json",
-                                        "71": "block_states",
-                                        "74": "command"
+                                    "container",
+                                    [
+                                      {
+                                        "name": "parameter_name",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "name": "value_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "1": "int",
+                                              "3": "float",
+                                              "4": "value",
+                                              "5": "wildcard_int",
+                                              "6": "operator",
+                                              "7": "command_operator",
+                                              "8": "target",
+                                              "10": "wildcard_target",
+                                              "17": "file_path",
+                                              "23": "integer_range",
+                                              "43": "equipment_slots",
+                                              "44": "string",
+                                              "52": "block_position",
+                                              "53": "position",
+                                              "55": "message",
+                                              "58": "raw_text",
+                                              "62": "json",
+                                              "71": "block_states",
+                                              "74": "command"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "enum_type",
+                                        "type": [
+                                          "mapper",
+                                          {
+                                            "type": "lu16",
+                                            "mappings": {
+                                              "16": "valid",
+                                              "48": "enum",
+                                              "256": "suffixed",
+                                              "1040": "soft_enum"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "name": "optional",
+                                        "type": "bool"
+                                      },
+                                      {
+                                        "name": "options",
+                                        "type": "CommandFlags"
                                       }
-                                    }
+                                    ]
                                   ]
-                                },
-                                {
-                                  "name": "enum_type",
-                                  "type": [
-                                    "mapper",
-                                    {
-                                      "type": "lu16",
-                                      "mappings": {
-                                        "16": "valid",
-                                        "48": "enum",
-                                        "256": "suffixed",
-                                        "1040": "soft_enum"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "optional",
-                                  "type": "bool"
-                                },
-                                {
-                                  "name": "options",
-                                  "type": "CommandFlags"
                                 }
                               ]
-                            ]
-                          }
+                            }
+                          ]
                         ]
                       }
                     ]

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -7181,9 +7181,9 @@
                                       "type": "lu16",
                                       "mappings": {
                                         "16": "valid",
-                                        "32": "enum",
+                                        "48": "enum",
                                         "256": "suffixed",
-                                        "1024": "soft_enum"
+                                        "1040": "soft_enum"
                                       }
                                     }
                                   ]

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -7256,9 +7256,9 @@
                                             "type": "lu16",
                                             "mappings": {
                                               "16": "valid",
-                                              "32": "enum",
+                                              "48": "enum",
                                               "256": "suffixed",
-                                              "1024": "soft_enum"
+                                              "1040": "soft_enum"
                                             }
                                           }
                                         ]

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -7206,7 +7206,7 @@
                               "type": "bool"
                             },
                             {
-                              "name": "__4265",
+                              "name": "parameters",
                               "type": [
                                 "array",
                                 {

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -1756,7 +1756,7 @@ packet_available_commands:
          # chaining determines if the parameters use chained subcommands or not.
          chaining: bool
          # Each of the parameters gets an array of posible overloads
-         _: []varint
+         parameters: []varint
             # The name of the parameter shown to the user (the `amount` in `/xp <amount: int>`)
             parameter_name: string
             value_type: lu16 =>

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -1782,9 +1782,9 @@ packet_available_commands:
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
-               0x20: enum
+               0x30: enum
                0x100: suffixed
-               0x400: soft_enum
+               0x410: soft_enum
             # Is this parameter required?
             optional: bool
             # Additinal options for this command (thanks macroshaft...)


### PR DESCRIPTION
The bedrock `available_commands` packet's overloads field has a value called `enum_type`, which is documented to be set to possible values 0x10, 0x20, 0x100 and 0x400; however upon testing all supported versions on their vanilla BDS, two of these values seem to be incorrect. 0x20 should be 0x30 (48) and 0x400 should be 0x410 (1040). This PR is a fix for these values.
There also seemed to be something strange with the `overloads` field in `available_commands` - In 1.20.10, the objects in the array have the `chaining` bool, but then the parameters are in another field called `__4265`. I assume this was because it was setting an array as an anonymous field. I fixed this by naming the field `parameters` - but if this breaks anything I can revert it. Locally testing it with a vanilla BDS on a few versions including 1.20.10 looks good.