### PR TITLE
Add skinUsesKeyedProperties

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -855,5 +855,10 @@
     "name": "noAckOnCreateSetSlotPacket",
     "description": "Server does not send ack on creative_set_slot packets",
     "versions": ["1.21.3", "latest"]
+  },
+  {
+    "name": "skinUsesKeyedProperties",
+    "description": "`player_info` packet uses the `key` field for skin properties instead of `name`",
+    "versions": ["1.19.3", "latest"]
   }
 ]


### PR DESCRIPTION
`player_info` packet uses the `key` field for skin properties instead of `name`, Applies to Minecraft 1.19.3 and above.