### PR TITLE
Change has_stack_id in bedrock Item to a boolean

### DIFF
--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -481,7 +481,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.16.220/types.yml
+++ b/data/bedrock/1.16.220/types.yml
@@ -129,7 +129,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -485,7 +485,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.17.0/types.yml
+++ b/data/bedrock/1.17.0/types.yml
@@ -130,7 +130,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -485,7 +485,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.17.10/types.yml
+++ b/data/bedrock/1.17.10/types.yml
@@ -130,7 +130,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -485,7 +485,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.17.30/types.yml
+++ b/data/bedrock/1.17.30/types.yml
@@ -130,7 +130,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -485,7 +485,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.17.40/types.yml
+++ b/data/bedrock/1.17.40/types.yml
@@ -130,7 +130,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -485,7 +485,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.18.0/types.yml
+++ b/data/bedrock/1.18.0/types.yml
@@ -130,7 +130,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -485,7 +485,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.18.11/types.yml
+++ b/data/bedrock/1.18.11/types.yml
@@ -130,7 +130,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.18.30/types.yml
+++ b/data/bedrock/1.18.30/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.1/types.yml
+++ b/data/bedrock/1.19.1/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.10/types.yml
+++ b/data/bedrock/1.19.10/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.20/types.yml
+++ b/data/bedrock/1.19.20/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.21/types.yml
+++ b/data/bedrock/1.19.21/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.30/types.yml
+++ b/data/bedrock/1.19.30/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.40/types.yml
+++ b/data/bedrock/1.19.40/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.50/types.yml
+++ b/data/bedrock/1.19.50/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.60/types.yml
+++ b/data/bedrock/1.19.60/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.62/types.yml
+++ b/data/bedrock/1.19.62/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.70/types.yml
+++ b/data/bedrock/1.19.70/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.19.80/types.yml
+++ b/data/bedrock/1.19.80/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/1.20.0/types.yml
+++ b/data/bedrock/1.20.0/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -486,7 +486,7 @@
                   },
                   {
                     "name": "has_stack_id",
-                    "type": "u8"
+                    "type": "bool"
                   },
                   {
                     "name": "stack_id",

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -131,7 +131,7 @@ Item:
          metadata: varint
          # When server authoritative inventory is enabled, all allocated items have a unique ID used to identify
          # a specifc item instance.
-         has_stack_id: u8
+         has_stack_id: bool
          # StackNetworkID is the network ID of this item *instance*. If the stack is empty, 0 is always written for this
          # field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
          # StartGame packet, or to a unique stack ID if it is enabled.


### PR DESCRIPTION
Change the type of the `has_stack_id` field in `Item` type for bedrock protocol definition to a boolean type.