### PR TITLE
Bedrock ItemStackRequest missing some "times_crafted" fields

### DIFF
--- a/data/bedrock/1.21.50/protocol.json
+++ b/data/bedrock/1.21.50/protocol.json
@@ -2918,6 +2918,10 @@
                                 "type": "varint"
                               },
                               {
+                                "name": "times_crafted",
+                                "type": "u8"
+                              },
+                              {
                                 "name": "cost",
                                 "type": "varint"
                               }
@@ -2929,6 +2933,10 @@
                               {
                                 "name": "pattern",
                                 "type": "string"
+                              },
+                              {
+                                "name": "times_crafted",
+                                "type": "u8"
                               }
                             ]
                           ],

--- a/data/bedrock/1.21.50/types.yml
+++ b/data/bedrock/1.21.50/types.yml
@@ -1104,8 +1104,8 @@ ItemStackRequest:
             # one of the recipes sent in the CraftingData packet, where each of the recipes have a RecipeNetworkID as
             recipe_network_id: varint
             # NumberOfCrafts is how many times the recipe was crafted. This field appears to be boilerplate and
-	         # has no effect.
-	         times_crafted: u8
+            # has no effect.
+            times_crafted: u8
             # Cost is the cost of the recipe that was crafted.
             cost: varint
          if craft_loom_request:

--- a/data/bedrock/1.21.50/types.yml
+++ b/data/bedrock/1.21.50/types.yml
@@ -1103,11 +1103,16 @@ ItemStackRequest:
             # RecipeNetworkID is the network ID of the recipe that is about to be crafted. This network ID matches
             # one of the recipes sent in the CraftingData packet, where each of the recipes have a RecipeNetworkID as
             recipe_network_id: varint
+            # NumberOfCrafts is how many times the recipe was crafted. This field appears to be boilerplate and
+	         # has no effect.
+	         times_crafted: u8
             # Cost is the cost of the recipe that was crafted.
             cost: varint
          if craft_loom_request:
             # Pattern is the pattern identifier for the loom recipe.
             pattern: string
+            # TimesCrafted is how many times the recipe was crafted.
+            times_crafted: u8
          if non_implemented: void
          if results_deprecated:
             result_items: ItemLegacy[]varint

--- a/data/bedrock/1.21.60/protocol.json
+++ b/data/bedrock/1.21.60/protocol.json
@@ -2939,6 +2939,10 @@
                                 "type": "varint"
                               },
                               {
+                                "name": "times_crafted",
+                                "type": "u8"
+                              },
+                              {
                                 "name": "cost",
                                 "type": "varint"
                               }
@@ -2950,6 +2954,10 @@
                               {
                                 "name": "pattern",
                                 "type": "string"
+                              },
+                              {
+                                "name": "times_crafted",
+                                "type": "u8"
                               }
                             ]
                           ],

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -1113,8 +1113,8 @@ ItemStackRequest:
             # one of the recipes sent in the CraftingData packet, where each of the recipes have a RecipeNetworkID as
             recipe_network_id: varint
             # NumberOfCrafts is how many times the recipe was crafted. This field appears to be boilerplate and
-	         # has no effect.
-	         times_crafted: u8
+            # has no effect.
+            times_crafted: u8
             # Cost is the cost of the recipe that was crafted.
             cost: varint
          if craft_loom_request:

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -1112,11 +1112,16 @@ ItemStackRequest:
             # RecipeNetworkID is the network ID of the recipe that is about to be crafted. This network ID matches
             # one of the recipes sent in the CraftingData packet, where each of the recipes have a RecipeNetworkID as
             recipe_network_id: varint
+            # NumberOfCrafts is how many times the recipe was crafted. This field appears to be boilerplate and
+	         # has no effect.
+	         times_crafted: u8
             # Cost is the cost of the recipe that was crafted.
             cost: varint
          if craft_loom_request:
             # Pattern is the pattern identifier for the loom recipe.
             pattern: string
+            # TimesCrafted is how many times the recipe was crafted.
+            times_crafted: u8
          if non_implemented: void
          if results_deprecated:
             result_items: ItemLegacy[]varint


### PR DESCRIPTION
In the Bedrock protocol the ItemStackRequest type is missing two `times_crafted` fields in `craft_grindstone_request` and `craft_loom_request` ([Reference](https://github.com/Sandertv/gophertunnel/blob/bfe0892926356f3aeb922df94a2e909804ea007e/minecraft/protocol/item_stack.go))

Unrelated question, is there any way to change all effected versions any other way rather than changing each file one by one? Apologies if I'm asking a silly question, I am not too familiar with github features.