### PR TITLE
chore: sync protocol json with yaml

### DIFF
--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -3423,10 +3423,7 @@
         },
         {
           "name": "value",
-          "type": [
-            "option",
-            "ByteArray"
-          ]
+          "type": "ByteArray"
         }
       ]
     ],
@@ -9036,7 +9033,7 @@
             },
             {
               "name": "checksum",
-              "type": "u8"
+              "type": "i8"
             }
           ]
         ],

--- a/data/pc/1.21.9/protocol.json
+++ b/data/pc/1.21.9/protocol.json
@@ -3423,7 +3423,10 @@
         },
         {
           "name": "value",
-          "type": "ByteArray"
+          "type": [
+            "option",
+            "ByteArray"
+          ]
         }
       ]
     ],
@@ -9162,7 +9165,7 @@
             },
             {
               "name": "checksum",
-              "type": "i8"
+              "type": "u8"
             }
           ]
         ],


### PR DESCRIPTION
fixes 1.21.8 and 1.21.9.  The bot changed .8 making it out of sync even though this is a .9 branch.   I can remove .8 if requested