### PR TITLE
Bedrock protocol added missing code_builder packet

### DIFF
--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -2277,6 +2277,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -2820,6 +2820,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -2990,6 +2991,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -7188,6 +7190,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -2403,6 +2403,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -3107,6 +3107,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -3278,6 +3279,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -7699,6 +7701,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.16.220/proto.yml
+++ b/data/bedrock/1.16.220/proto.yml
@@ -2878,6 +2878,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.16.220/protocol.json
+++ b/data/bedrock/1.16.220/protocol.json
@@ -3602,6 +3602,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -3773,6 +3774,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -8614,6 +8616,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.17.0/proto.yml
+++ b/data/bedrock/1.17.0/proto.yml
@@ -2880,6 +2880,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.17.0/protocol.json
+++ b/data/bedrock/1.17.0/protocol.json
@@ -3673,6 +3673,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -3847,6 +3848,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -8696,6 +8698,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.17.10/proto.yml
+++ b/data/bedrock/1.17.10/proto.yml
@@ -2977,6 +2977,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.17.10/protocol.json
+++ b/data/bedrock/1.17.10/protocol.json
@@ -3675,6 +3675,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -3851,6 +3852,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -8812,6 +8814,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.17.30/proto.yml
+++ b/data/bedrock/1.17.30/proto.yml
@@ -3007,6 +3007,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.17.30/protocol.json
+++ b/data/bedrock/1.17.30/protocol.json
@@ -3769,6 +3769,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -3949,6 +3950,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9033,6 +9035,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.17.40/proto.yml
+++ b/data/bedrock/1.17.40/proto.yml
@@ -2997,6 +2997,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.17.40/protocol.json
+++ b/data/bedrock/1.17.40/protocol.json
@@ -3793,6 +3793,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -3975,6 +3976,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9035,6 +9037,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.18.0/proto.yml
+++ b/data/bedrock/1.18.0/proto.yml
@@ -3014,6 +3014,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.18.0/protocol.json
+++ b/data/bedrock/1.18.0/protocol.json
@@ -3803,6 +3803,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -3985,6 +3986,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9084,6 +9086,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.18.11/proto.yml
+++ b/data/bedrock/1.18.11/proto.yml
@@ -3021,6 +3021,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.18.11/protocol.json
+++ b/data/bedrock/1.18.11/protocol.json
@@ -3870,6 +3870,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4055,6 +4056,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9179,6 +9181,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.18.30/proto.yml
+++ b/data/bedrock/1.18.30/proto.yml
@@ -3034,6 +3034,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.18.30/protocol.json
+++ b/data/bedrock/1.18.30/protocol.json
@@ -3930,6 +3930,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4119,6 +4120,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9275,6 +9277,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.1/proto.yml
+++ b/data/bedrock/1.19.1/proto.yml
@@ -3053,6 +3053,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.1/protocol.json
+++ b/data/bedrock/1.19.1/protocol.json
@@ -3963,6 +3963,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4156,6 +4157,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9340,6 +9342,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -3104,6 +3104,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -4055,6 +4055,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4252,6 +4253,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9433,6 +9435,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -3141,6 +3141,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -4093,6 +4093,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4291,6 +4292,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9596,6 +9598,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -3141,6 +3141,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -4093,6 +4093,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4291,6 +4292,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9596,6 +9598,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -3156,6 +3156,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -4174,6 +4174,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4376,6 +4377,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9724,6 +9726,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -3166,6 +3166,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -4243,6 +4243,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4445,6 +4446,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9806,6 +9808,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -3168,6 +3168,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -4261,6 +4261,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4464,6 +4465,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9828,6 +9830,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -3175,6 +3175,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -4296,6 +4296,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4500,6 +4501,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9883,6 +9885,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -3176,6 +3176,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -4300,6 +4300,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4504,6 +4505,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9887,6 +9889,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -3180,6 +3180,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -4317,6 +4317,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4524,6 +4525,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9915,6 +9917,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -3193,6 +3193,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -4352,6 +4352,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4562,6 +4563,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9978,6 +9980,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.20.0/proto.yml
+++ b/data/bedrock/1.20.0/proto.yml
@@ -3204,6 +3204,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -4358,6 +4358,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4568,6 +4569,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -9997,6 +9999,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.20.10/proto.yml
+++ b/data/bedrock/1.20.10/proto.yml
@@ -3230,6 +3230,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -4363,6 +4363,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4574,6 +4575,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10072,6 +10074,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.20.30/proto.yml
+++ b/data/bedrock/1.20.30/proto.yml
@@ -3240,6 +3240,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.20.30/protocol.json
+++ b/data/bedrock/1.20.30/protocol.json
@@ -4452,6 +4452,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4664,6 +4665,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10197,6 +10199,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.20.40/proto.yml
+++ b/data/bedrock/1.20.40/proto.yml
@@ -3244,6 +3244,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.20.40/protocol.json
+++ b/data/bedrock/1.20.40/protocol.json
@@ -4579,6 +4579,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4791,6 +4792,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10329,6 +10331,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.20.50/proto.yml
+++ b/data/bedrock/1.20.50/proto.yml
@@ -3249,6 +3249,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.20.50/protocol.json
+++ b/data/bedrock/1.20.50/protocol.json
@@ -4609,6 +4609,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4823,6 +4824,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10376,6 +10378,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.20.61/proto.yml
+++ b/data/bedrock/1.20.61/proto.yml
@@ -3237,6 +3237,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.20.61/protocol.json
+++ b/data/bedrock/1.20.61/protocol.json
@@ -4611,6 +4611,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4824,6 +4825,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10382,6 +10384,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.20.71/proto.yml
+++ b/data/bedrock/1.20.71/proto.yml
@@ -3244,6 +3244,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.20.71/protocol.json
+++ b/data/bedrock/1.20.71/protocol.json
@@ -4634,6 +4634,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4846,6 +4847,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10421,6 +10423,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.20.80/proto.yml
+++ b/data/bedrock/1.20.80/proto.yml
@@ -3249,6 +3249,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.20.80/protocol.json
+++ b/data/bedrock/1.20.80/protocol.json
@@ -4678,6 +4678,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4890,6 +4891,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10474,6 +10476,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.21.0/proto.yml
+++ b/data/bedrock/1.21.0/proto.yml
@@ -3261,6 +3261,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.21.0/protocol.json
+++ b/data/bedrock/1.21.0/protocol.json
@@ -4745,6 +4745,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4958,6 +4959,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10567,6 +10569,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.21.2/proto.yml
+++ b/data/bedrock/1.21.2/proto.yml
@@ -3261,6 +3261,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.21.2/protocol.json
+++ b/data/bedrock/1.21.2/protocol.json
@@ -4745,6 +4745,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -4959,6 +4960,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10569,6 +10571,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.21.20/proto.yml
+++ b/data/bedrock/1.21.20/proto.yml
@@ -3274,6 +3274,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.21.20/protocol.json
+++ b/data/bedrock/1.21.20/protocol.json
@@ -4830,6 +4830,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -5048,6 +5049,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10723,6 +10725,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.21.30/proto.yml
+++ b/data/bedrock/1.21.30/proto.yml
@@ -3281,6 +3281,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.21.30/protocol.json
+++ b/data/bedrock/1.21.30/protocol.json
@@ -4819,6 +4819,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -5039,6 +5040,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10728,6 +10730,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.21.42/proto.yml
+++ b/data/bedrock/1.21.42/proto.yml
@@ -3294,6 +3294,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.21.42/protocol.json
+++ b/data/bedrock/1.21.42/protocol.json
@@ -4862,6 +4862,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -5084,6 +5085,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10753,6 +10755,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.21.50/proto.yml
+++ b/data/bedrock/1.21.50/proto.yml
@@ -3315,6 +3315,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.21.50/protocol.json
+++ b/data/bedrock/1.21.50/protocol.json
@@ -4929,6 +4929,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -5152,6 +5153,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10852,6 +10854,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.21.60/proto.yml
+++ b/data/bedrock/1.21.60/proto.yml
@@ -3345,6 +3345,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:

