### PR TITLE
[bedrock] Fix issue with player auth input data

### DIFF
--- a/data/bedrock/1.20.61/protocol.json
+++ b/data/bedrock/1.20.61/protocol.json
@@ -9758,7 +9758,7 @@
           "type": [
             "switch",
             {
-              "compareTo": "input_data.item_stack_request",
+              "compareTo": "input_data.client_predicted_vehicle",
               "fields": {
                 "true": "zigzag64"
               },

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3082,7 +3082,7 @@ packet_player_auth_input:
          data: TransactionUseItem
    item_stack_request: input_data.item_stack_request ?
       if true: ItemStackRequest
-   predicted_vehicle: input_data.item_stack_request ?
+   predicted_vehicle: input_data.client_predicted_vehicle ?
       if true: zigzag64
    block_action: input_data.block_action ?
       if true: []zigzag32


### PR DESCRIPTION
The pull request for adding Minecraft Bedrock 1.20.60 had an issue where `predicted_vehicle` would only be set in the Packet if `item_stack_request` is true in the InputFlag bitfield. It should have checked if `client_predicted_vehicle` is true instead.

This caused BDS to send a packet_violation_warning packet and close the connection with the Relay player when a player tried to ride an entity.