### PR TITLE
Fix spelling on packet_configuration_acknowledged in 1.20.2 protocol.json

### DIFF
--- a/data/pc/1.20.2/protocol.json
+++ b/data/pc/1.20.2/protocol.json
@@ -6964,7 +6964,7 @@
             }
           ]
         ],
-        "packet_configuation_acknowledged": [
+        "packet_configuration_acknowledged": [
           "container",
           []
         ],
@@ -6998,7 +6998,7 @@
                     "0x08": "client_command",
                     "0x09": "settings",
                     "0x0a": "tab_complete",
-                    "0x0b": "configuation_acknowledged",
+                    "0x0b": "configuration_acknowledged",
                     "0x0c": "enchant_item",
                     "0x0d": "window_click",
                     "0x0e": "close_window",
@@ -7104,7 +7104,7 @@
                     "block_place": "packet_block_place",
                     "use_item": "packet_use_item",
                     "chunk_batch_received": "packet_chunk_batch_received",
-                    "configuation_acknowledged": "packet_configuation_acknowledged",
+                    "configuration_acknowledged": "packet_configuration_acknowledged",
                     "ping_request": "packet_ping_request"
                   }
                 }


### PR DESCRIPTION
More of my dumb spelling mistakes from my 1.20.2 data pull request. :/ 