### PR TITLE
Fix packet_explosion partial packet issue

### DIFF
--- a/data/pc/1.21.4/proto.yml
+++ b/data/pc/1.21.4/proto.yml
@@ -1736,7 +1736,7 @@
       x: f64
       y: f64
       z: f64
-      playerKnockback?: vec3f
+      playerKnockback?: vec3f64
       explosionParticle: Particle
       sound: ItemSoundHolder
    # MC: ClientboundForgetLevelChunkPacket

--- a/data/pc/1.21.4/protocol.json
+++ b/data/pc/1.21.4/protocol.json
@@ -4975,7 +4975,7 @@
               "name": "playerKnockback",
               "type": [
                 "option",
-                "vec3f"
+                "vec3f64"
               ]
             },
             {

--- a/data/pc/1.21.5/proto.yml
+++ b/data/pc/1.21.5/proto.yml
@@ -1848,7 +1848,7 @@
       x: f64
       y: f64
       z: f64
-      playerKnockback?: vec3f
+      playerKnockback?: vec3f64
       explosionParticle: Particle
       sound: ItemSoundHolder
    # MC: ClientboundForgetLevelChunkPacket

--- a/data/pc/1.21.5/protocol.json
+++ b/data/pc/1.21.5/protocol.json
@@ -5350,7 +5350,7 @@
               "name": "playerKnockback",
               "type": [
                 "option",
-                "vec3f"
+                "vec3f64"
               ]
             },
             {

--- a/data/pc/1.21.6/proto.yml
+++ b/data/pc/1.21.6/proto.yml
@@ -1877,7 +1877,7 @@
       x: f64
       y: f64
       z: f64
-      playerKnockback?: vec3f
+      playerKnockback?: vec3f64
       explosionParticle: Particle
       sound: ItemSoundHolder
    # MC: ClientboundForgetLevelChunkPacket

--- a/data/pc/1.21.6/protocol.json
+++ b/data/pc/1.21.6/protocol.json
@@ -5440,7 +5440,7 @@
               "name": "playerKnockback",
               "type": [
                 "option",
-                "vec3f"
+                "vec3f64"
               ]
             },
             {

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -5440,7 +5440,7 @@
               "name": "playerKnockback",
               "type": [
                 "option",
-                "vec3f"
+                "vec3f64"
               ]
             },
             {

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -1877,7 +1877,7 @@
       x: f64
       y: f64
       z: f64
-      playerKnockback?: vec3f
+      playerKnockback?: vec3f64
       explosionParticle: Particle
       sound: ItemSoundHolder
    # MC: ClientboundForgetLevelChunkPacket


### PR DESCRIPTION
`packet_explosion` was reading 32 bit vec3 for playerKnockback instead of 64 bit vec3. 
This was causing issues with knockback calculation. Mineflayer bot  in survival mode when affected by explosion knockback results in a crash.  
https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol?oldid=3258009#Explosion

Versions updated
- 1.21.8
- 1.21.7
- 1.21.6
- 1.21.5
- 1.21.4

Fixes https://github.com/PrismarineJS/mineflayer/issues/3753