### PR TITLE
Enforce no additional properties for enchantments

### DIFF
--- a/schemas/enchantments_schema.json
+++ b/schemas/enchantments_schema.json
@@ -2,7 +2,7 @@
   "title": "enchantments",
   "type": "array",
   "uniqueItems": true,
-  "items" : {
+  "items": {
     "title": "enchantment",
     "type": "object",
     "properties": {
@@ -99,6 +99,7 @@
       "curse",
       "tradeable",
       "discoverable"
-    ]
+    ],
+    "additionalProperties": false
   }
 }


### PR DESCRIPTION
The enchantments schema currently doesn't contain `additionalProperties: false` setting, which allows values to potentially add extra fields undocumented fields, this PR simply adds that setting to prevent such scenario.

Note that all of the data currently conforms to the schema even with this setting added.
