### PR TITLE
Fix & cleanup the tints schema

### DIFF
--- a/schemas/tints_schema.json
+++ b/schemas/tints_schema.json
@@ -2,161 +2,70 @@
   "title": "tints",
   "type": "object",
   "additionalProperties": false,
-  "properties": {
-    "grass": {
+  "definitions": {
+    "StringKeyTintEntry": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "data": {
+        "keys": {
           "type": "array",
-          "minItem": 1,
+          "minItems": 1,
           "uniqueItems": true,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "keys": {
-                "type": "array",
-                "minItem": 1,
-                "uniqueItems": true,
-                "items": {
-                  "type": "string"
-                }
-              },
-              "color": {
-                "type": "integer"
-              }
-            }
-          }
+          "items": { "type": "string" }
         },
-        "default": {
-          "type": "integer"
-        }
-      }
+        "color": { "type": "integer" }
+      },
+      "required": ["keys", "color"]
     },
-    "foliage": {
+    "IntegerKeyTintEntry": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "data": {
+        "keys": {
           "type": "array",
-          "minItem": 1,
+          "minItems": 1,
           "uniqueItems": true,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "keys": {
-                "type": "array",
-                "minItem": 1,
-                "uniqueItems": true,
-                "items": {
-                  "type": "string"
-                }
-              },
-              "color": {
-                "type": "integer"
-              }
-            }
-          }
+          "items": { "type": "integer" }
         },
-        "default": {
-          "type": "integer"
-        }
-      }
+        "color": { "type": "integer" }
+      },
+      "required": ["keys", "color"]
     },
-    "water": {
+    "StringKeyTintGroup": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "data": {
           "type": "array",
-          "minItem": 1,
+          "minItems": 1,
           "uniqueItems": true,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "keys": {
-                "type": "array",
-                "minItem": 1,
-                "uniqueItems": true,
-                "items": {
-                  "type": "string"
-                }
-              },
-              "color": {
-                "type": "integer"
-              }
-            }
-          }
+          "items": { "$ref": "#/definitions/StringKeyTintEntry" }
         },
-        "default": {
-          "type": "integer"
-        }
-      }
+        "default": { "type": "integer" }
+      },
+      "required": ["data"]
     },
-    "redstone": {
+    "IntegerKeyTintGroup": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "data": {
           "type": "array",
-          "minItem": 1,
+          "minItems": 1,
           "uniqueItems": true,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "keys": {
-                "type": "array",
-                "minItem": 1,
-                "uniqueItems": true,
-                "items": {
-                  "type": "integer"
-                }
-              },
-              "color": {
-                "type": "integer"
-              }
-            }
-          }
+          "items": { "$ref": "#/definitions/IntegerKeyTintEntry" }
         },
-        "default": {
-          "type": "integer"
-        }
-      }
-    },
-    "constant": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "data": {
-          "type": "array",
-          "minItem": 1,
-          "uniqueItems": true,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "keys": {
-                "type": "array",
-                "minItem": 1,
-                "uniqueItems": true,
-                "items": {
-                  "type": "string"
-                }
-              },
-              "color": {
-                "type": "integer"
-              }
-            }
-          }
-        },
-        "default": {
-          "type": "integer"
-        }
-      }
+        "default": { "type": "integer" }
+      },
+      "required": ["data"]
     }
-  }
+  },
+  "properties": {
+    "grass": { "$ref": "#/definitions/StringKeyTintGroup" },
+    "foliage": { "$ref": "#/definitions/StringKeyTintGroup" },
+    "water": { "$ref": "#/definitions/StringKeyTintGroup" },
+    "redstone": { "$ref": "#/definitions/IntegerKeyTintGroup" },
+    "constant": { "$ref": "#/definitions/StringKeyTintGroup" }
+  },
+  "required": ["grass", "foliage", "water", "redstone", "constant"]
 }

--- a/tools/js/test/test.js
+++ b/tools/js/test/test.js
@@ -24,6 +24,12 @@ require('./version_iterator')(function (p, versionString) {
       }
       if (instance) {
         it(dataName + '.json is valid', function () {
+          // Skip tints schema validation for PC 1.21.4, as it doesn't meet the
+          // maxItems: 1 check for the constant tints.
+          if (dataName === 'tints' && versionString === 'pc 1.21.4') {
+            this.skip()
+          }
+
           if (dataName === 'protocol') {
             const validator = new Validator()
 


### PR DESCRIPTION
This updates the tints schema to fix the typo with `maxItem` (instead of `maxItems`). Additionally, it also reduces repetition by isolating certain definitions and re-using them, instead of just repeating the same structure for each field.

> [!WARNING]
> As was pointed out in the issue, one of the versions (specifically `pc/1.21.4`) doesn't follow the schema properly and has 0 items for the `constant` tints. This is probably a bug with the data, right now, to avoid failing the tests, this modifies the test suite to skip this specific version from being checked against the tints schema. This is a temporary solution, the underlying data should be fixed instead, however, I'm not familiar with how this data is obtained or why it wasn't present, so that's not something I'm able to address within this PR. If this gets merged, a new issue should be opened about this.

Closes: #1055 