### PR TITLE
Fix editBookPacketUsesNbt version range

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -244,7 +244,7 @@
   {
     "name": "editBookPacketUsesNbt",
     "description": "edit_book packet sends a new book item (with its NBT containing page data) to server",
-    "versions": ["1.13", "1.17.1"]
+    "versions": ["1.13", "1.17"]
   },
   {
     "name": "clientUpdateBookIdWhenSign",


### PR DESCRIPTION
In #876 a feature `editBookPacketUsesNbt` was added that describes the structure of the `edit_book` packet. However, it seems like the packet already changed in `1.17.1`, rather than in `1.18`. For that reason, `1.17` is the last version where that packet includes the new book nbt data.

For reference

1.17:
- <https://prismarinejs.github.io/minecraft-data/?v=1.17&d=protocol#play.toServer.types.packet_edit_book>
- <https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol?oldid=2772685#Edit_Book>

1.17.1:
- <https://prismarinejs.github.io/minecraft-data/?v=1.17.1&d=protocol#play.toServer.types.packet_edit_book>
- <https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol?oldid=2772702#Edit_Book>