### PR TITLE
Added a resource pack UUID feature that 1.20.3 and later versions use.

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -359,6 +359,11 @@
     "versions": ["1.8", "1.9.4"]
   },
   {
+    "name": "resourcePackUsesUUID",
+    "description": "resource pack uses UUID identification",
+    "versions": ["1.20.3", "latest"]
+  },
+  {
     "name": "lessCharsInChat",
     "description": "max chars in chat",
     "versions": ["1.8", "1.10.2"]


### PR DESCRIPTION
The big reason for this is to allow for checking if a resource pack packet should include a UUID