### PR TITLE
Fix CameraPresets parse error

### DIFF
--- a/data/bedrock/1.20.30/protocol.json
+++ b/data/bedrock/1.20.30/protocol.json
@@ -3989,6 +3989,41 @@
         }
       ]
     ],
+    "CameraPresets": [
+      "container",
+      [
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "parent",
+          "type": "string"
+        },
+        {
+          "name": "position",
+          "type": "Vec3fopts"
+        },
+        {
+          "name": "rotation",
+          "type": "Vec2fopts"
+        },
+        {
+          "name": "audio_listener",
+          "type": [
+            "option",
+            "u8"
+          ]
+        },
+        {
+          "name": "player_effects",
+          "type": [
+            "option",
+            "bool"
+          ]
+        }
+      ]
+    ],
     "mcpe_packet": [
       "container",
       [
@@ -11044,33 +11079,13 @@
       "container",
       [
         {
-          "name": "name",
-          "type": "string"
-        },
-        {
-          "name": "parent",
-          "type": "string"
-        },
-        {
-          "name": "position",
-          "type": "Vec3fopts"
-        },
-        {
-          "name": "rotation",
-          "type": "Vec2fopts"
-        },
-        {
-          "name": "audio_listener",
+          "name": "presets",
           "type": [
-            "option",
-            "u8"
-          ]
-        },
-        {
-          "name": "player_effects",
-          "type": [
-            "option",
-            "bool"
+            "array",
+            {
+              "countType": "u8",
+              "type": "CameraPresets"
+            }
           ]
         }
       ]

--- a/data/bedrock/1.20.30/protocol.json
+++ b/data/bedrock/1.20.30/protocol.json
@@ -11083,7 +11083,7 @@
           "type": [
             "array",
             {
-              "countType": "u8",
+              "countType": "varint",
               "type": "CameraPresets"
             }
           ]

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3964,7 +3964,7 @@ packet_client_cheat_ability:
 packet_camera_presets:
    !id: 0xc6
    !bound: client
-   presets: CameraPresets[]u8
+   presets: CameraPresets[]varint
 
 # unlocked_recipes gives the client a list of recipes that have been unlocked, restricting the recipes that appear in
 # the recipe book.

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3964,15 +3964,7 @@ packet_client_cheat_ability:
 packet_camera_presets:
    !id: 0xc6
    !bound: client
-   # Name is the name of the preset. Each preset must have their own unique name.
-   name: string
-   # Parent is the name of the preset that this preset extends upon. This can be left empty.
-   parent: string
-   position: Vec3fopts
-   rotation: Vec2fopts
-   ## TODO: make this an enum afer adding proper optional support inside pdefyaml
-   audio_listener?: u8
-   player_effects?: bool
+   presets: CameraPresets[]u8
 
 # unlocked_recipes gives the client a list of recipes that have been unlocked, restricting the recipes that appear in
 # the recipe book.

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -2115,3 +2115,14 @@ AbilityLayers:
    fly_speed: lf32
    # WalkSpeed is the default walk speed of the layer.
    walk_speed: lf32
+
+CameraPresets:
+   # Name is the name of the preset. Each preset must have their own unique name.
+   name: string
+   # Parent is the name of the preset that this preset extends upon. This can be left empty.
+   parent: string
+   position: Vec3fopts
+   rotation: Vec2fopts
+   ## TODO: make this an enum afer adding proper optional support inside pdefyaml
+   audio_listener?: u8
+   player_effects?: bool


### PR DESCRIPTION
In 1.20.30 the CameraPresets packet was changed. #774 was created to add support for this, however the packet's fields was not properly updated.

The packet should contain an array of the presets (evident in [GopherTunnel](https://github.com/Sandertv/gophertunnel/blob/master/minecraft/protocol/packet/camera_presets.go#L11), [Pocketmine-MP](https://github.com/pmmp/BedrockProtocol/blob/master/src/CameraPresetsPacket.php#L25) and [CloudburstMC](https://github.com/CloudburstMC/Protocol/blob/3.0/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/CameraPresetsPacket.java#L17)) meanwhile minecraft-data did not account for this.

This PR fixes this issue, which intern fixes the bedrock-protocol relay crashing when trying to log into a BDS server.