### PR TITLE
Bedrock protocol missing debug_info packet

### DIFF
--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -2351,7 +2351,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -2345,6 +2345,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -2824,6 +2824,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -2993,6 +2994,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -7263,6 +7265,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -2824,7 +2824,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -2477,7 +2477,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -2471,6 +2471,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -3111,6 +3111,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -3281,6 +3282,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -7774,6 +7776,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -3111,7 +3111,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -2952,7 +2952,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -2946,6 +2946,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -3606,6 +3606,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -3776,6 +3777,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -8689,6 +8691,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -3606,7 +3606,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -2948,6 +2948,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -2954,7 +2954,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -3677,7 +3677,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -3677,6 +3677,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -3850,6 +3851,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -8771,6 +8773,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -3045,6 +3045,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -3051,7 +3051,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -3679,6 +3679,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -3854,6 +3855,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -8887,6 +8889,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -3679,7 +3679,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -3075,6 +3075,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -3081,7 +3081,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -3773,7 +3773,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -3773,6 +3773,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -3952,6 +3953,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9108,6 +9110,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -3065,6 +3065,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -3071,7 +3071,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -3797,7 +3797,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -3797,6 +3797,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -3978,6 +3979,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9110,6 +9112,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -3083,6 +3083,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -3089,7 +3089,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -3807,6 +3807,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -3988,6 +3989,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9159,6 +9161,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -3807,7 +3807,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -3090,6 +3090,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -3096,7 +3096,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -3874,7 +3874,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -3874,6 +3874,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4058,6 +4059,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9254,6 +9256,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -3109,7 +3109,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -3103,6 +3103,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -3934,7 +3934,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -3934,6 +3934,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4122,6 +4123,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9350,6 +9352,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -3128,7 +3128,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -3122,6 +3122,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -3967,7 +3967,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -3967,6 +3967,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4159,6 +4160,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9415,6 +9417,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -3173,6 +3173,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -3179,7 +3179,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -4059,6 +4059,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4255,6 +4256,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9508,6 +9510,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -4059,7 +4059,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -3216,7 +3216,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -3210,6 +3210,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -4097,6 +4097,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4294,6 +4295,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9671,6 +9673,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -4097,7 +4097,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -3216,7 +3216,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -3210,6 +3210,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -4097,6 +4097,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4294,6 +4295,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9671,6 +9673,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -4097,7 +4097,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -3231,7 +3231,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -3225,6 +3225,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -4178,7 +4178,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -4178,6 +4178,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4379,6 +4380,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9799,6 +9801,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -3241,7 +3241,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -3235,6 +3235,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -4247,7 +4247,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -4247,6 +4247,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4448,6 +4449,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9881,6 +9883,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -3243,7 +3243,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -3237,6 +3237,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -4265,6 +4265,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4467,6 +4468,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9903,6 +9905,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -4265,7 +4265,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -3250,7 +3250,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -3244,6 +3244,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -4300,7 +4300,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -4300,6 +4300,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4503,6 +4504,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9958,6 +9960,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -3245,6 +3245,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -3251,7 +3251,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -4304,6 +4304,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4507,6 +4508,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9962,6 +9964,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -4304,7 +4304,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -3255,7 +3255,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -3249,6 +3249,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -4321,7 +4321,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -4321,6 +4321,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4527,6 +4528,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -9990,6 +9992,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -3268,7 +3268,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -3262,6 +3262,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -4356,7 +4356,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -4356,6 +4356,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4565,6 +4566,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10053,6 +10055,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.20.0/proto.yml
+++ b/data/bedrock/1.20.0/proto.yml
@@ -3273,6 +3273,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.20.0/proto.yml
+++ b/data/bedrock/1.20.0/proto.yml
@@ -3279,7 +3279,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -4362,7 +4362,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -4362,6 +4362,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4571,6 +4572,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10072,6 +10074,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.20.10/proto.yml
+++ b/data/bedrock/1.20.10/proto.yml
@@ -3299,6 +3299,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.20.10/proto.yml
+++ b/data/bedrock/1.20.10/proto.yml
@@ -3305,7 +3305,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -4367,7 +4367,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -4367,6 +4367,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4577,6 +4578,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10147,6 +10149,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.20.30/proto.yml
+++ b/data/bedrock/1.20.30/proto.yml
@@ -3315,7 +3315,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.20.30/proto.yml
+++ b/data/bedrock/1.20.30/proto.yml
@@ -3309,6 +3309,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.20.30/protocol.json
+++ b/data/bedrock/1.20.30/protocol.json
@@ -4456,7 +4456,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.20.30/protocol.json
+++ b/data/bedrock/1.20.30/protocol.json
@@ -4456,6 +4456,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4667,6 +4668,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10272,6 +10274,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.20.40/proto.yml
+++ b/data/bedrock/1.20.40/proto.yml
@@ -3313,6 +3313,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.20.40/proto.yml
+++ b/data/bedrock/1.20.40/proto.yml
@@ -3319,7 +3319,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.20.40/protocol.json
+++ b/data/bedrock/1.20.40/protocol.json
@@ -4583,6 +4583,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4794,6 +4795,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10404,6 +10406,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.20.40/protocol.json
+++ b/data/bedrock/1.20.40/protocol.json
@@ -4583,7 +4583,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.20.50/proto.yml
+++ b/data/bedrock/1.20.50/proto.yml
@@ -3324,7 +3324,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.20.50/proto.yml
+++ b/data/bedrock/1.20.50/proto.yml
@@ -3318,6 +3318,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.20.50/protocol.json
+++ b/data/bedrock/1.20.50/protocol.json
@@ -4613,6 +4613,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4826,6 +4827,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10451,6 +10453,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.20.50/protocol.json
+++ b/data/bedrock/1.20.50/protocol.json
@@ -4613,7 +4613,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.20.61/proto.yml
+++ b/data/bedrock/1.20.61/proto.yml
@@ -3306,6 +3306,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.20.61/proto.yml
+++ b/data/bedrock/1.20.61/proto.yml
@@ -3312,7 +3312,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.20.61/protocol.json
+++ b/data/bedrock/1.20.61/protocol.json
@@ -4615,6 +4615,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4827,6 +4828,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10457,6 +10459,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.20.61/protocol.json
+++ b/data/bedrock/1.20.61/protocol.json
@@ -4615,7 +4615,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.20.71/proto.yml
+++ b/data/bedrock/1.20.71/proto.yml
@@ -3313,6 +3313,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.20.71/proto.yml
+++ b/data/bedrock/1.20.71/proto.yml
@@ -3319,7 +3319,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.20.71/protocol.json
+++ b/data/bedrock/1.20.71/protocol.json
@@ -4638,7 +4638,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.20.71/protocol.json
+++ b/data/bedrock/1.20.71/protocol.json
@@ -4638,6 +4638,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4849,6 +4850,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10496,6 +10498,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.20.80/proto.yml
+++ b/data/bedrock/1.20.80/proto.yml
@@ -3319,6 +3319,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.20.80/proto.yml
+++ b/data/bedrock/1.20.80/proto.yml
@@ -3325,7 +3325,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.20.80/protocol.json
+++ b/data/bedrock/1.20.80/protocol.json
@@ -4682,7 +4682,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.20.80/protocol.json
+++ b/data/bedrock/1.20.80/protocol.json
@@ -4682,6 +4682,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4893,6 +4894,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10553,6 +10555,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.21.0/proto.yml
+++ b/data/bedrock/1.21.0/proto.yml
@@ -3337,7 +3337,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.21.0/proto.yml
+++ b/data/bedrock/1.21.0/proto.yml
@@ -3331,6 +3331,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.21.0/protocol.json
+++ b/data/bedrock/1.21.0/protocol.json
@@ -4749,7 +4749,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.21.0/protocol.json
+++ b/data/bedrock/1.21.0/protocol.json
@@ -4749,6 +4749,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4961,6 +4962,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10646,6 +10648,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.21.2/proto.yml
+++ b/data/bedrock/1.21.2/proto.yml
@@ -3337,7 +3337,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.21.2/proto.yml
+++ b/data/bedrock/1.21.2/proto.yml
@@ -3331,6 +3331,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.21.2/protocol.json
+++ b/data/bedrock/1.21.2/protocol.json
@@ -4749,6 +4749,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -4962,6 +4963,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10648,6 +10650,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.21.2/protocol.json
+++ b/data/bedrock/1.21.2/protocol.json
@@ -4749,7 +4749,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.21.20/proto.yml
+++ b/data/bedrock/1.21.20/proto.yml
@@ -3350,7 +3350,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.21.20/proto.yml
+++ b/data/bedrock/1.21.20/proto.yml
@@ -3344,6 +3344,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.21.20/protocol.json
+++ b/data/bedrock/1.21.20/protocol.json
@@ -4834,7 +4834,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.21.20/protocol.json
+++ b/data/bedrock/1.21.20/protocol.json
@@ -4834,6 +4834,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -5051,6 +5052,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10802,6 +10804,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.21.30/proto.yml
+++ b/data/bedrock/1.21.30/proto.yml
@@ -3357,7 +3357,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.21.30/proto.yml
+++ b/data/bedrock/1.21.30/proto.yml
@@ -3351,6 +3351,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.21.30/protocol.json
+++ b/data/bedrock/1.21.30/protocol.json
@@ -4823,7 +4823,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.21.30/protocol.json
+++ b/data/bedrock/1.21.30/protocol.json
@@ -4823,6 +4823,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -5042,6 +5043,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10807,6 +10809,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.21.42/proto.yml
+++ b/data/bedrock/1.21.42/proto.yml
@@ -3363,6 +3363,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.21.42/proto.yml
+++ b/data/bedrock/1.21.42/proto.yml
@@ -3369,7 +3369,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.21.42/protocol.json
+++ b/data/bedrock/1.21.42/protocol.json
@@ -4866,6 +4866,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -5087,6 +5088,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10832,6 +10834,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.21.42/protocol.json
+++ b/data/bedrock/1.21.42/protocol.json
@@ -4866,7 +4866,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.21.50/proto.yml
+++ b/data/bedrock/1.21.50/proto.yml
@@ -3384,6 +3384,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.21.50/proto.yml
+++ b/data/bedrock/1.21.50/proto.yml
@@ -3390,7 +3390,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.21.50/protocol.json
+++ b/data/bedrock/1.21.50/protocol.json
@@ -4933,6 +4933,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -5155,6 +5156,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -10931,6 +10933,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.21.50/protocol.json
+++ b/data/bedrock/1.21.50/protocol.json
@@ -4933,7 +4933,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.21.60/proto.yml
+++ b/data/bedrock/1.21.60/proto.yml
@@ -3414,6 +3414,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:

