### PR TITLE
Fix enchant_item button id: varint, not i8 (1.21 container rework)

### DIFF
--- a/data/pc/1.21.1/proto.yml
+++ b/data/pc/1.21.1/proto.yml
@@ -2702,7 +2702,7 @@
    # MC: ServerboundContainerButtonClickPacket
    packet_enchant_item:
       windowId: ContainerID
-      enchantment: i8
+      enchantment: varint
    # MC: ServerboundContainerClickPacket
    packet_window_click:
       windowId: ContainerID

--- a/data/pc/1.21.1/protocol.json
+++ b/data/pc/1.21.1/protocol.json
@@ -7783,7 +7783,7 @@
             },
             {
               "name": "enchantment",
-              "type": "i8"
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/1.21.11/protocol.json
+++ b/data/pc/1.21.11/protocol.json
@@ -10539,7 +10539,7 @@
             },
             {
               "name": "enchantment",
-              "type": "i8"
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/1.21.3/proto.yml
+++ b/data/pc/1.21.3/proto.yml
@@ -2855,7 +2855,7 @@
    # MC: ServerboundContainerButtonClickPacket
    packet_enchant_item:
       windowId: ContainerID
-      enchantment: i8
+      enchantment: varint
    # MC: ServerboundContainerClickPacket
    packet_window_click:
       windowId: ContainerID

--- a/data/pc/1.21.3/protocol.json
+++ b/data/pc/1.21.3/protocol.json
@@ -8323,7 +8323,7 @@
             },
             {
               "name": "enchantment",
-              "type": "i8"
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/1.21.4/proto.yml
+++ b/data/pc/1.21.4/proto.yml
@@ -2859,7 +2859,7 @@
    # MC: ServerboundContainerButtonClickPacket
    packet_enchant_item:
       windowId: ContainerID
-      enchantment: i8
+      enchantment: varint
    # MC: ServerboundContainerClickPacket
    packet_window_click:
       windowId: ContainerID

--- a/data/pc/1.21.4/protocol.json
+++ b/data/pc/1.21.4/protocol.json
@@ -8345,7 +8345,7 @@
             },
             {
               "name": "enchantment",
-              "type": "i8"
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/1.21.5/proto.yml
+++ b/data/pc/1.21.5/proto.yml
@@ -2979,7 +2979,7 @@
    # MC: ServerboundContainerButtonClickPacket
    packet_enchant_item:
       windowId: ContainerID
-      enchantment: i8
+      enchantment: varint
    # MC: ServerboundContainerClickPacket
    packet_window_click:
       windowId: ContainerID

--- a/data/pc/1.21.5/protocol.json
+++ b/data/pc/1.21.5/protocol.json
@@ -8744,7 +8744,7 @@
             },
             {
               "name": "enchantment",
-              "type": "i8"
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/1.21.6/proto.yml
+++ b/data/pc/1.21.6/proto.yml
@@ -3076,7 +3076,7 @@
    # MC: ServerboundContainerButtonClickPacket
    packet_enchant_item:
       windowId: ContainerID
-      enchantment: i8
+      enchantment: varint
    # MC: ServerboundContainerClickPacket
    packet_window_click:
       windowId: ContainerID

--- a/data/pc/1.21.6/protocol.json
+++ b/data/pc/1.21.6/protocol.json
@@ -9118,7 +9118,7 @@
             },
             {
               "name": "enchantment",
-              "type": "i8"
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/1.21.8/proto.yml
+++ b/data/pc/1.21.8/proto.yml
@@ -3076,7 +3076,7 @@
    # MC: ServerboundContainerButtonClickPacket
    packet_enchant_item:
       windowId: ContainerID
-      enchantment: i8
+      enchantment: varint
    # MC: ServerboundContainerClickPacket
    packet_window_click:
       windowId: ContainerID

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -9115,7 +9115,7 @@
             },
             {
               "name": "enchantment",
-              "type": "i8"
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/1.21.9/proto.yml
+++ b/data/pc/1.21.9/proto.yml
@@ -3350,7 +3350,7 @@
    # MC: ServerboundContainerButtonClickPacket
    packet_enchant_item:
       windowId: ContainerID
-      enchantment: i8
+      enchantment: varint
    # MC: ServerboundContainerClickPacket
    packet_window_click:
       windowId: ContainerID

--- a/data/pc/1.21.9/protocol.json
+++ b/data/pc/1.21.9/protocol.json
@@ -10249,7 +10249,7 @@
             },
             {
               "name": "enchantment",
-              "type": "i8"
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -3427,7 +3427,7 @@
    # MC: ServerboundContainerButtonClickPacket
    packet_enchant_item:
       windowId: ContainerID
-      enchantment: i8
+      enchantment: varint
    # MC: ServerboundContainerClickPacket
    packet_window_click:
       windowId: ContainerID


### PR DESCRIPTION
## Problem

`packet_enchant_item` (vanilla `ServerboundContainerButtonClickPacket`) defines its `enchantment` field — the container button id — as `i8`. Since the 1.21 container rework the vanilla codec encodes it as a **VarInt**:

```java
// ServerboundContainerButtonClickPacket, 1.21+
StreamCodec.composite(
  ByteBufCodecs.CONTAINER_ID, ::containerId,   // varint (plain VAR_INT in 1.21.1)
  ByteBufCodecs.VAR_INT,      ::buttonId,      // varint  <-- mcdata still has i8
  ::new)
```

minecraft-data already updated `windowId` to `ContainerID` (varint) for 1.21+, but left `enchantment` as `i8` — an incomplete update of the same packet.

| versions          | windowId      | enchantment (mcdata) | jar button id |
|-------------------|---------------|----------------------|---------------|
| ≤ 1.20.5          | `i8`          | `i8` ✓               | byte          |
| 1.21.1 – 1.21.11  | `ContainerID` | `i8` ✗               | VarInt        |

Before 1.21 both fields were a single byte (`readByte`/`writeByte`), so `i8` is correct there — this only affects **1.21.1 – 1.21.11**.

## Impact

A VarInt and a byte encode identically for button ids below 128, so it seldom surfaces. But a button id ≥ 128 — e.g. a stonecutter or loom recipe index on a server with a large recipe set — needs a 2-byte VarInt that an `i8` writer cannot represent. The packet is serverbound, so this affects any client encoding it.

## Verification

Decompiled the official Mojang server jars: `readByte`/`writeByte` for both fields in **1.19.4** (pre-rework), and a `VAR_INT` button id in **1.21.1** (where the rework lands) and **1.21.3 / 1.21.5 / 1.21.6 / 1.21.8 / 1.21.9**.

## Change

`enchantment: i8` → `enchantment: varint` in `packet_enchant_item`, for 1.21.1 → 1.21.11. `proto.yml` edited and `protocol.json` regenerated with `npm run build` (16 files, +16/−16; nothing else touched). `node compileProtocol.js` validate passes for all versions.
