### PR TITLE
Bedrock stack and request network id fix for 1.16.220 to 1.20.10

### DIFF
--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -2064,7 +2064,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2342,7 +2342,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2390,7 +2390,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.16.220/types.yml
+++ b/data/bedrock/1.16.220/types.yml
@@ -779,7 +779,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -915,7 +915,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -936,7 +936,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -2067,7 +2067,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2345,7 +2345,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2393,7 +2393,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.17.0/types.yml
+++ b/data/bedrock/1.17.0/types.yml
@@ -782,7 +782,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -918,7 +918,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -939,7 +939,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -2067,7 +2067,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2345,7 +2345,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2393,7 +2393,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.17.10/types.yml
+++ b/data/bedrock/1.17.10/types.yml
@@ -782,7 +782,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -918,7 +918,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -939,7 +939,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -2075,7 +2075,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2353,7 +2353,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2401,7 +2401,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.17.30/types.yml
+++ b/data/bedrock/1.17.30/types.yml
@@ -787,7 +787,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -923,7 +923,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -944,7 +944,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -2075,7 +2075,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2377,7 +2377,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2425,7 +2425,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.17.40/types.yml
+++ b/data/bedrock/1.17.40/types.yml
@@ -787,7 +787,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -938,7 +938,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -959,7 +959,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -2075,7 +2075,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2377,7 +2377,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2425,7 +2425,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.18.0/types.yml
+++ b/data/bedrock/1.18.0/types.yml
@@ -787,7 +787,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -938,7 +938,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -959,7 +959,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -2075,7 +2075,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2379,7 +2379,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2427,7 +2427,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.18.11/types.yml
+++ b/data/bedrock/1.18.11/types.yml
@@ -791,7 +791,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -946,7 +946,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -967,7 +967,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -2079,7 +2079,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2383,7 +2383,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2431,7 +2431,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.18.30/types.yml
+++ b/data/bedrock/1.18.30/types.yml
@@ -799,7 +799,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -954,7 +954,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -975,7 +975,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -2081,7 +2081,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2385,7 +2385,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2433,7 +2433,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.1/types.yml
+++ b/data/bedrock/1.19.1/types.yml
@@ -801,7 +801,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -956,7 +956,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -977,7 +977,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -2081,7 +2081,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2385,7 +2385,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2433,7 +2433,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.10/types.yml
+++ b/data/bedrock/1.19.10/types.yml
@@ -801,7 +801,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -956,7 +956,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -977,7 +977,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -2119,7 +2119,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2423,7 +2423,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2471,7 +2471,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.20/types.yml
+++ b/data/bedrock/1.19.20/types.yml
@@ -808,7 +808,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -963,7 +963,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -984,7 +984,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -2119,7 +2119,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2423,7 +2423,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2471,7 +2471,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.21/types.yml
+++ b/data/bedrock/1.19.21/types.yml
@@ -808,7 +808,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -963,7 +963,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -984,7 +984,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -2179,7 +2179,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2505,7 +2505,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2553,7 +2553,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.30/types.yml
+++ b/data/bedrock/1.19.30/types.yml
@@ -837,7 +837,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -1006,7 +1006,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -1027,7 +1027,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -2231,7 +2231,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2558,7 +2558,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2606,7 +2606,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.40/types.yml
+++ b/data/bedrock/1.19.40/types.yml
@@ -848,7 +848,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -1018,7 +1018,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -1039,7 +1039,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -2231,7 +2231,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2560,7 +2560,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2608,7 +2608,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.50/types.yml
+++ b/data/bedrock/1.19.50/types.yml
@@ -852,7 +852,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -1024,7 +1024,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -1045,7 +1045,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -2262,7 +2262,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2591,7 +2591,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2639,7 +2639,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.60/types.yml
+++ b/data/bedrock/1.19.60/types.yml
@@ -872,7 +872,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -1044,7 +1044,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -1065,7 +1065,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -2266,7 +2266,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2595,7 +2595,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2643,7 +2643,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.62/types.yml
+++ b/data/bedrock/1.19.62/types.yml
@@ -873,7 +873,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -1045,7 +1045,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -1066,7 +1066,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -2276,7 +2276,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2603,7 +2603,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2651,7 +2651,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.70/types.yml
+++ b/data/bedrock/1.19.70/types.yml
@@ -883,7 +883,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -1053,7 +1053,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -1074,7 +1074,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -2310,7 +2310,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2637,7 +2637,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2685,7 +2685,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.19.80/types.yml
+++ b/data/bedrock/1.19.80/types.yml
@@ -892,7 +892,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -1062,7 +1062,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -1083,7 +1083,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -2310,7 +2310,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2639,7 +2639,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2687,7 +2687,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/1.20.0/types.yml
+++ b/data/bedrock/1.20.0/types.yml
@@ -892,7 +892,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -1064,7 +1064,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -1085,7 +1085,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -2314,7 +2314,7 @@
       [
         {
           "name": "request_id",
-          "type": "varint"
+          "type": "zigzag32"
         },
         {
           "name": "actions",
@@ -2643,7 +2643,7 @@
             },
             {
               "name": "request_id",
-              "type": "varint"
+              "type": "zigzag32"
             },
             {
               "anon": true,
@@ -2691,7 +2691,7 @@
                                             },
                                             {
                                               "name": "item_stack_id",
-                                              "type": "varint"
+                                              "type": "zigzag32"
                                             },
                                             {
                                               "name": "custom_name",

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -897,7 +897,7 @@ StackRequestSlotInfo:
 ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
-   request_id: varint
+   request_id: zigzag32
    actions: []varint
       type_id: u8 =>
          # TakeStackRequestAction is sent by the client to the server to take x amount of items from one slot in a
@@ -1069,7 +1069,7 @@ ItemStackResponses: []varint
       1: error
    # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
    # will undo the actions from the request with this ID.
-   request_id: varint
+   request_id: zigzag32
    _: status ?
       if ok:
          # ContainerInfo holds information on the containers that had their contents changed as a result of the
@@ -1090,7 +1090,7 @@ ItemStackResponses: []varint
                # sent to the client.
                count: u8
                # StackNetworkID is the network ID of the new stack at a specific slot.
-               item_stack_id: varint
+               item_stack_id: zigzag32
                # CustomName is the custom name of the item stack. It is used in relation to text filtering.
                custom_name: string
                # DurabilityCorrection is the current durability of the item stack. This durability will be shown


### PR DESCRIPTION
This is a follow-up for PR [#749](https://github.com/PrismarineJS/minecraft-data/pull/749#issuecomment-1672845618), which incorrectly changed the `stack_id` to `varint`.

Following the discussion, the `item_stack_id` and `request_id` was updated to `zigzag32`.

Here are the code references again if needed:
- [CloudburstMC](https://github.com/CloudburstMC/Protocol/blob/e2abbaed93d8e19f4db62c51567dea7c3496c9ed/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v422/serializer/ItemStackResponseSerializer_v422.java#L19)
- [PMMP](https://github.com/pmmp/BedrockProtocol/blob/master/src/types/inventory/stackresponse/ItemStackResponseSlotInfo.php#L45)

As always, the change was applied and tested for for all supported (and playable 1.16.220+) versions against vanilla bedrock servers.