### PR TITLE
Add feature flag for lpVec3 entity velocity

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -907,6 +907,11 @@
     "versions": ["1.21.9", "latest"]
   },
   {
+    "name": "entityVelocityIsLpVec3",
+    "description": "entity velocity packets use length-prefixed vectors in blocks per tick",
+    "versions": ["1.21.9", "latest"]
+  },
+  {
     "name": "gameRuleUsesResourceLocation",
     "description": "gamerule names use resource location syntax",
     "versions": ["1.21.11", "latest"]


### PR DESCRIPTION
## Summary

Adds `entityVelocityIsLpVec3` for Java Edition 1.21.9 and newer. These versions changed entity velocity packet fields from fixed-point `vec3i16` values to `lpVec3` values expressed in blocks per tick.

Mineflayer needs this boundary to avoid applying the legacy 1/8000 conversion to already-decoded `lpVec3` values.

## Validation

- `npm test` in `tools/js`