### PR TITLE
Propose blocks extended data

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 Language independent module providing minecraft data for minecraft clients, servers and libraries.
 
 Supports
+
 * Minecraft PC version 0.30c (classic), 1.7.10, 1.8.8, 1.9 (15w40b, 1.9, 1.9.1-pre2, 1.9.2, 1.9.4),
 1.10 (16w20a, 1.10-pre1, 1.10, 1.10.1, 1.10.2), 1.11 (16w35a, 1.11, 1.11.2), 1.12 (17w15a, 17w18b, 1.12-pre4, 1.12, 1.12.1, 1.12.2), 1.13 (17w50a, 1.13, 1.13.1, 1.13.2-pre1, 1.13.2-pre2, 1.13.2), 1.14 (1.14, 1.14.1, 1.14.3, 1.14.4), 1.15 (1.15, 1.15.1, 1.15.2), 1.16 (20w13b, 20w14a, 1.16-rc1, 1.16, 1.16.1, 1.16.2, 1.16.3, 1.16.4, 1.16.5), 1.17, 1.17.1, 1.18 (1.18, 1.18.1, 1.18.2), 1.19 (1.19, 1.19.2, 1.19.3, 1.19.4), 1.20 (1.20, 1.20.1, 1.20.2, 1.20.3, 1.20.4)
 * Minecraft bedrock version 0.14, 0.15, 1.0, 1.16.201, 1.16.210, 1.16.220, 1.17.0, 1.17.10, 1.17.30, 1.17.40, 1.18.0, 1.18.11, 1.18.30, 1.19.1, 1.19.10, 1.19.20, 1.19.21, 1.19.30, 1.19.40, 1.19.50, 1.19.60, 1.19.62, 1.19.63, 1.19.70, 1.19.80, 1.20.0, 1.20.10, 1.20.30, 1.20.40, 1.20.50
-
 
 ## Wrappers
 
@@ -55,6 +55,7 @@ Data provided:
 | Foods | list of foods each with there id, saturation, foodpoints and more |
 | Commands | a tree structure for vanilla minecraft server commands, and some info needed to implement sub-parsers.
 | Legacy | mappings between legacy (1.12) and post-flattening (1.13+) blocks and items ids
+| Block Extended Data | Blocks with some extended data
 | Skin data | (bedrock edition) Skin geometry and texture data for steve skin
 | Features | This can be used to check is a specific feature is available in the current Minecraft version. This is usually only required for handling version-specific functionality.
 
