### PR TITLE
Mention minebase wrapper lib in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Minecraft-data is language independent, you can use it with these language speci
 | --- | --- | --- |
 | [node-minecraft-data](https://github.com/PrismarineJS/node-minecraft-data) | Node.js | everything |
 | [python-minecraft-data](https://github.com/SpockBotMC/python-minecraft-data) | python | everything |
+| [minebase](https://github.com/py-mine/minebase) | python | everything |
 | [McData](https://github.com/McEx/McData) | Elixir | protocol |
 | [ProtocolGen](https://github.com/Johni0702/ProtocolGen) | java | generated java files from protocol.json to read and write minecraft packets |
 | [mcdata](https://github.com/wlwanpan/mcdata) | Go | everything |


### PR DESCRIPTION
Hey, I’ve created a new Python wrapper for minecraft-data: [`minebase`](https://github.com/py-mine/minebase), as the existing one appears to be inactive (last released over two years ago). This PR is a small suggestion to add it to your README alongside the other wrappers.

The library lives under the [`py-mine`](https://github.com/py-mine) organization, which maintains a few notable Python projects related to Minecraft. I'm one of the maintainers there.

At this stage, the wrapper already provides access to nearly all of the data as Python dictionaries (except for the YAML files, though support is planned there too). It’s available on [PyPI](https://pypi.org/project/minebase/) (python package manager) for easy installation. While there are some improvements I'd still like to make (e.g., better type safety), the project is actively maintained and usable today.

Hope this might be a useful addition for Python developers looking for a maintained wrapper library.