### PR TITLE
bedrock: fix BiomeChunkGeneration structure for 1.26.20+ (proto 970+)

### DIFF
--- a/data/bedrock/1.26.20/protocol.json
+++ b/data/bedrock/1.26.20/protocol.json
@@ -5634,43 +5634,6 @@
           ]
         },
         {
-          "name": "surface_materials",
-          "type": [
-            "option",
-            "BiomeSurfaceMaterial"
-          ]
-        },
-        {
-          "name": "has_default_overworld_surface",
-          "type": "bool"
-        },
-        {
-          "name": "has_swamp_surface",
-          "type": "bool"
-        },
-        {
-          "name": "has_frozen_ocean_surface",
-          "type": "bool"
-        },
-        {
-          "name": "has_end_surface",
-          "type": "bool"
-        },
-        {
-          "name": "mesa_surface",
-          "type": [
-            "option",
-            "BiomeMesaSurface"
-          ]
-        },
-        {
-          "name": "capped_surface",
-          "type": [
-            "option",
-            "BiomeCappedSurface"
-          ]
-        },
-        {
           "name": "overworld_rules",
           "type": [
             "option",
@@ -5723,6 +5686,112 @@
               "fields": {
                 "true": "u8"
               }
+            }
+          ]
+        },
+        {
+          "name": "surface_builder_data",
+          "type": [
+            "option",
+            "BiomeSurfaceBuilderData"
+          ]
+        },
+        {
+          "name": "subsurface_builder_data",
+          "type": [
+            "option",
+            "BiomeSurfaceBuilderData"
+          ]
+        }
+      ]
+    ],
+    "BiomeSurfaceBuilderData": [
+      "container",
+      [
+        {
+          "name": "surface_materials",
+          "type": [
+            "option",
+            "BiomeSurfaceMaterial"
+          ]
+        },
+        {
+          "name": "has_default_overworld_surface",
+          "type": "bool"
+        },
+        {
+          "name": "has_swamp_surface",
+          "type": "bool"
+        },
+        {
+          "name": "has_frozen_ocean_surface",
+          "type": "bool"
+        },
+        {
+          "name": "has_end_surface",
+          "type": "bool"
+        },
+        {
+          "name": "mesa_surface",
+          "type": [
+            "option",
+            "BiomeMesaSurface"
+          ]
+        },
+        {
+          "name": "capped_surface",
+          "type": [
+            "option",
+            "BiomeCappedSurface"
+          ]
+        },
+        {
+          "name": "noise_gradient_surface",
+          "type": [
+            "option",
+            "BiomeNoiseGradientSurfaceData"
+          ]
+        }
+      ]
+    ],
+    "BiomeNoiseGradientSurfaceData": [
+      "container",
+      [
+        {
+          "name": "non_replaceable_blocks",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "lu32"
+            }
+          ]
+        },
+        {
+          "name": "gradient_blocks",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "lu32"
+            }
+          ]
+        },
+        {
+          "name": "noise_seed_string",
+          "type": "string"
+        },
+        {
+          "name": "first_octave",
+          "type": "li32"
+        },
+        {
+          "name": "amplitudes",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "lf32"
             }
           ]
         }

--- a/data/bedrock/1.26.20/types.yml
+++ b/data/bedrock/1.26.20/types.yml
@@ -2814,6 +2814,25 @@ BiomeChunkGeneration:
    mountain_parameters?: BiomeMountainParameters
    # SurfaceMaterialAdjustments is a list of surface material adjustments.
    surface_material_adjustments?: BiomeElementData[]varint
+   # OverworldRules is optional information to specify the biome's overworld rules, such as rivers and hills.
+   overworld_rules?: BiomeOverworldRules
+   # MultiNoiseRules is optional information to specify the biome's multi-noise rules.
+   multi_noise_rules?: BiomeMultiNoiseRules
+   # LegacyRules is a list of legacy rules for the biomes using an older format, which is just a list of
+   # weighted biomes.
+   legacy_rules?: BiomeConditionalTransformation[]varint
+   # ReplacementsData is a list of biome replacement data.
+   replacements_data?: BiomeReplacementData[]varint
+   has_village_type: bool
+   village_type: has_village_type ?
+      if true: u8
+   # SurfaceBuilderData is optional information for surface building.
+   surface_builder_data?: BiomeSurfaceBuilderData
+   # SubsurfaceBuilderData is optional information for subsurface building.
+   subsurface_builder_data?: BiomeSurfaceBuilderData
+
+# BiomeSurfaceBuilderData specifies the surface building configuration for a biome.
+BiomeSurfaceBuilderData:
    # SurfaceMaterials is a set of materials to use for the surface layers of the biome.
    surface_materials?: BiomeSurfaceMaterial
    # HasDefaultOverworldSurface is true if the biome has a default overworld surface.
