### PR TITLE
chore: resolve helper package audit advisories

### DIFF
--- a/.github/helper-bot/package.json
+++ b/.github/helper-bot/package.json
@@ -3,9 +3,20 @@
     "fix": "standard --fix"
   },
   "dependencies": {
-    "gh-helpers": "^1.0.0"
+    "gh-helpers": "^1.2.0"
   },
   "devDependencies": {
     "standard": "^17.1.2"
+  },
+  "overrides": {
+    "@actions/artifact": "5.0.3",
+    "@actions/github": "8.0.0",
+    "@actions/http-client": "3.0.2",
+    "@octokit/core": "7.0.6",
+    "@octokit/graphql": "9.0.2",
+    "@octokit/plugin-paginate-rest": "14.0.0",
+    "@octokit/request": "10.0.7",
+    "@octokit/request-error": "7.1.0",
+    "undici": "6.25.0"
   }
 }

--- a/tools/js/package.json
+++ b/tools/js/package.json
@@ -19,5 +19,11 @@
   },
   "devDependencies": {
     "protodef-yaml": "^1.5.0"
+  },
+  "overrides": {
+    "jsdom": "29.1.1",
+    "serialize-javascript": "7.0.5",
+    "showdown": "git+https://github.com/showdownjs/showdown.git#2a8a64eb3dd137dc456fd016322a78cde66136d7",
+    "undici": "7.25.0"
   }
 }


### PR DESCRIPTION
Updates GitHub helper/tool package manifests so generated npm audit lockfiles report zero vulnerabilities.\n\nChanges:\n- add overrides for vulnerable mocha/serialize-javascript and protodef-yaml/showdown transitives in tools/js\n- update gh-helpers and force patched CommonJS-compatible @actions/@octokit/undici versions for the helper bot\n\nVerification:\n- npm audit --json in tools/js\n- npm audit --json in .github/helper-bot\n- npm run lint in tools/js\n- npm test in tools/js (1742 passing, 1 pending)