### PR TITLE
Fix bedrock recipe text encoding issue

### DIFF
--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 varint64: native                                      # Some primitives
 zigzag32: native
 zigzag64: native

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -1203,7 +1203,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1248,7 +1248,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1293,7 +1293,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1338,7 +1338,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1397,7 +1397,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -7339,6 +7339,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "AdventureFlags": [

--- a/data/bedrock/1.16.201/types.yml
+++ b/data/bedrock/1.16.201/types.yml
@@ -455,7 +455,7 @@ Recipes: []varint
       '7': 'shaped_chemistry' #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: Item[]varint
          uuid: uuid
@@ -463,7 +463,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: zigzag32
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # todo: can this become

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 varint64: native                                      # Some primitives
 zigzag32: native
 zigzag64: native

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -1225,7 +1225,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1270,7 +1270,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1315,7 +1315,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1360,7 +1360,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1419,7 +1419,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -7790,6 +7790,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "MetadataFlags1": [

--- a/data/bedrock/1.16.210/types.yml
+++ b/data/bedrock/1.16.210/types.yml
@@ -589,7 +589,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: Item[]varint
          uuid: uuid
@@ -597,7 +597,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # todo: can this become

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -1355,7 +1355,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1400,7 +1400,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1445,7 +1445,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1490,7 +1490,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1549,7 +1549,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -8688,6 +8688,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.16.220/types.yml
+++ b/data/bedrock/1.16.220/types.yml
@@ -626,7 +626,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -634,7 +634,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -1358,7 +1358,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1403,7 +1403,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1448,7 +1448,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1493,7 +1493,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1552,7 +1552,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -8798,6 +8798,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.17.0/types.yml
+++ b/data/bedrock/1.17.0/types.yml
@@ -629,7 +629,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -637,7 +637,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -1358,7 +1358,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1403,7 +1403,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1448,7 +1448,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1493,7 +1493,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1552,7 +1552,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -8972,6 +8972,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.17.10/types.yml
+++ b/data/bedrock/1.17.10/types.yml
@@ -629,7 +629,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -637,7 +637,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -1358,7 +1358,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1403,7 +1403,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1448,7 +1448,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1493,7 +1493,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1552,7 +1552,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -9270,6 +9270,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.17.30/types.yml
+++ b/data/bedrock/1.17.30/types.yml
@@ -629,7 +629,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -637,7 +637,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -1358,7 +1358,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1403,7 +1403,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1448,7 +1448,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1493,7 +1493,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1552,7 +1552,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -9367,6 +9367,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.17.40/types.yml
+++ b/data/bedrock/1.17.40/types.yml
@@ -629,7 +629,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -637,7 +637,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -1358,7 +1358,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1403,7 +1403,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1448,7 +1448,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1493,7 +1493,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1552,7 +1552,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -9429,6 +9429,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.18.0/types.yml
+++ b/data/bedrock/1.18.0/types.yml
@@ -629,7 +629,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -637,7 +637,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -1358,7 +1358,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1403,7 +1403,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1448,7 +1448,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1493,7 +1493,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1552,7 +1552,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -9685,6 +9685,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.18.11/types.yml
+++ b/data/bedrock/1.18.11/types.yml
@@ -633,7 +633,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -641,7 +641,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -1362,7 +1362,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1407,7 +1407,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1452,7 +1452,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1497,7 +1497,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1556,7 +1556,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -9923,6 +9923,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.18.30/types.yml
+++ b/data/bedrock/1.18.30/types.yml
@@ -641,7 +641,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -649,7 +649,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -1362,7 +1362,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1407,7 +1407,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1452,7 +1452,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1497,7 +1497,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1556,7 +1556,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -10091,6 +10091,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.1/types.yml
+++ b/data/bedrock/1.19.1/types.yml
@@ -641,7 +641,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -649,7 +649,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -1362,7 +1362,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1407,7 +1407,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1452,7 +1452,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1497,7 +1497,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1556,7 +1556,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -10239,6 +10239,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.10/types.yml
+++ b/data/bedrock/1.19.10/types.yml
@@ -641,7 +641,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -649,7 +649,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -1400,7 +1400,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1445,7 +1445,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1490,7 +1490,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1535,7 +1535,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1594,7 +1594,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -10431,6 +10431,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.20/types.yml
+++ b/data/bedrock/1.19.20/types.yml
@@ -648,7 +648,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -656,7 +656,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -1400,7 +1400,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1445,7 +1445,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1490,7 +1490,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1535,7 +1535,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1594,7 +1594,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -10431,6 +10431,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.21/types.yml
+++ b/data/bedrock/1.19.21/types.yml
@@ -648,7 +648,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -656,7 +656,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -1460,7 +1460,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1505,7 +1505,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1550,7 +1550,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1595,7 +1595,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1654,7 +1654,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -10644,6 +10644,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.30/types.yml
+++ b/data/bedrock/1.19.30/types.yml
@@ -677,7 +677,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -685,7 +685,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -1512,7 +1512,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1557,7 +1557,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1602,7 +1602,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1647,7 +1647,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1706,7 +1706,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -10716,6 +10716,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.40/types.yml
+++ b/data/bedrock/1.19.40/types.yml
@@ -688,7 +688,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -696,7 +696,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -1512,7 +1512,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1557,7 +1557,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1602,7 +1602,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1647,7 +1647,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1706,7 +1706,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -10747,6 +10747,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.50/types.yml
+++ b/data/bedrock/1.19.50/types.yml
@@ -692,7 +692,7 @@ Recipes: []varint
       7: shaped_chemistry #'ENTRY_SHAPED_CHEMISTRY', //TODO
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -700,7 +700,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -1513,7 +1513,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1558,7 +1558,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1603,7 +1603,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1648,7 +1648,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1707,7 +1707,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1817,7 +1817,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "base",
@@ -10828,6 +10828,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.60/types.yml
+++ b/data/bedrock/1.19.60/types.yml
@@ -695,7 +695,7 @@ Recipes: []varint
       8: smithing_transform
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -703,7 +703,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height
@@ -729,7 +729,7 @@ Recipes: []varint
       if smithing_transform:
          # RecipeID is a unique ID of the recipe. This ID must be unique amongst all other types of recipes too,
          # but its functionality is not exactly known.
-         recipe_id: string
+         recipe_id: LatinString
          # Base is the item that the Addition is being applied to in the smithing table.
          base: RecipeIngredient
          # Addition is the item that is being added to the Base item to result in a modified item.

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -1513,7 +1513,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1558,7 +1558,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1603,7 +1603,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1648,7 +1648,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1707,7 +1707,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1817,7 +1817,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "base",
@@ -10832,6 +10832,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.62/types.yml
+++ b/data/bedrock/1.19.62/types.yml
@@ -695,7 +695,7 @@ Recipes: []varint
       8: smithing_transform
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -703,7 +703,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height
@@ -729,7 +729,7 @@ Recipes: []varint
       if smithing_transform:
          # RecipeID is a unique ID of the recipe. This ID must be unique amongst all other types of recipes too,
          # but its functionality is not exactly known.
-         recipe_id: string
+         recipe_id: LatinString
          # Base is the item that the Addition is being applied to in the smithing table.
          base: RecipeIngredient
          # Addition is the item that is being added to the Base item to result in a modified item.

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -1523,7 +1523,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1568,7 +1568,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1613,7 +1613,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1658,7 +1658,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1717,7 +1717,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1827,7 +1827,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "base",
@@ -10891,6 +10891,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.70/types.yml
+++ b/data/bedrock/1.19.70/types.yml
@@ -705,7 +705,7 @@ Recipes: []varint
       8: smithing_transform
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -713,7 +713,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height
@@ -739,7 +739,7 @@ Recipes: []varint
       if smithing_transform:
          # RecipeID is a unique ID of the recipe. This ID must be unique amongst all other types of recipes too,
          # but its functionality is not exactly known.
-         recipe_id: string
+         recipe_id: LatinString
          # Base is the item that the Addition is being applied to in the smithing table.
          base: RecipeIngredient
          # Addition is the item that is being added to the Base item to result in a modified item.

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -1524,7 +1524,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1569,7 +1569,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1614,7 +1614,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1659,7 +1659,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1718,7 +1718,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1828,7 +1828,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -1861,7 +1861,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -11029,6 +11029,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.19.80/types.yml
+++ b/data/bedrock/1.19.80/types.yml
@@ -706,7 +706,7 @@ Recipes: []varint
       9: smithing_trim
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -714,7 +714,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height
@@ -740,7 +740,7 @@ Recipes: []varint
       if smithing_transform:
          # RecipeID is a unique ID of the recipe. This ID must be unique amongst all other types of recipes too,
          # but its functionality is not exactly known.
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          # Base is the item that the Addition is being applied to in the smithing table.
          base: RecipeIngredient
@@ -755,7 +755,7 @@ Recipes: []varint
          # This field must never be 0.
          network_id: varint
       if smithing_trim:
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          input: RecipeIngredient
          addition: RecipeIngredient

--- a/data/bedrock/1.20.0/proto.yml
+++ b/data/bedrock/1.20.0/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -1524,7 +1524,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1569,7 +1569,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1614,7 +1614,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1659,7 +1659,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1718,7 +1718,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1828,7 +1828,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -1861,7 +1861,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -11060,6 +11060,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.20.0/types.yml
+++ b/data/bedrock/1.20.0/types.yml
@@ -706,7 +706,7 @@ Recipes: []varint
       9: smithing_trim
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -714,7 +714,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height
@@ -740,7 +740,7 @@ Recipes: []varint
       if smithing_transform:
          # RecipeID is a unique ID of the recipe. This ID must be unique amongst all other types of recipes too,
          # but its functionality is not exactly known.
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          # Base is the item that the Addition is being applied to in the smithing table.
          base: RecipeIngredient
@@ -755,7 +755,7 @@ Recipes: []varint
          # This field must never be 0.
          network_id: varint
       if smithing_trim:
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          input: RecipeIngredient
          addition: RecipeIngredient

--- a/data/bedrock/1.20.10/proto.yml
+++ b/data/bedrock/1.20.10/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -1525,7 +1525,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1570,7 +1570,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1615,7 +1615,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1660,7 +1660,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1719,7 +1719,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1829,7 +1829,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -1862,7 +1862,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -11153,6 +11153,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.20.10/types.yml
+++ b/data/bedrock/1.20.10/types.yml
@@ -708,7 +708,7 @@ Recipes: []varint
       9: smithing_trim
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -716,7 +716,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height
@@ -742,7 +742,7 @@ Recipes: []varint
       if smithing_transform:
          # RecipeID is a unique ID of the recipe. This ID must be unique amongst all other types of recipes too,
          # but its functionality is not exactly known.
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          # Base is the item that the Addition is being applied to in the smithing table.
          base: RecipeIngredient
@@ -757,7 +757,7 @@ Recipes: []varint
          # This field must never be 0.
          network_id: varint
       if smithing_trim:
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          input: RecipeIngredient
          addition: RecipeIngredient

--- a/data/bedrock/1.20.30/proto.yml
+++ b/data/bedrock/1.20.30/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.20.30/protocol.json
+++ b/data/bedrock/1.20.30/protocol.json
@@ -1570,7 +1570,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1615,7 +1615,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1660,7 +1660,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1705,7 +1705,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1764,7 +1764,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1874,7 +1874,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -1907,7 +1907,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -11417,6 +11417,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.20.30/types.yml
+++ b/data/bedrock/1.20.30/types.yml
@@ -717,7 +717,7 @@ Recipes: []varint
       9: smithing_trim
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -725,7 +725,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height
@@ -751,7 +751,7 @@ Recipes: []varint
       if smithing_transform:
          # RecipeID is a unique ID of the recipe. This ID must be unique amongst all other types of recipes too,
          # but its functionality is not exactly known.
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          # Base is the item that the Addition is being applied to in the smithing table.
          base: RecipeIngredient
@@ -766,7 +766,7 @@ Recipes: []varint
          # This field must never be 0.
          network_id: varint
       if smithing_trim:
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          input: RecipeIngredient
          addition: RecipeIngredient

--- a/data/bedrock/1.20.40/proto.yml
+++ b/data/bedrock/1.20.40/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/1.20.40/protocol.json
+++ b/data/bedrock/1.20.40/protocol.json
@@ -1570,7 +1570,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1615,7 +1615,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1660,7 +1660,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1705,7 +1705,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1764,7 +1764,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1874,7 +1874,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -1907,7 +1907,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -11545,6 +11545,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/1.20.40/types.yml
+++ b/data/bedrock/1.20.40/types.yml
@@ -720,7 +720,7 @@ Recipes: []varint
       9: smithing_trim
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -728,7 +728,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height
@@ -754,7 +754,7 @@ Recipes: []varint
       if smithing_transform:
          # RecipeID is a unique ID of the recipe. This ID must be unique amongst all other types of recipes too,
          # but its functionality is not exactly known.
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          # Base is the item that the Addition is being applied to in the smithing table.
          base: RecipeIngredient
@@ -769,7 +769,7 @@ Recipes: []varint
          # This field must never be 0.
          network_id: varint
       if smithing_trim:
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          input: RecipeIngredient
          addition: RecipeIngredient

--- a/data/bedrock/1.20.50/protocol.json
+++ b/data/bedrock/1.20.50/protocol.json
@@ -1587,7 +1587,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1632,7 +1632,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1677,7 +1677,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "input",
@@ -1722,7 +1722,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1781,7 +1781,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "width",
@@ -1891,7 +1891,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -1924,7 +1924,7 @@
                       [
                         {
                           "name": "recipe_id",
-                          "type": "string"
+                          "type": "LatinString"
                         },
                         {
                           "name": "template",
@@ -11690,6 +11690,13 @@
       "pstring",
       {
         "countType": "li32"
+      }
+    ],
+    "LatinString": [
+      "pstring",
+      {
+        "countType": "varint",
+        "encoding": "latin1"
       }
     ],
     "ShortArray": [

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -8,6 +8,7 @@ string: ["pstring",{"countType":"varint"}]            # String / array types
 ByteArray: ["buffer",{"countType":"varint"}]
 SignedByteArray: ["buffer",{"countType":"zigzag32"}]
 LittleString: ["pstring",{"countType":"li32"}]
+LatinString: ["pstring",{"countType":"varint", "encoding": "latin1"}]
 ShortArray: ["buffer",{"countType":"li16"}]
 ShortString: ["pstring",{"countType":"li16"}]
 varint64: native                                      # Some primitives

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -725,7 +725,7 @@ Recipes: []varint
       9: smithing_trim
    recipe: type?
       if shapeless or shulker_box or shapeless_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          input: RecipeIngredient[]varint
          output: ItemLegacy[]varint
          uuid: uuid
@@ -733,7 +733,7 @@ Recipes: []varint
          priority: zigzag32
          network_id: varint
       if shaped or shaped_chemistry:
-         recipe_id: string
+         recipe_id: LatinString
          width: zigzag32
          height: zigzag32
          # 2D input array, size of width*height
@@ -759,7 +759,7 @@ Recipes: []varint
       if smithing_transform:
          # RecipeID is a unique ID of the recipe. This ID must be unique amongst all other types of recipes too,
          # but its functionality is not exactly known.
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          # Base is the item that the Addition is being applied to in the smithing table.
          base: RecipeIngredient
@@ -774,7 +774,7 @@ Recipes: []varint
          # This field must never be 0.
          network_id: varint
       if smithing_trim:
-         recipe_id: string
+         recipe_id: LatinString
          template: RecipeIngredient
          input: RecipeIngredient
          addition: RecipeIngredient

--- a/tools/js/test/test.js
+++ b/tools/js/test/test.js
@@ -27,6 +27,7 @@ require('./version_iterator')(function (p, versionString) {
           if (dataName === 'protocol') {
             const validator = new Validator()
 
+            instance.types.LatinString = 'native' // TODO: Update protodef validator
             validator.addType('entityMetadataItem', require('../../../schemas/protocol_types/entity_metadata_item.json'))
             validator.addType('entityMetadataLoop', require('../../../schemas/protocol_types/entity_metadata_loop.json'))
             validator.validateProtocol(instance)


### PR DESCRIPTION
Fix https://github.com/PrismarineJS/bedrock-protocol/issues/469#issuecomment-1867764311 where decode and re-encode yeilds different data, but only applying this to recipe IDs

Reading strings as latin1/ascii prevents issues with UTF-8 where byte length != char length as there are no multibyte characters