@@ -2828,18 +2847,21 @@ BiomeChunkGeneration:
    mesa_surface?: BiomeMesaSurface
    # CappedSurface is optional information to specify the biome's capped surface, i.e. in the Nether.
    capped_surface?: BiomeCappedSurface
-   # OverworldRules is optional information to specify the biome's overworld rules, such as rivers and hills.
-   overworld_rules?: BiomeOverworldRules
-   # MultiNoiseRules is optional information to specify the biome's multi-noise rules.
-   multi_noise_rules?: BiomeMultiNoiseRules
-   # LegacyRules is a list of legacy rules for the biomes using an older format, which is just a list of
-   # weighted biomes.
-   legacy_rules?: BiomeConditionalTransformation[]varint
-   # ReplacementsData is a list of biome replacement data.
-   replacements_data?: BiomeReplacementData[]varint
-   has_village_type: bool
-   village_type: has_village_type ?
-      if true: u8
+   # NoiseGradientSurface is optional information for noise gradient surface generation.
+   noise_gradient_surface?: BiomeNoiseGradientSurfaceData
+
+# BiomeNoiseGradientSurfaceData specifies noise gradient surface data for a biome.
+BiomeNoiseGradientSurfaceData:
+   # NonReplaceableBlocks is a list of block runtime IDs that cannot be replaced by the gradient.
+   non_replaceable_blocks: lu32[]varint
+   # GradientBlocks is a list of block runtime IDs to use for the gradient.
+   gradient_blocks: lu32[]varint
+   # NoiseSeedString is the seed string used for noise generation.
+   noise_seed_string: string
+   # FirstOctave is the first octave of the noise.
+   first_octave: li32
+   # Amplitudes is a list of amplitudes for each octave of the noise.
+   amplitudes: lf32[]varint
 
 # BiomeClimate represents the climate of a biome, mainly for ambience but also defines certain behaviours.
 BiomeClimate:

--- a/data/bedrock/1.26.30/protocol.json
+++ b/data/bedrock/1.26.30/protocol.json
@@ -5713,43 +5713,6 @@
           ]
         },
         {
-          "name": "surface_materials",
-          "type": [
-            "option",
-            "BiomeSurfaceMaterial"
-          ]
-        },
-        {
-          "name": "has_default_overworld_surface",
-          "type": "bool"
-        },
-        {
-          "name": "has_swamp_surface",
-          "type": "bool"
-        },
-        {
-          "name": "has_frozen_ocean_surface",
-          "type": "bool"
-        },
-        {
-          "name": "has_end_surface",
-          "type": "bool"
-        },
-        {
-          "name": "mesa_surface",
-          "type": [
-            "option",
-            "BiomeMesaSurface"
-          ]
-        },
-        {
-          "name": "capped_surface",
-          "type": [
-            "option",
-            "BiomeCappedSurface"
-          ]
-        },
-        {
           "name": "overworld_rules",
           "type": [
             "option",
@@ -5802,6 +5765,112 @@
               "fields": {
                 "true": "u8"
               }
+            }
+          ]
+        },
+        {
+          "name": "surface_builder_data",
+          "type": [
+            "option",
+            "BiomeSurfaceBuilderData"
+          ]
+        },
+        {
+          "name": "subsurface_builder_data",
+          "type": [
+            "option",
+            "BiomeSurfaceBuilderData"
+          ]
+        }
+      ]
+    ],
+    "BiomeSurfaceBuilderData": [
+      "container",
+      [
+        {
+          "name": "surface_materials",
+          "type": [
+            "option",
+            "BiomeSurfaceMaterial"
+          ]
+        },
+        {
+          "name": "has_default_overworld_surface",
+          "type": "bool"
+        },
+        {
+          "name": "has_swamp_surface",
+          "type": "bool"
+        },
+        {
+          "name": "has_frozen_ocean_surface",
+          "type": "bool"
+        },
+        {
+          "name": "has_end_surface",
+          "type": "bool"
+        },
+        {
+          "name": "mesa_surface",
+          "type": [
+            "option",
+            "BiomeMesaSurface"
+          ]
+        },
+        {
+          "name": "capped_surface",
+          "type": [
+            "option",
+            "BiomeCappedSurface"
+          ]
+        },
+        {
+          "name": "noise_gradient_surface",
+          "type": [
+            "option",
+            "BiomeNoiseGradientSurfaceData"
+          ]
+        }
+      ]
+    ],
+    "BiomeNoiseGradientSurfaceData": [
+      "container",
+      [
+        {
+          "name": "non_replaceable_blocks",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "lu32"
+            }
+          ]
+        },
+        {
+          "name": "gradient_blocks",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "lu32"
+            }
+          ]
+        },
+        {
+          "name": "noise_seed_string",
+          "type": "string"
+        },
+        {
+          "name": "first_octave",
+          "type": "li32"
+        },
+        {
+          "name": "amplitudes",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "lf32"
             }
           ]
         }

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -2846,6 +2846,25 @@ BiomeChunkGeneration:
    mountain_parameters?: BiomeMountainParameters
    # SurfaceMaterialAdjustments is a list of surface material adjustments.
    surface_material_adjustments?: BiomeElementData[]varint
