### PR TITLE
Sync itemDrop object types in blockLoot_schema and entityLoot_schema

### DIFF
--- a/schemas/blockLoot_schema.json
+++ b/schemas/blockLoot_schema.json
@@ -41,7 +41,7 @@
               "description": "The min/max of number of items in this item drop stack",
               "type": "array",
               "items": {
-                "type": ["number", "null"]
+                "type": ["number"]
               }
             },
             "blockAge": {

--- a/schemas/blockLoot_schema.json
+++ b/schemas/blockLoot_schema.json
@@ -20,7 +20,7 @@
         "type": "array",
         "uniqueItems": true,
         "items": {
-          "title": "itemDrop",
+          "title": "blockItemDrop",
           "type": "object",
           "properties": {
             "item": {
@@ -41,7 +41,7 @@
               "description": "The min/max of number of items in this item drop stack",
               "type": "array",
               "items": {
-                "type": ["number"]
+                "type": ["number", "null"]
               }
             },
             "blockAge": {

--- a/schemas/entityLoot_schema.json
+++ b/schemas/entityLoot_schema.json
@@ -35,7 +35,10 @@
             },
             "stackSizeRange": {
               "description": "The min/max of number of items in this item drop stack",
-              "type": "array"
+              "type": "array",
+              "items": {
+                "type": ["number"]
+              }
             },
             "playerKill": {
               "description": "If a player killer is required",

--- a/schemas/entityLoot_schema.json
+++ b/schemas/entityLoot_schema.json
@@ -16,7 +16,7 @@
         "type": "array",
         "uniqueItems": true,
         "items": {
-          "title": "itemDrop",
+          "title": "entityItemDrop",
           "type": "object",
           "properties": {
             "item": {
@@ -37,7 +37,7 @@
               "description": "The min/max of number of items in this item drop stack",
               "type": "array",
               "items": {
-                "type": ["number"]
+                "type": ["number", "null"]
               }
             },
             "playerKill": {


### PR DESCRIPTION
Fix #746 not updating entityLoot with blockLoot. This was failing node-minecraft-protocol CI as the typescript generation doesn't inline nested types, causing two `"title": "itemDrop",`'s in top level namespace to conflict with each other. 