### PR TITLE
Fixed 1.20.3 and 1.20.4 loginPacket version was set incorrectly on da…

### DIFF
--- a/data/dataPaths.json
+++ b/data/dataPaths.json
@@ -1294,7 +1294,7 @@
       "particles": "pc/1.20.3",
       "blockLoot": "pc/1.20",
       "entityLoot": "pc/1.20",
-      "loginPacket": "pc/1.19.2",
+      "loginPacket": "pc/1.20.2",
       "tints": "pc/1.20.2",
       "mapIcons": "pc/1.20.2",
       "commands": "pc/1.20.3"
@@ -1319,7 +1319,7 @@
       "particles": "pc/1.20.3",
       "blockLoot": "pc/1.20",
       "entityLoot": "pc/1.20",
-      "loginPacket": "pc/1.19.2",
+      "loginPacket": "pc/1.20.2",
       "tints": "pc/1.20.2",
       "mapIcons": "pc/1.20.2",
       "commands": "pc/1.20.3"


### PR DESCRIPTION
In data/dataPaths.json the loginPacket version was set to 1.19.2, but changes were made in 1.20.2 what lead to issues when using loginPacket for 1.20.3 and 1.20.4, updating them in data/dataPaths.json solves the issues