### PR TITLE
Fix breeze and wind charge being type player.

### DIFF
--- a/data/pc/1.20.3/entities.json
+++ b/data/pc/1.20.3/entities.json
@@ -301,7 +301,7 @@
     "displayName": "Breeze",
     "width": 0.6,
     "height": 1.7,
-    "type": "player",
+    "type": "hostile",
     "category": "Hostile mobs",
     "metadataKeys": [
       "shared_flags",
@@ -3157,7 +3157,7 @@
     "displayName": "Wind Charge",
     "width": 0.3125,
     "height": 0.3125,
-    "type": "player",
+    "type": "projectile",
     "category": "Projectiles",
     "metadataKeys": [
       "shared_flags",


### PR DESCRIPTION
This was due to them being 1.21 feature entities.