### PR TITLE
Fix errors in protocol.json caused by my horrible spelling

### DIFF
--- a/data/pc/1.20.2/protocol.json
+++ b/data/pc/1.20.2/protocol.json
@@ -1655,7 +1655,7 @@
       }
     }
   },
-  "configutation": {
+  "configuration": {
     "toClient": {
       "types": {
         "packet_custom_payload": [
@@ -1680,7 +1680,7 @@
             }
           ]
         ],
-        "packet_finish_configuation": [
+        "packet_finish_configurationn": [
           "container",
           []
         ],
@@ -1809,7 +1809,7 @@
                   "fields": {
                     "custom_payload": "packet_custom_payload",
                     "disconnect": "packet_disconnect",
-                    "finish_configuration": "packet_finish_configuation",
+                    "finish_configuration": "packet_finish_configuration",
                     "keep_alive": "packet_keep_alive",
                     "ping": "packet_ping",
                     "registry_data": "packet_registry_data",
@@ -1876,7 +1876,7 @@
             }
           ]
         ],
-        "packet_finish_configuation": [
+        "packet_finish_configuration": [
           "container",
           []
         ],
@@ -1919,7 +1919,7 @@
                   "mappings": {
                     "0x00": "settings",
                     "0x01": "custom_payload",
-                    "0x02": "finish_configuation",
+                    "0x02": "finish_configuration",
                     "0x03": "keep_alive",
                     "0x04": "pong",
                     "0x05": "resource_pack_receive"
@@ -1936,7 +1936,7 @@
                   "fields": {
                     "settings": "packet_settings",
                     "custom_payload": "packet_custom_payload",
-                    "finish_configuation": "packet_finish_configuation",
+                    "finish_configuration": "packet_finish_configuration",
                     "keep_alive": "packet_keep_alive",
                     "pong": "packet_pong",
                     "resource_pack_receive": "packet_resource_pack_receive"


### PR DESCRIPTION
Fixes miss-spelling of configuration that was breaking its packets.

This is just a basic fix for my dumb mistakes, still have to fully verify the whole protocol. 