### PR TITLE
fix: typo in SlotDisplay `smithing_trim`

### DIFF
--- a/data/pc/1.21.3/proto.yml
+++ b/data/pc/1.21.3/proto.yml
@@ -1463,7 +1463,7 @@
          if item: varint
          if item_stack: Slot
          if tag: string
-         if simthing_trim:
+         if smithing_trim:
             base: SlotDisplay
             material: SlotDisplay
             pattern: SlotDisplay

--- a/data/pc/1.21.3/protocol.json
+++ b/data/pc/1.21.3/protocol.json
@@ -3922,7 +3922,7 @@
                     "item": "varint",
                     "item_stack": "Slot",
                     "tag": "string",
-                    "simthing_trim": [
+                    "smithing_trim": [
                       "container",
                       [
                         {

--- a/data/pc/1.21.4/protocol.json
+++ b/data/pc/1.21.4/protocol.json
@@ -3932,7 +3932,7 @@
                     "item": "varint",
                     "item_stack": "Slot",
                     "tag": "string",
-                    "simthing_trim": [
+                    "smithing_trim": [
                       "container",
                       [
                         {

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -1463,7 +1463,7 @@
          if item: varint
          if item_stack: Slot
          if tag: string
-         if simthing_trim:
+         if smithing_trim:
             base: SlotDisplay
             material: SlotDisplay
             pattern: SlotDisplay


### PR DESCRIPTION
Fixes https://github.com/PrismarineJS/node-minecraft-protocol/issues/1406.