### PR TITLE
Elytra support

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -23,14 +23,9 @@
     "versions": ["1.11", "1.13.2"]
   },
   {
-    "name": "fireworkMetadataVarInt8",
-    "description": "firework attached entity metadata is at index 8 and is varint",
-    "versions": ["1.14", "1.14.4"]
-  },
-  {
     "name": "fireworkMetadataOptVarInt8",
     "description": "firework attached entity metadata is at index 8 and is optvarint",
-    "versions": ["1.15", "1.16.5"]
+    "versions": ["1.14", "1.16.5"]
   },
   {
     "name": "fireworkMetadataOptVarInt9",
@@ -40,12 +35,12 @@
   {
     "name": "fireworkNamePlural",
     "description": "the firework entity used for elytra boosting is named fireworks_rocket",
-    "versions": ["1.11", "1.13.2"]
+    "versions": ["1.11", "1.12.2"]
   },
   {
     "name": "fireworkNameSingular",
     "description": "the firework entity used for elytra boosting is named firework_rocket",
-    "versions": ["1.14", "latest"]
+    "versions": ["1.13", "latest"]
   },
   {
     "name": "blockMetadata",

--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -13,6 +13,41 @@
     ]
   },
   {
+    "name": "hasElytraFlying",
+    "description": "the elytra exists and players can fly with it",
+    "versions": ["1.9", "latest"]
+  },
+  {
+    "name": "fireworkMetadataVarInt7",
+    "description": "firework attached entity metadata is at index 7 and is varint",
+    "versions": ["1.11", "1.13.2"]
+  },
+  {
+    "name": "fireworkMetadataVarInt8",
+    "description": "firework attached entity metadata is at index 8 and is varint",
+    "versions": ["1.14", "1.14.4"]
+  },
+  {
+    "name": "fireworkMetadataOptVarInt8",
+    "description": "firework attached entity metadata is at index 8 and is optvarint",
+    "versions": ["1.15", "1.16.5"]
+  },
+  {
+    "name": "fireworkMetadataOptVarInt9",
+    "description": "firework attached entity metadata is at index 9 and is optvarint",
+    "versions": ["1.17", "latest"]
+  },
+  {
+    "name": "fireworkNamePlural",
+    "description": "the firework entity used for elytra boosting is named fireworks_rocket",
+    "versions": ["1.11", "1.13.2"]
+  },
+  {
+    "name": "fireworkNameSingular",
+    "description": "the firework entity used for elytra boosting is named firework_rocket",
+    "versions": ["1.14", "latest"]
+  },
+  {
     "name": "blockMetadata",
     "description": "block metadata is encoded in a separate metadata",
     "versions": ["1.8", "1.12.2"]


### PR DESCRIPTION
# elytra support

This adds support for elytra, but I needed to know if elytra flying was supported and was rocket flying supported and what index the rocket entity attachement was and what type of data was it

# versions

## elytra support

**1.9.4: 0 0x80 bit**

- https://wiki.vg/index.php?title=Entity_metadata&oldid=7416
  - updated for 1.9
  - 0 0x80 bit

## firework support

**1.11.2: 7 VarInt**

firework entity reports its attached entity
- https://wiki.vg/index.php?title=Entity_metadata&direction=next&oldid=8403
  - 1.11.2
  - 7 VarInt

**1.14.4: 7 VarInt -> 8 VarInt**

Note: This seems to have been a temporary mistaken change. 1.14 is 8 OptVarInt

fireworks entity attached changed index 
- https://wiki.vg/index.php?title=Entity_metadata&direction=next&oldid=14800
  - """"""merged"""""" (i.e. just pasted the diff) 1.14.4 changes)
  - 8 OptVarInt
  - wip changes it seems

- https://wiki.vg/index.php?title=Entity_metadata&direction=next&oldid=15236
  - Remove the massive unmerged information block. This page should now be up to date for 1.14.4 (NOT 1.15.1 yet)
  - 8 VarInt

**1.15.2: 8 VarInt -> 8 OptVarInt**

attached entity: VarInt to OptVarInt
- https://wiki.vg/index.php?title=Entity_metadata&oldid=15541 (older, varint)
  - Update panda flags
  - 8 VarInt
- https://wiki.vg/index.php?title=Entity_metadata&oldid=15581 (newer, optvarint)
  - Fireworks use OptVarInts for entity IDs
  - 8 OptVarInt

**1.17.1: 8 OptVarInt -> 9 OptVarInt**

- https://wiki.vg/index.php?title=Entity_metadata&oldid=16738
  - Add "Ticks frozen in powdered snow" from Pre-release protocol. I'm not sure if there are other changes that weren't listed there though
  - 9 OptVarInt

- latest
  - 9 OptVarInt

## firework naming

from entities.json

- 1.11: fireworks_rocket (mob/obj)
- 1.13: fireworks_rocket (mob) / firework_rocket (obj)
- 1.14: firework_rocket (mob)
- 1.17: firework_rocket (projectile)

note: 1.13 uses firework_rocket for rocket flying
