### PR TITLE
Bedrock serverbound_loading_screen malformed packet

### DIFF
--- a/data/bedrock/1.21.20/proto.yml
+++ b/data/bedrock/1.21.20/proto.yml
@@ -4227,7 +4227,7 @@ packet_serverbound_loading_screen:
    !bound: server
    # The type of the loading screen event.
    type: zigzag32
-   loading_screen_id?: varint
+   loading_screen_id?: lu32
 
 # JigsawStructureData is sent by the server to let the client know all the rules for jigsaw structures.
 packet_jigsaw_structure_data:

--- a/data/bedrock/1.21.20/protocol.json
+++ b/data/bedrock/1.21.20/protocol.json
@@ -12578,7 +12578,7 @@
           "name": "loading_screen_id",
           "type": [
             "option",
-            "varint"
+            "lu32"
           ]
         }
       ]

--- a/data/bedrock/1.21.30/proto.yml
+++ b/data/bedrock/1.21.30/proto.yml
@@ -4234,7 +4234,7 @@ packet_serverbound_loading_screen:
    !bound: server
    # The type of the loading screen event.
    type: zigzag32
-   loading_screen_id?: varint
+   loading_screen_id?: lu32
 
 # JigsawStructureData is sent by the server to let the client know all the rules for jigsaw structures.
 packet_jigsaw_structure_data:

--- a/data/bedrock/1.21.30/protocol.json
+++ b/data/bedrock/1.21.30/protocol.json
@@ -12585,7 +12585,7 @@
           "name": "loading_screen_id",
           "type": [
             "option",
-            "varint"
+            "lu32"
           ]
         }
       ]

--- a/data/bedrock/1.21.42/protocol.json
+++ b/data/bedrock/1.21.42/protocol.json
@@ -12610,7 +12610,7 @@
           "name": "loading_screen_id",
           "type": [
             "option",
-            "varint"
+            "lu32"
           ]
         }
       ]

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -4238,7 +4238,7 @@ packet_serverbound_loading_screen:
    !bound: server
    # The type of the loading screen event.
    type: zigzag32
-   loading_screen_id?: varint
+   loading_screen_id?: lu32
 
 # JigsawStructureData is sent by the server to let the client know all the rules for jigsaw structures.
 packet_jigsaw_structure_data:


### PR DESCRIPTION
When the `serverbound_loading_screen` is sent serverbound, the client can be kicked by the server due to a "malformed" packet with the specified paramaters.
```
{
  violation_type: 'malformed',
  severity: 'terminating',
  packet_id: 312,
  reason: 'BinaryStream read() overflow checkedNumber = 8, mReadPointer = 4, buffer Length is = 5 bytes\n' +
    'readNoHeader failed! packetId: 312'
}
```
This can be triggered by changing between dimensions using a nether or end portal in a relay server using the [docs/API](https://github.com/Sandertv/gophertunnel/blob/master/minecraft/protocol/packet/server_bound_loading_screen.go) code within bedrock-protocol.
[Here](https://github.com/Sandertv/gophertunnel/blob/master/minecraft/protocol/packet/server_bound_loading_screen.go) is the refrence I have used for the changes made.