--- a/data/bedrock/1.21.60/proto.yml
+++ b/data/bedrock/1.21.60/proto.yml
@@ -3420,7 +3420,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/1.21.60/protocol.json
+++ b/data/bedrock/1.21.60/protocol.json
@@ -4955,6 +4955,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -5179,6 +5180,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -11012,6 +11014,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/1.21.60/protocol.json
+++ b/data/bedrock/1.21.60/protocol.json
@@ -4955,7 +4955,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.21.70/protocol.json
+++ b/data/bedrock/1.21.70/protocol.json
@@ -4958,7 +4958,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
-                "155": "packet_debug_info",
+                "155": "debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",

--- a/data/bedrock/1.21.70/protocol.json
+++ b/data/bedrock/1.21.70/protocol.json
@@ -4958,6 +4958,7 @@
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
                 "154": "position_tracking_db_request",
+                "155": "packet_debug_info",
                 "156": "packet_violation_warning",
                 "157": "motion_prediction_hints",
                 "158": "animate_entity",
@@ -5185,6 +5186,7 @@
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
                 "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "debug_info": "packet_debug_info",
                 "packet_violation_warning": "packet_packet_violation_warning",
                 "motion_prediction_hints": "packet_motion_prediction_hints",
                 "animate_entity": "packet_animate_entity",
