### PR TITLE
[bedrock] Add missing 1.21.20 packets

### DIFF
--- a/data/bedrock/1.21.20/protocol.json
+++ b/data/bedrock/1.21.20/protocol.json
@@ -4872,7 +4872,11 @@
                 "307": "set_player_inventory_options",
                 "308": "set_hud",
                 "309": "award_achievement",
-                "310": "clientbound_close_form"
+                "310": "clientbound_close_form",
+                "312": "serverbound_loading_screen",
+                "313": "jigsaw_structure_data",
+                "314": "current_structure_feature",
+                "315": "serverbound_diagnostics"
               }
             }
           ]
@@ -5086,7 +5090,11 @@
                 "set_hud": "packet_set_hud",
                 "award_achievement": "packet_award_achievement",
                 "server_post_move": "packet_server_post_move",
-                "clientbound_close_form": "packet_clientbound_close_form"
+                "clientbound_close_form": "packet_clientbound_close_form",
+                "serverbound_loading_screen": "packet_serverbound_loading_screen",
+                "jigsaw_structure_data": "packet_jigsaw_structure_data",
+                "current_structure_feature": "packet_current_structure_feature",
+                "serverbound_diagnostics": "packet_serverbound_diagnostics"
               }
             }
           ]
@@ -12549,6 +12557,81 @@
     "packet_clientbound_close_form": [
       "container",
       []
+    ],
+    "packet_serverbound_loading_screen": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": "zigzag32"
+        },
+        {
+          "name": "loading_screen_id",
+          "type": [
+            "option",
+            "varint"
+          ]
+        }
+      ]
+    ],
+    "packet_jigsaw_structure_data": [
+      "container",
+      [
+        {
+          "name": "structure_data",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_current_structure_feature": [
+      "container",
+      [
+        {
+          "name": "current_feature",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_serverbound_diagnostics": [
+      "container",
+      [
+        {
+          "name": "average_frames_per_second",
+          "type": "lf32"
+        },
+        {
+          "name": "average_server_sim_tick_time",
+          "type": "lf32"
+        },
+        {
+          "name": "average_client_sim_tick_time",
+          "type": "lf32"
+        },
+        {
+          "name": "average_begin_frame_time",
+          "type": "lf32"
+        },
+        {
+          "name": "average_input_time",
+          "type": "lf32"
+        },
+        {
+          "name": "average_render_time",
+          "type": "lf32"
+        },
+        {
+          "name": "average_end_frame_time",
+          "type": "lf32"
+        },
+        {
+          "name": "average_remainder_time_percent",
+          "type": "lf32"
+        },
+        {
+          "name": "average_unaccounted_time_percent",
+          "type": "lf32"
+        }
+      ]
     ]
   }
 }

--- a/data/bedrock/1.21.20/protocol.json
+++ b/data/bedrock/1.21.20/protocol.json
@@ -12579,7 +12579,7 @@
       [
         {
           "name": "structure_data",
-          "type": "string"
+          "type": "nbt"
         }
       ]
     ],

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -4217,3 +4217,45 @@ packet_server_post_move:
 packet_clientbound_close_form:
    !id: 0x136
    !bound: client
+
+# ServerBoundLoadingScreen is sent by the client to tell the server about the state of the loading
+# screen that the client is currently displaying.
+packet_serverbound_loading_screen:
+   !id: 0x138
+   !bound: server
+   # The type of the loading screen event.
+   type: zigzag32
+   loading_screen_id?: varint
+
+# JigsawStructureData is sent by the server to let the client know all the rules for jigsaw structures.
+packet_jigsaw_structure_data:
+   !id: 0x139
+   !bound: client
+   # StructureData is a network NBT serialised compound of all the jigsaw structure rules defined
+   # on the server.
+   structure_data: string
+
+# CurrentStructureFeature is sent by the server to let the client know the name of the structure feature
+# that the player is currently occupying.
+packet_current_structure_feature:
+   !id: 0x13A
+   !bound: client
+   # CurrentFeature is the identifier of the structure feature that the player is currently occupying.
+   # If the player is not occupying any structure feature, this field is empty.
+   current_feature: string
+
+# ServerBoundDiagnostics is sent by the client to tell the server about the performance diagnostics
+# of the client. It is sent by the client roughly every 500ms or 10 in-game ticks when the
+# "Creator > Enable Client Diagnostics" setting is enabled.
+packet_serverbound_diagnostics:
+   !id: 0x13B
+   !bound: server
+   average_frames_per_second: lf32
+   average_server_sim_tick_time: lf32
+   average_client_sim_tick_time: lf32
+   average_begin_frame_time: lf32
+   average_input_time: lf32
+   average_render_time: lf32
+   average_end_frame_time: lf32
+   average_remainder_time_percent: lf32
+   average_unaccounted_time_percent: lf32

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -4233,7 +4233,7 @@ packet_jigsaw_structure_data:
    !bound: client
    # StructureData is a network NBT serialised compound of all the jigsaw structure rules defined
    # on the server.
-   structure_data: string
+   structure_data: nbt
 
 # CurrentStructureFeature is sent by the server to let the client know the name of the structure feature
 # that the player is currently occupying.


### PR DESCRIPTION
The pull request that added protocol data for Minecraft 1.21.20 did not properly add packet IDs 312, 313, 314, and 315.