### PR TITLE
Inconsistency with 'unsignedChatContent' in 'player_chat' packet in version 1.19.2

### DIFF
--- a/data/pc/1.19.2/protocol.json
+++ b/data/pc/1.19.2/protocol.json
@@ -3316,7 +3316,7 @@
               "type": "previousMessages"
             },
             {
-              "name": "unsignedContent",
+              "name": "unsignedChatContent",
               "type": [
                 "option",
                 "string"


### PR DESCRIPTION
Unsigned message field in `player_chat` packet for version `1.19.2` was named `unsignedContent`, while in every other version, it is named `unsignedChatContent`.

Links for a better view:
- [1.19](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.19/protocol.json#L3204)
- [1.19.2](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.19.2/protocol.json#L3319)
- [1.19.3](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.19.3/protocol.json#L3340)
- [1.19.4](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.19.4/protocol.json#L3436)
- [1.20](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.20/protocol.json#L3436)
- [1.20.2](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.20.2/protocol.json#L3696)