@@ -62,9 +63,9 @@ See more information about this data in the [documentation](http://prismarinejs.
 
 ## Documentation
 
- * See [doc/history.md](doc/history.md)
- * [Documentation generated using the json schemas and docson](http://prismarinejs.github.io/minecraft-data)
- * [Textual documentation of the recipe format](doc/recipes.md)
+* See [doc/history.md](doc/history.md)
+* [Documentation generated using the json schemas and docson](http://prismarinejs.github.io/minecraft-data)
+* [Textual documentation of the recipe format](doc/recipes.md)
 
 ## Projects using minecraft-data
 
@@ -101,7 +102,6 @@ Projects that provide data:
 | [command-generator](https://github.com/Miro-Andrin/mc-data-command-generator) | Python | [Minecraft data generator](https://wiki.vg/Data_Generators) | Data used for parsing all vanilla server commands. |
 | [minecraft-data-generator](https://github.com/Archengius/minecraft-data-generator) | Java | minecraft client | biomes, block collision shapes, blocks, effects, enchantments, entities, foods, items, particles, tints. Required Fabric updated to the provided minecraft version. |
 
-
 Pages interesting to manually update the data if necessary:
 
 | Page | Data |
@@ -116,10 +116,10 @@ Pages interesting to manually update the data if necessary:
 
 Minecraft data provides scripts to audit the data, they can be useful to check the data is correct :
 
- * [audit_blocks](tools/js/test/audit_blocks.js)
- * [audit_items](tools/js/test/audit_items.js)
- * [audit_recipes](tools/js/test/audit_recipes.js)
- * [audit_shapes](tools/js/test/audit_shapes.js)
+* [audit_blocks](tools/js/test/audit_blocks.js)
+* [audit_items](tools/js/test/audit_items.js)
+* [audit_recipes](tools/js/test/audit_recipes.js)
+* [audit_shapes](tools/js/test/audit_shapes.js)
 
 Minecraft data also provides json schemas in enums_schemas/ that are used in
 test/test.js to check the json file are valid relative to these schemas.
@@ -128,7 +128,7 @@ formatted in order to use it.
 
 ## Contribute
 
-Please read https://github.com/PrismarineJS/prismarine-contribute
+Please read <https://github.com/PrismarineJS/prismarine-contribute>
 
 ## License
 

--- a/data/pc/common/blocksExtended.json
+++ b/data/pc/common/blocksExtended.json
@@ -1,0 +1,5341 @@
+[
+    {
+        "name": "stone",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "granite",
+        "color": "rgb(151, 109, 77)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_granite",
+        "color": "rgb(151, 109, 77)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "diorite",
+        "color": "rgb(255, 252, 245)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_diorite",
+        "color": "rgb(255, 252, 245)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "andesite",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_andesite",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "grass_block",
+        "color": "rgb(127, 178, 56)"
+    },
+    {
+        "name": "dirt",
+        "color": "rgb(151, 109, 77)"
+    },
+    {
+        "name": "coarse_dirt",
+        "color": "rgb(151, 109, 77)"
+    },
+    {
+        "name": "podzol",
+        "color": "rgb(129, 86, 49)"
+    },
+    {
+        "name": "cobblestone",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "oak_planks",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_planks",
+        "color": "rgb(129, 86, 49)",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_planks",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_planks",
+        "color": "rgb(151, 109, 77)",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_planks",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_planks",
+        "color": "rgb(209, 177, 161)",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_planks",
+        "color": "rgb(102, 76, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_planks",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_planks",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_mosaic",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "oak_sapling",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "spruce_sapling",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "birch_sapling",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "jungle_sapling",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "acacia_sapling",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "cherry_sapling",
+        "color": "rgb(242, 127, 165)"
+    },
+    {
+        "name": "dark_oak_sapling",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "mangrove_propagule",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "bedrock",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "water",
+        "color": "rgb(64, 64, 255)",
+        "isLiquid": true,
+        "isReplacable": true
+    },
+    {
+        "name": "lava",
+        "color": "rgb(255, 0, 0)",
+        "isLiquid": true,
+        "isReplacable": true,
+        "lightLevel": 15
+    },
+    {
+        "name": "sand",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "snare"
+    },
+    {
+        "name": "suspicious_sand",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "snare"
+    },
+    {
+        "name": "red_sand",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "snare"
+    },
+    {
+        "name": "gravel",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "snare"
+    },
+    {
+        "name": "suspicious_gravel",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "snare"
+    },
+    {
+        "name": "gold_ore",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "deepslate_gold_ore",
+        "color": "rgb(100, 100, 100)"
+    },
+    {
+        "name": "iron_ore",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "deepslate_iron_ore",
+        "color": "rgb(100, 100, 100)"
+    },
+    {
+        "name": "coal_ore",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "deepslate_coal_ore",
+        "color": "rgb(100, 100, 100)"
+    },
+    {
+        "name": "nether_gold_ore",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "mangrove_roots",
+        "color": "rgb(129, 86, 49)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "muddy_mangrove_roots",
+        "color": "rgb(129, 86, 49)"
+    },
+    {
+        "name": "oak_wood",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_wood",
+        "color": "rgb(129, 86, 49)",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_wood",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_wood",
+        "color": "rgb(151, 109, 77)",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_wood",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_wood",
+        "color": "rgb(57, 41, 35)",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_wood",
+        "color": "rgb(102, 76, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_wood",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_oak_wood",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_spruce_wood",
+        "color": "rgb(129, 86, 49)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_birch_wood",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_jungle_wood",
+        "color": "rgb(151, 109, 77)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_acacia_wood",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_cherry_wood",
+        "color": "rgb(160, 77, 78)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_dark_oak_wood",
+        "color": "rgb(102, 76, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "oak_leaves",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "spruce_leaves",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "birch_leaves",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "jungle_leaves",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "acacia_leaves",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "cherry_leaves",
+        "color": "rgb(242, 127, 165)",
+        "noOcclusions": true
+    },
+    {
+        "name": "dark_oak_leaves",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "mangrove_leaves",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "azalea_leaves",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "flowering_azalea_leaves",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "sponge",
+        "color": "rgb(229, 229, 51)"
+    },
+    {
+        "name": "wet_sponge",
+        "color": "rgb(229, 229, 51)"
+    },
+    {
+        "name": "lapis_ore",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "deepslate_lapis_ore",
+        "color": "rgb(100, 100, 100)"
+    },
+    {
+        "name": "lapis_block",
+        "color": "rgb(74, 128, 255)"
+    },
+    {
+        "name": "dispenser",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "sandstone",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_sandstone",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cut_sandstone",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "note_block",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "sticky_piston",
+        "color": "rgb(112, 112, 112)"
+    },
+    {
+        "name": "cobweb",
+        "color": "rgb(199, 199, 199)"
+    },
+    {
+        "name": "grass",
+        "color": "rgb(0, 124, 0)",
+        "isReplacable": true
+    },
+    {
+        "name": "fern",
+        "color": "rgb(0, 124, 0)",
+        "isReplacable": true
+    },
+    {
+        "name": "dead_bush",
+        "color": "rgb(143, 119, 72)",
+        "isReplacable": true
+    },
+    {
+        "name": "seagrass",
+        "color": "rgb(64, 64, 255)",
+        "isReplacable": true
+    },
+    {
+        "name": "tall_seagrass",
+        "color": "rgb(64, 64, 255)",
+        "isReplacable": true
+    },
+    {
+        "name": "piston",
+        "color": "rgb(112, 112, 112)"
+    },
+    {
+        "name": "piston_head",
+        "color": "rgb(112, 112, 112)"
+    },
+    {
+        "name": "white_wool",
+        "color": "rgb(255, 255, 255)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "orange_wool",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "magenta_wool",
+        "color": "rgb(178, 76, 216)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "light_blue_wool",
+        "color": "rgb(102, 153, 216)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "yellow_wool",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "lime_wool",
+        "color": "rgb(127, 204, 25)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "pink_wool",
+        "color": "rgb(242, 127, 165)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "gray_wool",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "light_gray_wool",
+        "color": "rgb(153, 153, 153)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "cyan_wool",
+        "color": "rgb(76, 127, 153)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "purple_wool",
+        "color": "rgb(127, 63, 178)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "blue_wool",
+        "color": "rgb(51, 76, 178)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "brown_wool",
+        "color": "rgb(102, 76, 51)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "green_wool",
+        "color": "rgb(102, 127, 51)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "red_wool",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "black_wool",
+        "color": "rgb(25, 25, 25)",
+        "instrument": "guitar"
+    },
+    {
+        "name": "moving_piston",
+        "color": "rgb(112, 112, 112)",
+        "noOcclusions": true
+    },
+    {
+        "name": "dandelion",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "torchflower",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "poppy",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "blue_orchid",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "allium",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "azure_bluet",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "red_tulip",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "orange_tulip",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "white_tulip",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "pink_tulip",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "oxeye_daisy",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "cornflower",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "wither_rose",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "lily_of_the_valley",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "brown_mushroom",
+        "color": "rgb(102, 76, 51)",
+        "lightLevel": 1
+    },
+    {
+        "name": "red_mushroom",
+        "color": "rgb(153, 51, 51)"
+    },
+    {
+        "name": "gold_block",
+        "color": "rgb(250, 238, 77)",
+        "instrument": "bell"
+    },
+    {
+        "name": "iron_block",
+        "color": "rgb(167, 167, 167)",
+        "instrument": "iron_xylophone"
+    },
+    {
+        "name": "bricks",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "tnt",
+        "color": "rgb(255, 0, 0)"
+    },
+    {
+        "name": "bookshelf",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "chiseled_bookshelf",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "mossy_cobblestone",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "obsidian",
+        "color": "rgb(25, 25, 25)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "fire",
+        "color": "rgb(255, 0, 0)",
+        "isReplacable": true,
+        "lightLevel": 15
+    },
+    {
+        "name": "soul_fire",
+        "color": "rgb(102, 153, 216)",
+        "isReplacable": true,
+        "lightLevel": 10
+    },
+    {
+        "name": "spawner",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum",
+        "noOcclusions": true
+    },
+    {
+        "name": "chest",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "diamond_ore",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "deepslate_diamond_ore",
+        "color": "rgb(100, 100, 100)"
+    },
+    {
+        "name": "diamond_block",
+        "color": "rgb(92, 219, 213)"
+    },
+    {
+        "name": "crafting_table",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "wheat",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "farmland",
+        "color": "rgb(151, 109, 77)"
+    },
+    {
+        "name": "furnace",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "oak_sign",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_sign",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_sign",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "oak_wall_sign",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_wall_sign",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_wall_sign",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_hanging_sign",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_hanging_sign",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_hanging_sign",
+        "color": "rgb(160, 77, 78)",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_hanging_sign",
+        "color": "rgb(148, 63, 97)",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_hanging_sign",
+        "color": "rgb(58, 142, 140)",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_hanging_sign",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_wall_hanging_sign",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_wall_hanging_sign",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_wall_hanging_sign",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_wall_hanging_sign",
+        "color": "rgb(160, 77, 78)",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_wall_hanging_sign",
+        "color": "rgb(148, 63, 97)",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_wall_hanging_sign",
+        "color": "rgb(58, 142, 140)",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_wall_hanging_sign",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stone_pressure_plate",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "iron_door",
+        "color": "rgb(167, 167, 167)",
+        "noOcclusions": true
+    },
+    {
+        "name": "redstone_ore",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "deepslate_redstone_ore",
+        "color": "rgb(100, 100, 100)"
+    },
+    {
+        "name": "snow",
+        "color": "rgb(255, 255, 255)",
+        "isReplacable": true
+    },
+    {
+        "name": "ice",
+        "color": "rgb(160, 160, 255)",
+        "noOcclusions": true
+    },
+    {
+        "name": "snow_block",
+        "color": "rgb(255, 255, 255)"
+    },
+    {
+        "name": "cactus",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "clay",
+        "color": "rgb(164, 168, 184)",
+        "instrument": "flute"
+    },
+    {
+        "name": "sugar_cane",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "jukebox",
+        "color": "rgb(151, 109, 77)",
+        "instrument": "bass"
+    },
+    {
+        "name": "pumpkin",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "didgeridoo"
+    },
+    {
+        "name": "netherrack",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "soul_sand",
+        "color": "rgb(102, 76, 51)",
+        "instrument": "cow_bell"
+    },
+    {
+        "name": "soul_soil",
+        "color": "rgb(102, 76, 51)"
+    },
+    {
+        "name": "basalt",
+        "color": "rgb(25, 25, 25)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_basalt",
+        "color": "rgb(25, 25, 25)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "glowstone",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "pling",
+        "lightLevel": 15
+    },
+    {
+        "name": "carved_pumpkin",
+        "color": "rgb(216, 127, 51)"
+    },
+    {
+        "name": "jack_o_lantern",
+        "color": "rgb(216, 127, 51)",
+        "lightLevel": 15
+    },
+    {
+        "name": "oak_trapdoor",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "spruce_trapdoor",
+        "color": "rgb(129, 86, 49)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "birch_trapdoor",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "jungle_trapdoor",
+        "color": "rgb(151, 109, 77)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "acacia_trapdoor",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "cherry_trapdoor",
+        "color": "rgb(209, 177, 161)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "dark_oak_trapdoor",
+        "color": "rgb(102, 76, 51)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "mangrove_trapdoor",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "bamboo_trapdoor",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "stone_bricks",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "mossy_stone_bricks",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cracked_stone_bricks",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_stone_bricks",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "mud_bricks",
+        "color": "rgb(135, 107, 98)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "infested_stone",
+        "color": "rgb(164, 168, 184)"
+    },
+    {
+        "name": "infested_cobblestone",
+        "color": "rgb(164, 168, 184)"
+    },
+    {
+        "name": "infested_stone_bricks",
+        "color": "rgb(164, 168, 184)"
+    },
+    {
+        "name": "infested_mossy_stone_bricks",
+        "color": "rgb(164, 168, 184)"
+    },
+    {
+        "name": "infested_cracked_stone_bricks",
+        "color": "rgb(164, 168, 184)"
+    },
+    {
+        "name": "infested_chiseled_stone_bricks",
+        "color": "rgb(164, 168, 184)"
+    },
+    {
+        "name": "brown_mushroom_block",
+        "color": "rgb(151, 109, 77)",
+        "instrument": "bass"
+    },
+    {
+        "name": "red_mushroom_block",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "mushroom_stem",
+        "color": "rgb(199, 199, 199)",
+        "instrument": "bass"
+    },
+    {
+        "name": "melon",
+        "color": "rgb(127, 204, 25)"
+    },
+    {
+        "name": "attached_pumpkin_stem",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "attached_melon_stem",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "pumpkin_stem",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "melon_stem",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "vine",
+        "color": "rgb(0, 124, 0)",
+        "isReplacable": true
+    },
+    {
+        "name": "glow_lichen",
+        "color": "rgb(127, 167, 150)",
+        "isReplacable": true
+    },
+    {
+        "name": "mycelium",
+        "color": "rgb(127, 63, 178)"
+    },
+    {
+        "name": "lily_pad",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "nether_bricks",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "nether_brick_fence",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "nether_wart",
+        "color": "rgb(153, 51, 51)"
+    },
+    {
+        "name": "enchanting_table",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "basedrum",
+        "lightLevel": 7
+    },
+    {
+        "name": "brewing_stand",
+        "color": "rgb(167, 167, 167)",
+        "noOcclusions": true,
+        "lightLevel": 1
+    },
+    {
+        "name": "cauldron",
+        "color": "rgb(112, 112, 112)",
+        "noOcclusions": true
+    },
+    {
+        "name": "end_portal",
+        "color": "rgb(25, 25, 25)",
+        "lightLevel": 15
+    },
+    {
+        "name": "end_portal_frame",
+        "color": "rgb(102, 127, 51)",
+        "instrument": "basedrum",
+        "lightLevel": 1
+    },
+    {
+        "name": "end_stone",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dragon_egg",
+        "color": "rgb(25, 25, 25)",
+        "noOcclusions": true,
+        "lightLevel": 1
+    },
+    {
+        "name": "cocoa",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "emerald_ore",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "deepslate_emerald_ore",
+        "color": "rgb(100, 100, 100)"
+    },
+    {
+        "name": "ender_chest",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum",
+        "lightLevel": 7
+    },
+    {
+        "name": "emerald_block",
+        "color": "rgb(0, 217, 58)",
+        "instrument": "bit"
+    },
+    {
+        "name": "command_block",
+        "color": "rgb(102, 76, 51)"
+    },
+    {
+        "name": "beacon",
+        "color": "rgb(92, 219, 213)",
+        "instrument": "hat",
+        "noOcclusions": true,
+        "lightLevel": 15
+    },
+    {
+        "name": "carrots",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "potatoes",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "anvil",
+        "color": "rgb(167, 167, 167)"
+    },
+    {
+        "name": "chipped_anvil",
+        "color": "rgb(167, 167, 167)"
+    },
+    {
+        "name": "damaged_anvil",
+        "color": "rgb(167, 167, 167)"
+    },
+    {
+        "name": "trapped_chest",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "light_weighted_pressure_plate",
+        "color": "rgb(250, 238, 77)"
+    },
+    {
+        "name": "heavy_weighted_pressure_plate",
+        "color": "rgb(167, 167, 167)"
+    },
+    {
+        "name": "daylight_detector",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "redstone_block",
+        "color": "rgb(255, 0, 0)"
+    },
+    {
+        "name": "nether_quartz_ore",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "hopper",
+        "color": "rgb(112, 112, 112)",
+        "noOcclusions": true
+    },
+    {
+        "name": "quartz_block",
+        "color": "rgb(255, 252, 245)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_quartz_block",
+        "color": "rgb(255, 252, 245)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "quartz_pillar",
+        "color": "rgb(255, 252, 245)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dropper",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "white_terracotta",
+        "color": "rgb(209, 177, 161)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "orange_terracotta",
+        "color": "rgb(159, 82, 36)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "magenta_terracotta",
+        "color": "rgb(149, 87, 108)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "light_blue_terracotta",
+        "color": "rgb(112, 108, 138)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "yellow_terracotta",
+        "color": "rgb(186, 133, 36)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "lime_terracotta",
+        "color": "rgb(103, 117, 53)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "pink_terracotta",
+        "color": "rgb(160, 77, 78)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "gray_terracotta",
+        "color": "rgb(57, 41, 35)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "light_gray_terracotta",
+        "color": "rgb(135, 107, 98)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cyan_terracotta",
+        "color": "rgb(87, 92, 92)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "purple_terracotta",
+        "color": "rgb(122, 73, 88)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "blue_terracotta",
+        "color": "rgb(76, 62, 92)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "brown_terracotta",
+        "color": "rgb(76, 50, 35)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "green_terracotta",
+        "color": "rgb(76, 82, 42)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "red_terracotta",
+        "color": "rgb(142, 60, 46)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "black_terracotta",
+        "color": "rgb(37, 22, 16)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "slime_block",
+        "color": "rgb(127, 178, 56)",
+        "noOcclusions": true
+    },
+    {
+        "name": "iron_trapdoor",
+        "color": "rgb(167, 167, 167)",
+        "noOcclusions": true
+    },
+    {
+        "name": "prismarine",
+        "color": "rgb(76, 127, 153)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "prismarine_bricks",
+        "color": "rgb(92, 219, 213)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dark_prismarine",
+        "color": "rgb(92, 219, 213)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "prismarine_slab",
+        "color": "rgb(76, 127, 153)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "prismarine_brick_slab",
+        "color": "rgb(92, 219, 213)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dark_prismarine_slab",
+        "color": "rgb(92, 219, 213)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "sea_lantern",
+        "color": "rgb(255, 252, 245)",
+        "instrument": "hat",
+        "lightLevel": 15
+    },
+    {
+        "name": "hay_block",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "banjo"
+    },
+    {
+        "name": "white_carpet",
+        "color": "rgb(255, 255, 255)"
+    },
+    {
+        "name": "orange_carpet",
+        "color": "rgb(216, 127, 51)"
+    },
+    {
+        "name": "magenta_carpet",
+        "color": "rgb(178, 76, 216)"
+    },
+    {
+        "name": "light_blue_carpet",
+        "color": "rgb(102, 153, 216)"
+    },
+    {
+        "name": "yellow_carpet",
+        "color": "rgb(229, 229, 51)"
+    },
+    {
+        "name": "lime_carpet",
+        "color": "rgb(127, 204, 25)"
+    },
+    {
+        "name": "pink_carpet",
+        "color": "rgb(242, 127, 165)"
+    },
+    {
+        "name": "gray_carpet",
+        "color": "rgb(76, 76, 76)"
+    },
+    {
+        "name": "light_gray_carpet",
+        "color": "rgb(153, 153, 153)"
+    },
+    {
+        "name": "cyan_carpet",
+        "color": "rgb(76, 127, 153)"
+    },
+    {
+        "name": "purple_carpet",
+        "color": "rgb(127, 63, 178)"
+    },
+    {
+        "name": "blue_carpet",
+        "color": "rgb(51, 76, 178)"
+    },
+    {
+        "name": "brown_carpet",
+        "color": "rgb(102, 76, 51)"
+    },
+    {
+        "name": "green_carpet",
+        "color": "rgb(102, 127, 51)"
+    },
+    {
+        "name": "red_carpet",
+        "color": "rgb(153, 51, 51)"
+    },
+    {
+        "name": "black_carpet",
+        "color": "rgb(25, 25, 25)"
+    },
+    {
+        "name": "terracotta",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "coal_block",
+        "color": "rgb(25, 25, 25)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "packed_ice",
+        "color": "rgb(160, 160, 255)",
+        "instrument": "chime"
+    },
+    {
+        "name": "sunflower",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "lilac",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "rose_bush",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "peony",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "tall_grass",
+        "color": "rgb(0, 124, 0)",
+        "isReplacable": true
+    },
+    {
+        "name": "large_fern",
+        "color": "rgb(0, 124, 0)",
+        "isReplacable": true
+    },
+    {
+        "name": "white_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "orange_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "magenta_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "light_blue_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "yellow_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "lime_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "pink_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "gray_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "light_gray_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "cyan_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "purple_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "blue_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "brown_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "green_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "red_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "black_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "white_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "orange_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "magenta_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "light_blue_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "yellow_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "lime_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "pink_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "gray_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "light_gray_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "cyan_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "purple_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "blue_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "brown_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "green_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "red_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "black_wall_banner",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "red_sandstone",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_red_sandstone",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cut_red_sandstone",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "oak_slab",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_slab",
+        "color": "rgb(129, 86, 49)",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_slab",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_slab",
+        "color": "rgb(151, 109, 77)",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_slab",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_slab",
+        "color": "rgb(209, 177, 161)",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_slab",
+        "color": "rgb(102, 76, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_slab",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_slab",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_mosaic_slab",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stone_slab",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_stone_slab",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "sandstone_slab",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cut_sandstone_slab",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "petrified_oak_slab",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cobblestone_slab",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "brick_slab",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "stone_brick_slab",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "mud_brick_slab",
+        "color": "rgb(135, 107, 98)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "nether_brick_slab",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "quartz_slab",
+        "color": "rgb(255, 252, 245)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "red_sandstone_slab",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cut_red_sandstone_slab",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "purpur_slab",
+        "color": "rgb(178, 76, 216)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_stone",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_sandstone",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_quartz",
+        "color": "rgb(255, 252, 245)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_red_sandstone",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chorus_plant",
+        "color": "rgb(127, 63, 178)",
+        "noOcclusions": true
+    },
+    {
+        "name": "chorus_flower",
+        "color": "rgb(127, 63, 178)",
+        "noOcclusions": true
+    },
+    {
+        "name": "purpur_block",
+        "color": "rgb(178, 76, 216)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "purpur_pillar",
+        "color": "rgb(178, 76, 216)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "end_stone_bricks",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "torchflower_crop",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "pitcher_crop",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "pitcher_plant",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "beetroots",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "dirt_path",
+        "color": "rgb(151, 109, 77)"
+    },
+    {
+        "name": "end_gateway",
+        "color": "rgb(25, 25, 25)",
+        "lightLevel": 15
+    },
+    {
+        "name": "repeating_command_block",
+        "color": "rgb(127, 63, 178)"
+    },
+    {
+        "name": "chain_command_block",
+        "color": "rgb(102, 127, 51)"
+    },
+    {
+        "name": "frosted_ice",
+        "color": "rgb(160, 160, 255)",
+        "noOcclusions": true
+    },
+    {
+        "name": "magma_block",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum",
+        "lightLevel": 3
+    },
+    {
+        "name": "nether_wart_block",
+        "color": "rgb(153, 51, 51)"
+    },
+    {
+        "name": "red_nether_bricks",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "bone_block",
+        "color": "rgb(247, 233, 163)",
+        "instrument": "xylophone"
+    },
+    {
+        "name": "observer",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "kelp",
+        "color": "rgb(64, 64, 255)"
+    },
+    {
+        "name": "kelp_plant",
+        "color": "rgb(64, 64, 255)"
+    },
+    {
+        "name": "dried_kelp_block",
+        "color": "rgb(102, 127, 51)"
+    },
+    {
+        "name": "turtle_egg",
+        "color": "rgb(247, 233, 163)",
+        "noOcclusions": true
+    },
+    {
+        "name": "sniffer_egg",
+        "color": "rgb(153, 51, 51)",
+        "noOcclusions": true
+    },
+    {
+        "name": "dead_tube_coral_block",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_brain_coral_block",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_bubble_coral_block",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_fire_coral_block",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_horn_coral_block",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "tube_coral_block",
+        "color": "rgb(51, 76, 178)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "brain_coral_block",
+        "color": "rgb(242, 127, 165)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "bubble_coral_block",
+        "color": "rgb(127, 63, 178)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "fire_coral_block",
+        "color": "rgb(153, 51, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "horn_coral_block",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_tube_coral",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_brain_coral",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_bubble_coral",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_fire_coral",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_horn_coral",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "tube_coral",
+        "color": "rgb(51, 76, 178)"
+    },
+    {
+        "name": "brain_coral",
+        "color": "rgb(242, 127, 165)"
+    },
+    {
+        "name": "bubble_coral",
+        "color": "rgb(127, 63, 178)"
+    },
+    {
+        "name": "fire_coral",
+        "color": "rgb(153, 51, 51)"
+    },
+    {
+        "name": "horn_coral",
+        "color": "rgb(229, 229, 51)"
+    },
+    {
+        "name": "dead_tube_coral_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_brain_coral_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_bubble_coral_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_fire_coral_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_horn_coral_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "tube_coral_fan",
+        "color": "rgb(51, 76, 178)"
+    },
+    {
+        "name": "brain_coral_fan",
+        "color": "rgb(242, 127, 165)"
+    },
+    {
+        "name": "bubble_coral_fan",
+        "color": "rgb(127, 63, 178)"
+    },
+    {
+        "name": "fire_coral_fan",
+        "color": "rgb(153, 51, 51)"
+    },
+    {
+        "name": "horn_coral_fan",
+        "color": "rgb(229, 229, 51)"
+    },
+    {
+        "name": "dead_tube_coral_wall_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_brain_coral_wall_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_bubble_coral_wall_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_fire_coral_wall_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_horn_coral_wall_fan",
+        "color": "rgb(76, 76, 76)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "tube_coral_wall_fan",
+        "color": "rgb(51, 76, 178)"
+    },
+    {
+        "name": "brain_coral_wall_fan",
+        "color": "rgb(242, 127, 165)"
+    },
+    {
+        "name": "bubble_coral_wall_fan",
+        "color": "rgb(127, 63, 178)"
+    },
+    {
+        "name": "fire_coral_wall_fan",
+        "color": "rgb(153, 51, 51)"
+    },
+    {
+        "name": "horn_coral_wall_fan",
+        "color": "rgb(229, 229, 51)"
+    },
+    {
+        "name": "sea_pickle",
+        "color": "rgb(102, 127, 51)",
+        "noOcclusions": true
+    },
+    {
+        "name": "blue_ice",
+        "color": "rgb(160, 160, 255)"
+    },
+    {
+        "name": "conduit",
+        "color": "rgb(92, 219, 213)",
+        "instrument": "hat",
+        "noOcclusions": true,
+        "lightLevel": 15
+    },
+    {
+        "name": "bamboo_sapling",
+        "color": "rgb(143, 119, 72)"
+    },
+    {
+        "name": "bamboo",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "bubble_column",
+        "color": "rgb(64, 64, 255)",
+        "isLiquid": true,
+        "isReplacable": true
+    },
+    {
+        "name": "scaffolding",
+        "color": "rgb(247, 233, 163)"
+    },
+    {
+        "name": "loom",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "barrel",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "smoker",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "blast_furnace",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cartography_table",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "fletching_table",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "grindstone",
+        "color": "rgb(167, 167, 167)"
+    },
+    {
+        "name": "lectern",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "smithing_table",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stonecutter",
+        "color": "rgb(112, 112, 112)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "bell",
+        "color": "rgb(250, 238, 77)"
+    },
+    {
+        "name": "lantern",
+        "color": "rgb(167, 167, 167)",
+        "noOcclusions": true,
+        "lightLevel": 15
+    },
+    {
+        "name": "soul_lantern",
+        "color": "rgb(167, 167, 167)",
+        "noOcclusions": true,
+        "lightLevel": 10
+    },
+    {
+        "name": "campfire",
+        "color": "rgb(129, 86, 49)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "soul_campfire",
+        "color": "rgb(129, 86, 49)",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "sweet_berry_bush",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "warped_hyphae",
+        "color": "rgb(86, 44, 62)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_warped_hyphae",
+        "color": "rgb(86, 44, 62)",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_nylium",
+        "color": "rgb(22, 126, 134)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "warped_fungus",
+        "color": "rgb(76, 127, 153)"
+    },
+    {
+        "name": "warped_wart_block",
+        "color": "rgb(20, 180, 133)"
+    },
+    {
+        "name": "warped_roots",
+        "color": "rgb(76, 127, 153)",
+        "isReplacable": true
+    },
+    {
+        "name": "nether_sprouts",
+        "color": "rgb(76, 127, 153)",
+        "isReplacable": true
+    },
+    {
+        "name": "crimson_hyphae",
+        "color": "rgb(92, 25, 29)",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_crimson_hyphae",
+        "color": "rgb(92, 25, 29)",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_nylium",
+        "color": "rgb(189, 48, 49)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "crimson_fungus",
+        "color": "rgb(112, 2, 0)"
+    },
+    {
+        "name": "shroomlight",
+        "color": "rgb(153, 51, 51)",
+        "lightLevel": 15
+    },
+    {
+        "name": "weeping_vines",
+        "color": "rgb(112, 2, 0)"
+    },
+    {
+        "name": "weeping_vines_plant",
+        "color": "rgb(112, 2, 0)"
+    },
+    {
+        "name": "twisting_vines",
+        "color": "rgb(76, 127, 153)"
+    },
+    {
+        "name": "twisting_vines_plant",
+        "color": "rgb(76, 127, 153)"
+    },
+    {
+        "name": "crimson_roots",
+        "color": "rgb(112, 2, 0)",
+        "isReplacable": true
+    },
+    {
+        "name": "crimson_planks",
+        "color": "rgb(148, 63, 97)",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_planks",
+        "color": "rgb(58, 142, 140)",
+        "instrument": "bass"
+    },
+    {
+        "name": "structure_block",
+        "color": "rgb(153, 153, 153)"
+    },
+    {
+        "name": "jigsaw",
+        "color": "rgb(153, 153, 153)"
+    },
+    {
+        "name": "composter",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "target",
+        "color": "rgb(255, 252, 245)"
+    },
+    {
+        "name": "bee_nest",
+        "color": "rgb(229, 229, 51)",
+        "instrument": "bass"
+    },
+    {
+        "name": "beehive",
+        "color": "rgb(143, 119, 72)",
+        "instrument": "bass"
+    },
+    {
+        "name": "honey_block",
+        "color": "rgb(216, 127, 51)",
+        "noOcclusions": true
+    },
+    {
+        "name": "honeycomb_block",
+        "color": "rgb(216, 127, 51)"
+    },
+    {
+        "name": "netherite_block",
+        "color": "rgb(25, 25, 25)"
+    },
+    {
+        "name": "ancient_debris",
+        "color": "rgb(25, 25, 25)"
+    },
+    {
+        "name": "crying_obsidian",
+        "color": "rgb(25, 25, 25)",
+        "instrument": "basedrum",
+        "lightLevel": 10
+    },
+    {
+        "name": "respawn_anchor",
+        "color": "rgb(25, 25, 25)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "lodestone",
+        "color": "rgb(167, 167, 167)"
+    },
+    {
+        "name": "blackstone",
+        "color": "rgb(25, 25, 25)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_blackstone_pressure_plate",
+        "color": "rgb(25, 25, 25)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_nether_bricks",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cracked_nether_bricks",
+        "color": "rgb(112, 2, 0)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "amethyst_block",
+        "color": "rgb(127, 63, 178)"
+    },
+    {
+        "name": "budding_amethyst",
+        "color": "rgb(127, 63, 178)"
+    },
+    {
+        "name": "amethyst_cluster",
+        "color": "rgb(127, 63, 178)",
+        "noOcclusions": true,
+        "lightLevel": 5
+    },
+    {
+        "name": "tuff",
+        "color": "rgb(57, 41, 35)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "calcite",
+        "color": "rgb(209, 177, 161)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "tinted_glass",
+        "color": "rgb(76, 76, 76)",
+        "noOcclusions": true
+    },
+    {
+        "name": "powder_snow",
+        "color": "rgb(255, 255, 255)"
+    },
+    {
+        "name": "sculk_sensor",
+        "color": "rgb(76, 127, 153)",
+        "lightLevel": 1
+    },
+    {
+        "name": "sculk",
+        "color": "rgb(25, 25, 25)"
+    },
+    {
+        "name": "sculk_vein",
+        "color": "rgb(25, 25, 25)"
+    },
+    {
+        "name": "sculk_catalyst",
+        "color": "rgb(25, 25, 25)",
+        "lightLevel": 6
+    },
+    {
+        "name": "sculk_shrieker",
+        "color": "rgb(25, 25, 25)"
+    },
+    {
+        "name": "oxidized_copper",
+        "color": "rgb(22, 126, 134)"
+    },
+    {
+        "name": "weathered_copper",
+        "color": "rgb(58, 142, 140)"
+    },
+    {
+        "name": "exposed_copper",
+        "color": "rgb(135, 107, 98)"
+    },
+    {
+        "name": "copper_block",
+        "color": "rgb(216, 127, 51)"
+    },
+    {
+        "name": "deepslate_copper_ore",
+        "color": "rgb(100, 100, 100)"
+    },
+    {
+        "name": "lightning_rod",
+        "color": "rgb(216, 127, 51)",
+        "noOcclusions": true
+    },
+    {
+        "name": "pointed_dripstone",
+        "color": "rgb(76, 50, 35)",
+        "instrument": "basedrum",
+        "noOcclusions": true
+    },
+    {
+        "name": "dripstone_block",
+        "color": "rgb(76, 50, 35)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cave_vines",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "cave_vines_plant",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "spore_blossom",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "azalea",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "flowering_azalea",
+        "color": "rgb(0, 124, 0)",
+        "noOcclusions": true
+    },
+    {
+        "name": "moss_carpet",
+        "color": "rgb(102, 127, 51)"
+    },
+    {
+        "name": "pink_petals",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "moss_block",
+        "color": "rgb(102, 127, 51)"
+    },
+    {
+        "name": "big_dripleaf",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "big_dripleaf_stem",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "small_dripleaf",
+        "color": "rgb(0, 124, 0)"
+    },
+    {
+        "name": "hanging_roots",
+        "color": "rgb(151, 109, 77)",
+        "isReplacable": true
+    },
+    {
+        "name": "rooted_dirt",
+        "color": "rgb(151, 109, 77)"
+    },
+    {
+        "name": "mud",
+        "color": "rgb(87, 92, 92)"
+    },
+    {
+        "name": "deepslate",
+        "color": "rgb(100, 100, 100)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "infested_deepslate",
+        "color": "rgb(100, 100, 100)"
+    },
+    {
+        "name": "raw_iron_block",
+        "color": "rgb(216, 175, 147)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "raw_copper_block",
+        "color": "rgb(216, 127, 51)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "raw_gold_block",
+        "color": "rgb(250, 238, 77)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "ochre_froglight",
+        "color": "rgb(247, 233, 163)",
+        "lightLevel": 15
+    },
+    {
+        "name": "verdant_froglight",
+        "color": "rgb(127, 167, 150)",
+        "lightLevel": 15
+    },
+    {
+        "name": "pearlescent_froglight",
+        "color": "rgb(242, 127, 165)",
+        "lightLevel": 15
+    },
+    {
+        "name": "frogspawn",
+        "color": "rgb(64, 64, 255)",
+        "noOcclusions": true
+    },
+    {
+        "name": "reinforced_deepslate",
+        "color": "rgb(100, 100, 100)",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "decorated_pot",
+        "color": "rgb(142, 60, 46)",
+        "noOcclusions": true
+    },
+    {
+        "name": "stone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "granite",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_granite",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "diorite",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_diorite",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "andesite",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_andesite",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cobblestone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "oak_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_mosaic",
+        "instrument": "bass"
+    },
+    {
+        "name": "bedrock",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "sand",
+        "instrument": "snare"
+    },
+    {
+        "name": "suspicious_sand",
+        "instrument": "snare"
+    },
+    {
+        "name": "red_sand",
+        "instrument": "snare"
+    },
+    {
+        "name": "gravel",
+        "instrument": "snare"
+    },
+    {
+        "name": "suspicious_gravel",
+        "instrument": "snare"
+    },
+    {
+        "name": "gold_ore",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "iron_ore",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "coal_ore",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "nether_gold_ore",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "oak_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_roots",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_block",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_spruce_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_birch_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_jungle_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_acacia_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_cherry_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_dark_oak_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_oak_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_mangrove_log",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_bamboo_block",
+        "instrument": "bass"
+    },
+    {
+        "name": "oak_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_oak_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_spruce_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_birch_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_jungle_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_acacia_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_cherry_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_dark_oak_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_mangrove_wood",
+        "instrument": "bass"
+    },
+    {
+        "name": "glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "lapis_ore",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dispenser",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "sandstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_sandstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cut_sandstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "note_block",
+        "instrument": "bass"
+    },
+    {
+        "name": "white_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "orange_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "magenta_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "light_blue_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "yellow_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "lime_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "pink_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "gray_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "light_gray_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "cyan_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "purple_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "blue_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "brown_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "green_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "red_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "black_wool",
+        "instrument": "guitar"
+    },
+    {
+        "name": "gold_block",
+        "instrument": "bell"
+    },
+    {
+        "name": "iron_block",
+        "instrument": "iron_xylophone"
+    },
+    {
+        "name": "bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "bookshelf",
+        "instrument": "bass"
+    },
+    {
+        "name": "chiseled_bookshelf",
+        "instrument": "bass"
+    },
+    {
+        "name": "mossy_cobblestone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "obsidian",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "spawner",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chest",
+        "instrument": "bass"
+    },
+    {
+        "name": "diamond_ore",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "crafting_table",
+        "instrument": "bass"
+    },
+    {
+        "name": "furnace",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "oak_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "oak_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "oak_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "oak_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "oak_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_wall_hanging_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "stone_pressure_plate",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "oak_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "redstone_ore",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "clay",
+        "instrument": "flute"
+    },
+    {
+        "name": "jukebox",
+        "instrument": "bass"
+    },
+    {
+        "name": "oak_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "pumpkin",
+        "instrument": "didgeridoo"
+    },
+    {
+        "name": "netherrack",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "soul_sand",
+        "instrument": "cow_bell"
+    },
+    {
+        "name": "basalt",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_basalt",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "glowstone",
+        "instrument": "pling"
+    },
+    {
+        "name": "white_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "orange_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "magenta_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_blue_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "yellow_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "lime_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "pink_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "gray_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_gray_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "cyan_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "purple_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "blue_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "brown_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "green_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "red_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "black_stained_glass",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "oak_trapdoor",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_trapdoor",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_trapdoor",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_trapdoor",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_trapdoor",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_trapdoor",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_trapdoor",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_trapdoor",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_trapdoor",
+        "instrument": "bass"
+    },
+    {
+        "name": "stone_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "mossy_stone_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cracked_stone_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_stone_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "mud_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "brown_mushroom_block",
+        "instrument": "bass"
+    },
+    {
+        "name": "red_mushroom_block",
+        "instrument": "bass"
+    },
+    {
+        "name": "mushroom_stem",
+        "instrument": "bass"
+    },
+    {
+        "name": "glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "oak_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "nether_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "nether_brick_fence",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "enchanting_table",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "end_portal_frame",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "end_stone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "emerald_ore",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "ender_chest",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "emerald_block",
+        "instrument": "bit"
+    },
+    {
+        "name": "beacon",
+        "instrument": "hat"
+    },
+    {
+        "name": "skeleton_skull",
+        "instrument": "skeleton"
+    },
+    {
+        "name": "wither_skeleton_skull",
+        "instrument": "wither_skeleton"
+    },
+    {
+        "name": "zombie_head",
+        "instrument": "zombie"
+    },
+    {
+        "name": "player_head",
+        "instrument": "custom_head"
+    },
+    {
+        "name": "creeper_head",
+        "instrument": "creeper"
+    },
+    {
+        "name": "dragon_head",
+        "instrument": "dragon"
+    },
+    {
+        "name": "piglin_head",
+        "instrument": "piglin"
+    },
+    {
+        "name": "trapped_chest",
+        "instrument": "bass"
+    },
+    {
+        "name": "daylight_detector",
+        "instrument": "bass"
+    },
+    {
+        "name": "nether_quartz_ore",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "quartz_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_quartz_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "quartz_pillar",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dropper",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "white_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "orange_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "magenta_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "light_blue_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "yellow_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "lime_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "pink_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "gray_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "light_gray_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cyan_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "purple_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "blue_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "brown_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "green_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "red_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "black_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "white_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "orange_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "magenta_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_blue_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "yellow_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "lime_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "pink_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "gray_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_gray_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "cyan_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "purple_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "blue_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "brown_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "green_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "red_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "black_stained_glass_pane",
+        "instrument": "hat",
+        "noOcclusions": true
+    },
+    {
+        "name": "prismarine",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "prismarine_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dark_prismarine",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "prismarine_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "prismarine_brick_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dark_prismarine_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "sea_lantern",
+        "instrument": "hat"
+    },
+    {
+        "name": "hay_block",
+        "instrument": "banjo"
+    },
+    {
+        "name": "terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "coal_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "packed_ice",
+        "instrument": "chime"
+    },
+    {
+        "name": "white_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "orange_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "magenta_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "light_blue_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "yellow_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "lime_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "pink_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "gray_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "light_gray_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "cyan_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "purple_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "blue_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "brown_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "green_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "red_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "black_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "white_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "orange_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "magenta_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "light_blue_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "yellow_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "lime_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "pink_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "gray_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "light_gray_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "cyan_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "purple_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "blue_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "brown_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "green_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "red_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "black_wall_banner",
+        "instrument": "bass"
+    },
+    {
+        "name": "red_sandstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_red_sandstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cut_red_sandstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "oak_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_mosaic_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "stone_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_stone_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "sandstone_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cut_sandstone_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "petrified_oak_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cobblestone_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "brick_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "stone_brick_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "mud_brick_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "nether_brick_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "quartz_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "red_sandstone_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cut_red_sandstone_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "purpur_slab",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_stone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_sandstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_quartz",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "smooth_red_sandstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "spruce_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "birch_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "jungle_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "acacia_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "cherry_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "dark_oak_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "mangrove_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "bamboo_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "spruce_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "birch_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "jungle_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "acacia_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "cherry_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "dark_oak_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "mangrove_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "bamboo_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "purpur_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "purpur_pillar",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "end_stone_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "magma_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "red_nether_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "bone_block",
+        "instrument": "xylophone"
+    },
+    {
+        "name": "observer",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "white_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "orange_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "magenta_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "light_blue_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "yellow_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "lime_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "pink_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "gray_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "light_gray_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cyan_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "purple_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "blue_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "brown_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "green_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "red_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "black_glazed_terracotta",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "white_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "orange_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "magenta_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "light_blue_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "yellow_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "lime_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "pink_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "gray_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "light_gray_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cyan_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "purple_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "blue_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "brown_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "green_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "red_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "black_concrete",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "white_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "orange_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "magenta_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "light_blue_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "yellow_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "lime_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "pink_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "gray_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "light_gray_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "cyan_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "purple_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "blue_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "brown_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "green_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "red_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "black_concrete_powder",
+        "instrument": "snare"
+    },
+    {
+        "name": "dead_tube_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_brain_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_bubble_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_fire_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_horn_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "tube_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "brain_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "bubble_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "fire_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "horn_coral_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_tube_coral",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_brain_coral",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_bubble_coral",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_fire_coral",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_horn_coral",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_tube_coral_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_brain_coral_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_bubble_coral_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_fire_coral_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_horn_coral_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_tube_coral_wall_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_brain_coral_wall_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_bubble_coral_wall_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_fire_coral_wall_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dead_horn_coral_wall_fan",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "conduit",
+        "instrument": "hat"
+    },
+    {
+        "name": "loom",
+        "instrument": "bass"
+    },
+    {
+        "name": "barrel",
+        "instrument": "bass"
+    },
+    {
+        "name": "smoker",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "blast_furnace",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cartography_table",
+        "instrument": "bass"
+    },
+    {
+        "name": "fletching_table",
+        "instrument": "bass"
+    },
+    {
+        "name": "lectern",
+        "instrument": "bass"
+    },
+    {
+        "name": "smithing_table",
+        "instrument": "bass"
+    },
+    {
+        "name": "stonecutter",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "campfire",
+        "instrument": "bass"
+    },
+    {
+        "name": "soul_campfire",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_stem",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_warped_stem",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_hyphae",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_warped_hyphae",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_nylium",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "crimson_stem",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_crimson_stem",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_hyphae",
+        "instrument": "bass"
+    },
+    {
+        "name": "stripped_crimson_hyphae",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_nylium",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "crimson_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_planks",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_slab",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_pressure_plate",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_fence",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_trapdoor",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "warped_trapdoor",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "crimson_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_fence_gate",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "warped_door",
+        "instrument": "bass",
+        "noOcclusions": true
+    },
+    {
+        "name": "crimson_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "crimson_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "warped_wall_sign",
+        "instrument": "bass"
+    },
+    {
+        "name": "composter",
+        "instrument": "bass"
+    },
+    {
+        "name": "bee_nest",
+        "instrument": "bass"
+    },
+    {
+        "name": "beehive",
+        "instrument": "bass"
+    },
+    {
+        "name": "crying_obsidian",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "respawn_anchor",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "blackstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "polished_blackstone_pressure_plate",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "chiseled_nether_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "cracked_nether_bricks",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "tuff",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "calcite",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "pointed_dripstone",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "dripstone_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "deepslate",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "raw_iron_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "raw_copper_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "raw_gold_block",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "reinforced_deepslate",
+        "instrument": "basedrum"
+    },
+    {
+        "name": "air",
+        "isAir": true,
+        "isReplacable": true
+    },
+    {
+        "name": "void_air",
+        "isAir": true,
+        "isReplacable": true
+    },
+    {
+        "name": "cave_air",
+        "isAir": true,
+        "isReplacable": true
+    },
+    {
+        "name": "water",
+        "isLiquid": true
+    },
+    {
+        "name": "lava",
+        "isLiquid": true
+    },
+    {
+        "name": "bubble_column",
+        "isLiquid": true
+    },
+    {
+        "name": "mangrove_roots",
+        "noOcclusions": true
+    },
+    {
+        "name": "oak_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "spruce_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "birch_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "jungle_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "acacia_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "cherry_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "dark_oak_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "mangrove_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "azalea_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "flowering_azalea_leaves",
+        "noOcclusions": true
+    },
+    {
+        "name": "glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "white_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "orange_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "magenta_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_blue_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "yellow_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "lime_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "pink_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "gray_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_gray_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "cyan_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "purple_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "blue_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "brown_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "green_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "red_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "black_bed",
+        "noOcclusions": true
+    },
+    {
+        "name": "moving_piston",
+        "noOcclusions": true
+    },
+    {
+        "name": "spawner",
+        "noOcclusions": true
+    },
+    {
+        "name": "oak_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "ladder",
+        "noOcclusions": true
+    },
+    {
+        "name": "iron_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "ice",
+        "noOcclusions": true
+    },
+    {
+        "name": "white_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "orange_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "magenta_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_blue_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "yellow_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "lime_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "pink_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "gray_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_gray_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "cyan_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "purple_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "blue_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "brown_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "green_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "red_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "black_stained_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "oak_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "spruce_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "birch_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "jungle_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "acacia_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "cherry_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "dark_oak_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "mangrove_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "bamboo_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "iron_bars",
+        "noOcclusions": true
+    },
+    {
+        "name": "chain",
+        "noOcclusions": true
+    },
+    {
+        "name": "glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "lily_pad",
+        "noOcclusions": true
+    },
+    {
+        "name": "brewing_stand",
+        "noOcclusions": true
+    },
+    {
+        "name": "cauldron",
+        "noOcclusions": true
+    },
+    {
+        "name": "dragon_egg",
+        "noOcclusions": true
+    },
+    {
+        "name": "cocoa",
+        "noOcclusions": true
+    },
+    {
+        "name": "beacon",
+        "noOcclusions": true
+    },
+    {
+        "name": "hopper",
+        "noOcclusions": true
+    },
+    {
+        "name": "white_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "orange_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "magenta_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_blue_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "yellow_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "lime_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "pink_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "gray_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_gray_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "cyan_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "purple_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "blue_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "brown_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "green_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "red_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "black_stained_glass_pane",
+        "noOcclusions": true
+    },
+    {
+        "name": "slime_block",
+        "noOcclusions": true
+    },
+    {
+        "name": "barrier",
+        "noOcclusions": true
+    },
+    {
+        "name": "light",
+        "noOcclusions": true,
+        "isReplacable": true
+    },
+    {
+        "name": "iron_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "spruce_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "birch_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "jungle_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "acacia_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "cherry_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "dark_oak_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "mangrove_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "bamboo_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "end_rod",
+        "noOcclusions": true,
+        "lightLevel": 14
+    },
+    {
+        "name": "chorus_plant",
+        "noOcclusions": true
+    },
+    {
+        "name": "chorus_flower",
+        "noOcclusions": true
+    },
+    {
+        "name": "frosted_ice",
+        "noOcclusions": true
+    },
+    {
+        "name": "turtle_egg",
+        "noOcclusions": true
+    },
+    {
+        "name": "sniffer_egg",
+        "noOcclusions": true
+    },
+    {
+        "name": "sea_pickle",
+        "noOcclusions": true
+    },
+    {
+        "name": "conduit",
+        "noOcclusions": true
+    },
+    {
+        "name": "bamboo",
+        "noOcclusions": true
+    },
+    {
+        "name": "lantern",
+        "noOcclusions": true
+    },
+    {
+        "name": "soul_lantern",
+        "noOcclusions": true
+    },
+    {
+        "name": "campfire",
+        "noOcclusions": true
+    },
+    {
+        "name": "soul_campfire",
+        "noOcclusions": true
+    },
+    {
+        "name": "crimson_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "warped_trapdoor",
+        "noOcclusions": true
+    },
+    {
+        "name": "crimson_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "warped_door",
+        "noOcclusions": true
+    },
+    {
+        "name": "honey_block",
+        "noOcclusions": true
+    },
+    {
+        "name": "candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "white_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "orange_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "magenta_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_blue_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "yellow_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "lime_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "pink_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "gray_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "light_gray_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "cyan_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "purple_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "blue_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "brown_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "green_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "red_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "black_candle",
+        "noOcclusions": true
+    },
+    {
+        "name": "amethyst_cluster",
+        "noOcclusions": true
+    },
+    {
+        "name": "tinted_glass",
+        "noOcclusions": true
+    },
+    {
+        "name": "lightning_rod",
+        "noOcclusions": true
+    },
+    {
+        "name": "pointed_dripstone",
+        "noOcclusions": true
+    },
+    {
+        "name": "azalea",
+        "noOcclusions": true
+    },
+    {
+        "name": "flowering_azalea",
+        "noOcclusions": true
+    },
+    {
+        "name": "frogspawn",
+        "noOcclusions": true
+    },
+    {
+        "name": "decorated_pot",
+        "noOcclusions": true
+    },
+    {
+        "name": "air",
+        "isReplacable": true
+    },
+    {
+        "name": "water",
+        "isReplacable": true
+    },
+    {
+        "name": "lava",
+        "isReplacable": true
+    },
+    {
+        "name": "grass",
+        "isReplacable": true
+    },
+    {
+        "name": "fern",
+        "isReplacable": true
+    },
+    {
+        "name": "dead_bush",
+        "isReplacable": true
+    },
+    {
+        "name": "seagrass",
+        "isReplacable": true
+    },
+    {
+        "name": "tall_seagrass",
+        "isReplacable": true
+    },
+    {
+        "name": "fire",
+        "isReplacable": true
+    },
+    {
+        "name": "soul_fire",
+        "isReplacable": true
+    },
+    {
+        "name": "snow",
+        "isReplacable": true
+    },
+    {
+        "name": "vine",
+        "isReplacable": true
+    },
+    {
+        "name": "glow_lichen",
+        "isReplacable": true
+    },
+    {
+        "name": "light",
+        "isReplacable": true
+    },
+    {
+        "name": "tall_grass",
+        "isReplacable": true
+    },
+    {
+        "name": "large_fern",
+        "isReplacable": true
+    },
+    {
+        "name": "structure_void",
+        "isReplacable": true
+    },
+    {
+        "name": "void_air",
+        "isReplacable": true
+    },
+    {
+        "name": "cave_air",
+        "isReplacable": true
+    },
+    {
+        "name": "bubble_column",
+        "isReplacable": true
+    },
+    {
+        "name": "warped_roots",
+        "isReplacable": true
+    },
+    {
+        "name": "nether_sprouts",
+        "isReplacable": true
+    },
+    {
+        "name": "crimson_roots",
+        "isReplacable": true
+    },
+    {
+        "name": "hanging_roots",
+        "isReplacable": true
+    },
+    {
+        "name": "lava",
+        "lightLevel": 15
+    },
+    {
+        "name": "brown_mushroom",
+        "lightLevel": 1
+    },
+    {
+        "name": "torch",
+        "lightLevel": 14
+    },
+    {
+        "name": "wall_torch",
+        "lightLevel": 14
+    },
+    {
+        "name": "fire",
+        "lightLevel": 15
+    },
+    {
+        "name": "soul_fire",
+        "lightLevel": 10
+    },
+    {
+        "name": "soul_torch",
+        "lightLevel": 10
+    },
+    {
+        "name": "soul_wall_torch",
+        "lightLevel": 10
+    },
+    {
+        "name": "glowstone",
+        "lightLevel": 15
+    },
+    {
+        "name": "nether_portal",
+        "lightLevel": 11
+    },
+    {
+        "name": "jack_o_lantern",
+        "lightLevel": 15
+    },
+    {
+        "name": "enchanting_table",
+        "lightLevel": 7
+    },
+    {
+        "name": "brewing_stand",
+        "lightLevel": 1
+    },
+    {
+        "name": "lava_cauldron",
+        "lightLevel": 15
+    },
+    {
+        "name": "end_portal",
+        "lightLevel": 15
+    },
+    {
+        "name": "end_portal_frame",
+        "lightLevel": 1
+    },
+    {
+        "name": "dragon_egg",
+        "lightLevel": 1
+    },
+    {
+        "name": "ender_chest",
+        "lightLevel": 7
+    },
+    {
+        "name": "beacon",
+        "lightLevel": 15
+    },
+    {
+        "name": "sea_lantern",
+        "lightLevel": 15
+    },
+    {
+        "name": "end_rod",
+        "lightLevel": 14
+    },
+    {
+        "name": "end_gateway",
+        "lightLevel": 15
+    },
+    {
+        "name": "magma_block",
+        "lightLevel": 3
+    },
+    {
+        "name": "conduit",
+        "lightLevel": 15
+    },
+    {
+        "name": "lantern",
+        "lightLevel": 15
+    },
+    {
+        "name": "soul_lantern",
+        "lightLevel": 10
+    },
+    {
+        "name": "shroomlight",
+        "lightLevel": 15
+    },
+    {
+        "name": "crying_obsidian",
+        "lightLevel": 10
+    },
+    {
+        "name": "amethyst_cluster",
+        "lightLevel": 5
+    },
+    {
+        "name": "large_amethyst_bud",
+        "lightLevel": 4
+    },
+    {
+        "name": "medium_amethyst_bud",
+        "lightLevel": 2
+    },
+    {
+        "name": "small_amethyst_bud",
+        "lightLevel": 1
+    },
+    {
+        "name": "sculk_sensor",
+        "lightLevel": 1
+    },
+    {
+        "name": "sculk_catalyst",
+        "lightLevel": 6
+    },
+    {
+        "name": "ochre_froglight",
+        "lightLevel": 15
+    },
+    {
+        "name": "verdant_froglight",
+        "lightLevel": 15
+    },
+    {
+        "name": "pearlescent_froglight",
+        "lightLevel": 15
+    }
+]


### PR DESCRIPTION
I was trying to extract all interaction shapes I needed with a quick parse script on js and also decided to do the same for other blocks data from 1.20.2 code. I'll try to rewrite setup with burger for reliability & automatization for all versions, but the data will include:
- name
- noOcclusion=true on some blocks (essentials for p viewer)
- lightLevel (actually can already be extracted with burger) (essentials for p viewer)
- isAir=true
- isLiquid=true
- isReplacable=true (essential for flying squid)
- color - RGB color of block (I want it most, to be honestly)
- instrument for noteblock

These additional data may be large, should they be merged with blocks.json? Is this is good direction overall?