### PR TITLE
Fix bedrock 1.21.50 protocol input flags

### DIFF
--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -2296,7 +2296,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -2748,7 +2748,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -2750,7 +2750,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -2847,7 +2847,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -2877,7 +2877,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -2877,7 +2877,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -2884,7 +2884,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -2891,7 +2891,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -2905,7 +2905,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -2924,7 +2924,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -2975,7 +2975,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -3012,7 +3012,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -3012,7 +3012,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -3027,7 +3027,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -3037,7 +3037,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -3039,7 +3039,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -3045,7 +3045,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -3046,7 +3046,6 @@ packet_player_auth_input:
                # concerned a block. If not, the face is always 0.
                face: zigzag32
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -3049,7 +3049,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -3062,7 +3062,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.20.0/proto.yml
+++ b/data/bedrock/1.20.0/proto.yml
@@ -3073,7 +3073,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.20.10/proto.yml
+++ b/data/bedrock/1.20.10/proto.yml
@@ -3096,7 +3096,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.20.30/proto.yml
+++ b/data/bedrock/1.20.30/proto.yml
@@ -3104,7 +3104,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.20.40/proto.yml
+++ b/data/bedrock/1.20.40/proto.yml
@@ -3107,7 +3107,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.20.50/proto.yml
+++ b/data/bedrock/1.20.50/proto.yml
@@ -3112,7 +3112,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.20.61/proto.yml
+++ b/data/bedrock/1.20.61/proto.yml
@@ -3099,7 +3099,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.20.71/proto.yml
+++ b/data/bedrock/1.20.71/proto.yml
@@ -3104,7 +3104,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.20.80/proto.yml
+++ b/data/bedrock/1.20.80/proto.yml
@@ -3109,7 +3109,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.21.0/proto.yml
+++ b/data/bedrock/1.21.0/proto.yml
@@ -3120,7 +3120,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.21.2/proto.yml
+++ b/data/bedrock/1.21.2/proto.yml
@@ -3120,7 +3120,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.21.20/proto.yml
+++ b/data/bedrock/1.21.20/proto.yml
@@ -3130,7 +3130,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.21.30/proto.yml
+++ b/data/bedrock/1.21.30/proto.yml
@@ -3133,7 +3133,6 @@ packet_player_auth_input:
    # values which are created using an analogue input.
    analogue_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.21.42/proto.yml
+++ b/data/bedrock/1.21.42/proto.yml
@@ -3142,7 +3142,6 @@ packet_player_auth_input:
    # transform movement to be camera relative.
    camera_orientation: vec3f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint64", "big": true,
    "flags": [

--- a/data/bedrock/1.21.50/protocol.json
+++ b/data/bedrock/1.21.50/protocol.json
@@ -10615,7 +10615,7 @@
     "InputFlag": [
       "bitflags",
       {
-        "type": "varint64",
+        "type": "varint128",
         "big": true,
         "flags": [
           "ascend",

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3155,7 +3155,6 @@ packet_player_auth_input:
    # speeds and isn't normalised for analogue inputs.
    raw_move_vector: vec2f
 
-#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint128", "big": true,
    "flags": [

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3157,7 +3157,7 @@ packet_player_auth_input:
 
 #TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
-   "type": "varint64", "big": true,
+   "type": "varint128", "big": true,
    "flags": [
       "ascend",
       "descend",


### PR DESCRIPTION
1.21.50 `player_auth_input` packet's input flags can exceed 64 bits. Fixed by using new 128-bit varint support in protodef.