### PR TITLE
fix(bedrock/proto): mismatched field type in GatheringJoinInfo

### DIFF
--- a/data/bedrock/26.10/protocol.json
+++ b/data/bedrock/26.10/protocol.json
@@ -5202,12 +5202,12 @@
           "type": "string"
         },
         {
-          "name": "unknown_uuid_1",
+          "name": "target_id",
           "type": "uuid"
         },
         {
-          "name": "unknown_uuid_2",
-          "type": "uuid"
+          "name": "scenario_id",
+          "type": "string"
         },
         {
           "name": "server_id",

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -2584,8 +2584,8 @@ GatheringJoinInfo:
    experience_world_id: uuid
    experience_world_name: string
    creator_id: string
-   unknown_uuid_1: uuid
-   unknown_uuid_2: uuid
+   target_id: uuid
+   scenario_id: string
    server_id: string
 
 StoreEntryPointInfo:


### PR DESCRIPTION
scenario_id should be string instead of uuid
https://github.com/CloudburstMC/Protocol/blob/3.0/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v944/serializer/StartGameSerializer_v944.java#L26