+   # OverworldRules is optional information to specify the biome's overworld rules, such as rivers and hills.
+   overworld_rules?: BiomeOverworldRules
+   # MultiNoiseRules is optional information to specify the biome's multi-noise rules.
+   multi_noise_rules?: BiomeMultiNoiseRules
+   # LegacyRules is a list of legacy rules for the biomes using an older format, which is just a list of
+   # weighted biomes.
+   legacy_rules?: BiomeConditionalTransformation[]varint
+   # ReplacementsData is a list of biome replacement data.
+   replacements_data?: BiomeReplacementData[]varint
+   has_village_type: bool
+   village_type: has_village_type ?
+      if true: u8
+   # SurfaceBuilderData is optional information for surface building.
+   surface_builder_data?: BiomeSurfaceBuilderData
+   # SubsurfaceBuilderData is optional information for subsurface building.
+   subsurface_builder_data?: BiomeSurfaceBuilderData
+
+# BiomeSurfaceBuilderData specifies the surface building configuration for a biome.
+BiomeSurfaceBuilderData:
    # SurfaceMaterials is a set of materials to use for the surface layers of the biome.
    surface_materials?: BiomeSurfaceMaterial
    # HasDefaultOverworldSurface is true if the biome has a default overworld surface.
@@ -2860,18 +2879,21 @@ BiomeChunkGeneration:
    mesa_surface?: BiomeMesaSurface
    # CappedSurface is optional information to specify the biome's capped surface, i.e. in the Nether.
    capped_surface?: BiomeCappedSurface
-   # OverworldRules is optional information to specify the biome's overworld rules, such as rivers and hills.
-   overworld_rules?: BiomeOverworldRules
-   # MultiNoiseRules is optional information to specify the biome's multi-noise rules.
-   multi_noise_rules?: BiomeMultiNoiseRules
-   # LegacyRules is a list of legacy rules for the biomes using an older format, which is just a list of
-   # weighted biomes.
-   legacy_rules?: BiomeConditionalTransformation[]varint
-   # ReplacementsData is a list of biome replacement data.
-   replacements_data?: BiomeReplacementData[]varint
-   has_village_type: bool
-   village_type: has_village_type ?
-      if true: u8
+   # NoiseGradientSurface is optional information for noise gradient surface generation.
+   noise_gradient_surface?: BiomeNoiseGradientSurfaceData
+
+# BiomeNoiseGradientSurfaceData specifies noise gradient surface data for a biome.
+BiomeNoiseGradientSurfaceData:
+   # NonReplaceableBlocks is a list of block runtime IDs that cannot be replaced by the gradient.
+   non_replaceable_blocks: lu32[]varint
+   # GradientBlocks is a list of block runtime IDs to use for the gradient.
+   gradient_blocks: lu32[]varint
+   # NoiseSeedString is the seed string used for noise generation.
+   noise_seed_string: string
+   # FirstOctave is the first octave of the noise.
+   first_octave: li32
+   # Amplitudes is a list of amplitudes for each octave of the noise.
+   amplitudes: lf32[]varint
 
 # BiomeClimate represents the climate of a biome, mainly for ambience but also defines certain behaviours.
 BiomeClimate:


### PR DESCRIPTION
Update BiomeChunkGeneration to match the official protocol documentation for protocol version 970+. Surface-related fields (surface_materials, has_default_overworld_surface, has_swamp_surface, has_frozen_ocean_surface, has_end_surface, mesa_surface, capped_surface) have been moved into a new BiomeSurfaceBuilderData container type, and two new optional fields (surface_builder_data, subsurface_builder_data) have been added.

Also adds the new BiomeNoiseGradientSurfaceData type referenced by BiomeSurfaceBuilderData.

This fixes parsing of biome_definition_list (0x7a) packets which caused 
['Server packet parse error' in bedrock-protocol relay mode.](https://github.com/PrismarineJS/bedrock-protocol/issues/655)