@@ -11025,6 +11027,19 @@
         {
           "name": "nbt",
           "type": "nbt"
+        }
+      ]
+    ],
+    "packet_debug_info": [
+      "container",
+      [
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "data",
+          "type": "ByteArray"
         }
       ]
     ],

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3424,7 +3424,7 @@ packet_debug_info:
     !id: 0x9b
     !bound: client
     # PlayerUniqueID is the unique ID of the player that the packet is sent to.
-    player_unique_id: varint64
+    player_unique_id: zigzag64
     # Data is the debug data.
     data: ByteArray
 

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3418,6 +3418,16 @@ packet_position_tracking_db_broadcast:
    tracking_id: zigzag32
    nbt: nbt
 
+# DebugInfo is a packet sent by the server to the client. It does not seem to do anything when sent to the
+# normal client in 1.16.
+packet_debug_info:
+    !id: 0x9b
+    !bound: client
+    # PlayerUniqueID is the unique ID of the player that the packet is sent to.
+    player_unique_id: varint64
+    # Data is the debug data.
+    data: ByteArray
+
 # PacketViolationWarning is sent by the client when it receives an invalid packet from the server. It holds
 # some information on the error that occurred.
 packet_packet_violation_warning:


### PR DESCRIPTION
All bedrock protocols past 1.16 are missing the `debug_info` packet (From reference [here](https://github.com/Sandertv/gophertunnel/blob/bfe0892926356f3aeb922df94a2e909804ea007e/minecraft/protocol/packet/debug_info.go)).