### PR TITLE
fix: correct schema types

### DIFF
--- a/schemas/blockLoot_schema.json
+++ b/schemas/blockLoot_schema.json
@@ -39,7 +39,10 @@
             },
             "stackSizeRange": {
               "description": "The min/max of number of items in this item drop stack",
-              "type": "array"
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
             },
             "blockAge": {
               "description": "The required age of the block for the item drop to occur",

--- a/schemas/blockLoot_schema.json
+++ b/schemas/blockLoot_schema.json
@@ -41,7 +41,7 @@
               "description": "The min/max of number of items in this item drop stack",
               "type": "array",
               "items": {
-                "type": "number"
+                "type": ["number", "null"]
               }
             },
             "blockAge": {

--- a/schemas/particles_schema.json
+++ b/schemas/particles_schema.json
@@ -16,6 +16,8 @@
         "type": "string",
         "pattern": "\\S+"
       }
-    }
+    },
+    "required": ["id", "name"],
+    "additionalProperties": false
   }
 }


### PR DESCRIPTION
This PR makes two fixes:

* Adds types to `stackSizeRange` in the blockLoot schema, setting the `number` or `null` type.
* Marks `id` and `name` as required in the particles schema, and sets `additionalProperties` to false.