### PR TITLE
Bedrock hotbar_slot type fix for 1.16.220 to 1.20.10

### DIFF
--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -944,7 +944,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.16.220/types.yml
+++ b/data/bedrock/1.16.220/types.yml
@@ -471,7 +471,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -947,7 +947,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.17.0/types.yml
+++ b/data/bedrock/1.17.0/types.yml
@@ -474,7 +474,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -947,7 +947,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.17.10/types.yml
+++ b/data/bedrock/1.17.10/types.yml
@@ -474,7 +474,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -947,7 +947,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.17.30/types.yml
+++ b/data/bedrock/1.17.30/types.yml
@@ -474,7 +474,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -947,7 +947,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.17.40/types.yml
+++ b/data/bedrock/1.17.40/types.yml
@@ -474,7 +474,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -947,7 +947,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.18.0/types.yml
+++ b/data/bedrock/1.18.0/types.yml
@@ -474,7 +474,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -947,7 +947,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.18.11/types.yml
+++ b/data/bedrock/1.18.11/types.yml
@@ -478,7 +478,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -951,7 +951,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.18.30/types.yml
+++ b/data/bedrock/1.18.30/types.yml
@@ -486,7 +486,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -951,7 +951,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.1/types.yml
+++ b/data/bedrock/1.19.1/types.yml
@@ -486,7 +486,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -951,7 +951,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.10/types.yml
+++ b/data/bedrock/1.19.10/types.yml
@@ -486,7 +486,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -989,7 +989,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.20/types.yml
+++ b/data/bedrock/1.19.20/types.yml
@@ -493,7 +493,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -989,7 +989,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.21/types.yml
+++ b/data/bedrock/1.19.21/types.yml
@@ -493,7 +493,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -989,7 +989,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.30/types.yml
+++ b/data/bedrock/1.19.30/types.yml
@@ -493,7 +493,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -1041,7 +1041,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.40/types.yml
+++ b/data/bedrock/1.19.40/types.yml
@@ -504,7 +504,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -1041,7 +1041,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.50/types.yml
+++ b/data/bedrock/1.19.50/types.yml
@@ -508,7 +508,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -1041,7 +1041,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.60/types.yml
+++ b/data/bedrock/1.19.60/types.yml
@@ -508,7 +508,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -1041,7 +1041,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.62/types.yml
+++ b/data/bedrock/1.19.62/types.yml
@@ -508,7 +508,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -1041,7 +1041,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.70/types.yml
+++ b/data/bedrock/1.19.70/types.yml
@@ -512,7 +512,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -1041,7 +1041,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.19.80/types.yml
+++ b/data/bedrock/1.19.80/types.yml
@@ -512,7 +512,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -1041,7 +1041,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/1.20.0/types.yml
+++ b/data/bedrock/1.20.0/types.yml
@@ -512,7 +512,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -1042,7 +1042,7 @@
         },
         {
           "name": "hotbar_slot",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "held_item",

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -514,7 +514,7 @@ TransactionUseItem:
    face: zigzag32
    # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
    # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-   hotbar_slot: varint
+   hotbar_slot: zigzag32
    # HeldItem is the item that was held to interact with the block. The server should check if this item
    # is actually present in the HotBarSlot.
    held_item: Item


### PR DESCRIPTION

The `hotbar_slot` field in `TransactionUseItem` needs to be `zigzag32` and not `varint`.

The problem was identified using the relay, and affects the `inventory_transaction` and `player_auth_input` packets.

The change was applied and tested for for all supported (and playable 1.16.220+) versions against vanilla bedrock servers.
 