### PR TITLE
Use PAT_PASSWORD for workflow consistency

### DIFF
--- a/.github/workflows/update-helper.yml
+++ b/.github/workflows/update-helper.yml
@@ -23,4 +23,4 @@ jobs:
       run: node index.js
       working-directory: .github/helper-bot
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT_PASSWORD }}


### PR DESCRIPTION
Changes minecraft-data update-helper workflow to use PAT_PASSWORD token for consistency with downstream repositories.

## Changes
- Replace GITHUB_TOKEN with PAT_PASSWORD in update-helper.yml
- Ensures consistent token usage across the PrismarineJS automation ecosystem
- Uses the same rom1504bot token that has workflow permissions

This aligns with the token usage in node-minecraft-protocol and mineflayer automation workflows.