### PR TITLE
fix type for packet_biome_definition_list in 1.21.130

### DIFF
--- a/data/bedrock/1.21.111/protocol.json
+++ b/data/bedrock/1.21.111/protocol.json
@@ -5009,10 +5009,7 @@
         },
         {
           "name": "has_default_overworld_surface",
-          "type": [
-            "option",
-            "bool"
-          ]
+          "type": "bool"
         },
         {
           "name": "has_swamp_surface",

--- a/data/bedrock/1.21.111/types.yml
+++ b/data/bedrock/1.21.111/types.yml
@@ -2591,7 +2591,7 @@ BiomeChunkGeneration:
    # SurfaceMaterials is a set of materials to use for the surface layers of the biome.
    surface_materials?: BiomeSurfaceMaterial
    # HasDefaultOverworldSurface is true if the biome has a default overworld surface.
-   has_default_overworld_surface?: bool
+   has_default_overworld_surface: bool
    # HasSwampSurface is true if the biome has a swamp surface.
    has_swamp_surface: bool
    # HasFrozenOceanSurface is true if the biome has a frozen ocean surface.

--- a/data/bedrock/1.21.120/protocol.json
+++ b/data/bedrock/1.21.120/protocol.json
@@ -5065,10 +5065,7 @@
         },
         {
           "name": "has_default_overworld_surface",
-          "type": [
-            "option",
-            "bool"
-          ]
+          "type": "bool"
         },
         {
           "name": "has_swamp_surface",

--- a/data/bedrock/1.21.120/types.yml
+++ b/data/bedrock/1.21.120/types.yml
@@ -2612,7 +2612,7 @@ BiomeChunkGeneration:
    # SurfaceMaterials is a set of materials to use for the surface layers of the biome.
    surface_materials?: BiomeSurfaceMaterial
    # HasDefaultOverworldSurface is true if the biome has a default overworld surface.
-   has_default_overworld_surface?: bool
+   has_default_overworld_surface: bool
    # HasSwampSurface is true if the biome has a swamp surface.
    has_swamp_surface: bool
    # HasFrozenOceanSurface is true if the biome has a frozen ocean surface.

--- a/data/bedrock/1.21.124/protocol.json
+++ b/data/bedrock/1.21.124/protocol.json
@@ -5065,10 +5065,7 @@
         },
         {
           "name": "has_default_overworld_surface",
-          "type": [
-            "option",
-            "bool"
-          ]
+          "type": "bool"
         },
         {
           "name": "has_swamp_surface",

--- a/data/bedrock/1.21.124/types.yml
+++ b/data/bedrock/1.21.124/types.yml
@@ -2612,7 +2612,7 @@ BiomeChunkGeneration:
    # SurfaceMaterials is a set of materials to use for the surface layers of the biome.
    surface_materials?: BiomeSurfaceMaterial
    # HasDefaultOverworldSurface is true if the biome has a default overworld surface.
-   has_default_overworld_surface?: bool
+   has_default_overworld_surface: bool
    # HasSwampSurface is true if the biome has a swamp surface.
    has_swamp_surface: bool
    # HasFrozenOceanSurface is true if the biome has a frozen ocean surface.

--- a/data/bedrock/1.21.130/protocol.json
+++ b/data/bedrock/1.21.130/protocol.json
@@ -5078,10 +5078,7 @@
         },
         {
           "name": "has_default_overworld_surface",
-          "type": [
-            "option",
-            "bool"
-          ]
+          "type": "bool"
         },
         {
           "name": "has_swamp_surface",

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -2625,7 +2625,7 @@ BiomeChunkGeneration:
    # SurfaceMaterials is a set of materials to use for the surface layers of the biome.
    surface_materials?: BiomeSurfaceMaterial
    # HasDefaultOverworldSurface is true if the biome has a default overworld surface.
-   has_default_overworld_surface?: bool
+   has_default_overworld_surface: bool
    # HasSwampSurface is true if the biome has a swamp surface.
    has_swamp_surface: bool
    # HasFrozenOceanSurface is true if the biome has a frozen ocean surface.


### PR DESCRIPTION
fixes #1128

has_default_overworld_surface is not optional. source: https://github.com/Mojang/bedrock-protocol-docs/blob/6e6ad8a183371fcd04acef31df7f81c70dbc38fe/html/svg/BiomeDefinitionChunkGenData.svg?plain=1#L4