### PR TITLE
pc: Fix chat packet checksum field type mismatch

### DIFF
--- a/data/pc/1.21.11/protocol.json
+++ b/data/pc/1.21.11/protocol.json
@@ -10420,7 +10420,7 @@
             },
             {
               "name": "checksum",
-              "type": "i8"
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/1.21.5/proto.yml
+++ b/data/pc/1.21.5/proto.yml
@@ -2934,7 +2934,7 @@
             "count": 3
          }
       ]
-      checksum: i8
+      checksum: u8
    # MC: ServerboundChatPacket
    packet_chat_message:
       message: string
@@ -2953,7 +2953,7 @@
             "count": 3
          }
       ]
-      checksum: i8
+      checksum: u8
    # MC: ServerboundChatSessionUpdatePacket
    packet_chat_session_update:
       sessionUUID: UUID

--- a/data/pc/1.21.5/protocol.json
+++ b/data/pc/1.21.5/protocol.json
@@ -8625,7 +8625,7 @@
             },
             {
               "name": "checksum",
-              "type": "i8"
+              "type": "u8"
             }
           ]
         ],
@@ -8671,7 +8671,7 @@
             },
             {
               "name": "checksum",
-              "type": "i8"
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/1.21.6/proto.yml
+++ b/data/pc/1.21.6/proto.yml
@@ -3031,7 +3031,7 @@
             "count": 3
          }
       ]
-      checksum: i8
+      checksum: u8
    # MC: ServerboundChatPacket
    packet_chat_message:
       message: string
@@ -3050,7 +3050,7 @@
             "count": 3
          }
       ]
-      checksum: i8
+      checksum: u8
    # MC: ServerboundChatSessionUpdatePacket
    packet_chat_session_update:
       sessionUUID: UUID

--- a/data/pc/1.21.6/protocol.json
+++ b/data/pc/1.21.6/protocol.json
@@ -8999,7 +8999,7 @@
             },
             {
               "name": "checksum",
-              "type": "i8"
+              "type": "u8"
             }
           ]
         ],
@@ -9045,7 +9045,7 @@
             },
             {
               "name": "checksum",
-              "type": "i8"
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/1.21.8/proto.yml
+++ b/data/pc/1.21.8/proto.yml
@@ -3031,7 +3031,7 @@
             "count": 3
          }
       ]
-      checksum: i8
+      checksum: u8
    # MC: ServerboundChatPacket
    packet_chat_message:
       message: string
@@ -3050,7 +3050,7 @@
             "count": 3
          }
       ]
-      checksum: i8
+      checksum: u8
    # MC: ServerboundChatSessionUpdatePacket
    packet_chat_session_update:
       sessionUUID: UUID

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -8996,7 +8996,7 @@
             },
             {
               "name": "checksum",
-              "type": "i8"
+              "type": "u8"
             }
           ]
         ],
@@ -9042,7 +9042,7 @@
             },
             {
               "name": "checksum",
-              "type": "i8"
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/1.21.9/proto.yml
+++ b/data/pc/1.21.9/proto.yml
@@ -3305,7 +3305,7 @@
             "count": 3
          }
       ]
-      checksum: i8
+      checksum: u8
    # MC: ServerboundChatPacket
    packet_chat_message:
       message: string

--- a/data/pc/1.21.9/protocol.json
+++ b/data/pc/1.21.9/protocol.json
@@ -10130,7 +10130,7 @@
             },
             {
               "name": "checksum",
-              "type": "i8"
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -3382,7 +3382,7 @@
             "count": 3
          }
       ]
-      checksum: i8
+      checksum: u8
    # MC: ServerboundChatPacket
    packet_chat_message:
       message: string


### PR DESCRIPTION
Fixes some chat `checksum` fields being incorrectly set to i8 instead of u8

Supersedes #1187 