### PR TITLE
Changed features "nbtNameForEnchant" and "typeOfValueForEnchantLevel"

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -646,8 +646,12 @@
     "description": "what the nbt key for enchants is",
     "values": [
       {
+        "value": "componentEnchantments",
+        "versions": ["1.20.5", "latest"]
+      },
+      {
         "value": "Enchantments",
-        "versions": ["1.13_major", "latest"]
+        "versions": ["1.13_major", "1.20.4"]
       },
       {
         "value": "ench",
@@ -665,12 +669,8 @@
     "description": "type of value that stores enchant lvl in the nbt",
     "values": [
       {
-        "value": "string",
-        "versions": ["1.13_major", "latest"]
-      },
-      {
         "value": "short",
-        "versions": ["1.8_major", "1.12_major"]
+        "versions": ["1.8_major", "latest"]
       }
     ]
   },


### PR DESCRIPTION
Added a record about the feature "nbtNameForEnchant" for the version from 1.20.5 to the latest
Changed the record about the feature "typeOfValueForEnchantLevel". The format of the level "short" is saved until the latest version. Tested on versions: 1.13, 1.13.1, 1.13.2, 1.15.2, 1.20.1, 1.20.4, 1.20.5, 1.21.4.