### PR TITLE
fix(protocol): add missing packet ids

### DIFF
--- a/data/pc/1.20.5/protocol.json
+++ b/data/pc/1.20.5/protocol.json
@@ -7237,7 +7237,8 @@
                     "0x75": "entity_update_attributes",
                     "0x76": "entity_effect",
                     "0x77": "declare_recipes",
-                    "0x78": "tags"
+                    "0x78": "tags",
+                    "0x79": "set_projectile_power"
                   }
                 }
               ]
@@ -7369,7 +7370,8 @@
                     "entity_update_attributes": "packet_entity_update_attributes",
                     "entity_effect": "packet_entity_effect",
                     "declare_recipes": "packet_declare_recipes",
-                    "tags": "packet_tags"
+                    "tags": "packet_tags",
+                    "set_projectile_power": "packet_set_projectile_power"
                   }
                 }
               ]
@@ -8558,7 +8560,8 @@
                     "arm_animation": "packet_arm_animation",
                     "spectate": "packet_spectate",
                     "block_place": "packet_block_place",
-                    "use_item": "packet_use_item"
+                    "use_item": "packet_use_item",
+                    "debug_sample_subscription": "packet_debug_sample_subscription"
                   }
                 }
               ]

--- a/data/pc/1.21.1/protocol.json
+++ b/data/pc/1.21.1/protocol.json
@@ -7417,7 +7417,8 @@
                     "0x75": "entity_update_attributes",
                     "0x76": "entity_effect",
                     "0x77": "declare_recipes",
-                    "0x78": "tags"
+                    "0x78": "tags",
+                    "0x79": "set_projectile_power"
                   }
                 }
               ]
@@ -7549,7 +7550,8 @@
                     "entity_update_attributes": "packet_entity_update_attributes",
                     "entity_effect": "packet_entity_effect",
                     "declare_recipes": "packet_declare_recipes",
-                    "tags": "packet_tags"
+                    "tags": "packet_tags",
+                    "set_projectile_power": "packet_set_projectile_power"
                   }
                 }
               ]
@@ -8742,7 +8744,8 @@
                     "arm_animation": "packet_arm_animation",
                     "spectate": "packet_spectate",
                     "block_place": "packet_block_place",
-                    "use_item": "packet_use_item"
+                    "use_item": "packet_use_item",
+                    "debug_sample_subscription": "packet_debug_sample_subscription"
                   }
                 }
               ]

--- a/data/pc/1.21.3/protocol.json
+++ b/data/pc/1.21.3/protocol.json
@@ -9312,7 +9312,8 @@
                     "arm_animation": "packet_arm_animation",
                     "spectate": "packet_spectate",
                     "block_place": "packet_block_place",
-                    "use_item": "packet_use_item"
+                    "use_item": "packet_use_item",
+                    "debug_sample_subscription": "packet_debug_sample_subscription"
                   }
                 }
               ]

--- a/data/pc/1.21.4/protocol.json
+++ b/data/pc/1.21.4/protocol.json
@@ -9363,7 +9363,8 @@
                     "arm_animation": "packet_arm_animation",
                     "spectate": "packet_spectate",
                     "block_place": "packet_block_place",
-                    "use_item": "packet_use_item"
+                    "use_item": "packet_use_item",
+                    "debug_sample_subscription": "packet_debug_sample_subscription"
                   }
                 }
               ]

--- a/data/pc/1.21.5/protocol.json
+++ b/data/pc/1.21.5/protocol.json
@@ -9863,7 +9863,8 @@
                     "test_instance_block_action": "packet_test_instance_block_action",
                     "spectate": "packet_spectate",
                     "block_place": "packet_block_place",
-                    "use_item": "packet_use_item"
+                    "use_item": "packet_use_item",
+                    "debug_sample_subscription": "packet_debug_sample_subscription"
                   }
                 }
               ]


### PR DESCRIPTION

I'm writing a C# packet generator based on minecraft-data. 
During validation I found that some packets were described in the protocol schema 
but had no IDs assigned in the `packet` mapping. Because of this my generator broke.  

This PR fixes the [issue ](https://github.com/PrismarineJS/minecraft-data/issues/981) by adding the missing packet IDs.  
I already created an issue about this a while ago, but it was ignored, 
so I'm opening a PR directly.