--- a/data/bedrock/1.21.60/protocol.json
+++ b/data/bedrock/1.21.60/protocol.json
@@ -4951,6 +4951,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -5176,6 +5177,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10933,6 +10935,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/1.21.70/protocol.json
+++ b/data/bedrock/1.21.70/protocol.json
@@ -4954,6 +4954,7 @@
                 "147": "item_stack_request",
                 "148": "item_stack_response",
                 "149": "player_armor_damage",
+                "150": "code_builder",
                 "151": "update_player_game_type",
                 "152": "emote_list",
                 "153": "position_tracking_db_broadcast",
@@ -5182,6 +5183,7 @@
                 "item_stack_request": "packet_item_stack_request",
                 "item_stack_response": "packet_item_stack_response",
                 "player_armor_damage": "packet_player_armor_damage",
+                "code_builder": "packet_code_builder",
                 "update_player_game_type": "packet_update_player_game_type",
                 "emote_list": "packet_emote_list",
                 "position_tracking_db_request": "packet_position_tracking_db_request",
@@ -10946,6 +10948,19 @@
         }
       }
     ],
+    "packet_code_builder": [
+		"container",
+		[
+			{
+				"name": "url",
+				"type": "string"
+			},
+			{
+				"name": "should_open_code_builder",
+				"type": "bool"
+			}
+		]
+	],
     "packet_update_player_game_type": [
       "container",
       [

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3349,6 +3349,18 @@ ArmorDamageType: [ "bitflags",
    }
 ]
 
+# CodeBuilder is an Education Edition packet sent by the server to the client to open the URL to a Code
+# Builder (websocket) server.
+packet_code_builder:
+   !id: 0x96
+   !bound: client
+   # URL is the url to the Code Builder (websocket) server.
+   url: string
+   # ShouldOpenCodeBuilder specifies if the client should automatically open the Code Builder app. If set to
+   # true, the client will attempt to use the Code Builder app to connect to and interface with the server
+   # running at the URL above.
+   should_open_code_builder: bool
+
 # UpdatePlayerGameType is sent by the server to change the game mode of a player. It is functionally
 # identical to the SetPlayerGameType packet.
 packet_update_player_game_type:


### PR DESCRIPTION
The `code_builder` packet is missing in all post-1.16 bedrock protocols. ([Reference](https://github.com/Sandertv/gophertunnel/blob/bfe0892926356f3aeb922df94a2e909804ea007e/minecraft/protocol/packet/code_builder.go))