### PR TITLE
Add anvilNameLengthIsFifty feature flag (1.17+)

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -348,6 +348,11 @@
     "versions": ["1.8", "1.12.2"]
   },
   {
+    "name": "anvilNameLengthIsFifty",
+    "description": "the maximum custom name length in an anvil is 50 characters instead of 35",
+    "versions": ["1.17", "latest"]
+  },
+  {
     "name": "selectingTradeMovesItems",
     "description": "selecting a trade automatically puts the required items into trading slots",
     "versions": [


### PR DESCRIPTION
Anvil name [limit](https://feedback.minecraft.net/hc/en-us/articles/4402626897165-Minecraft-Caves-Cliffs-Part-1-1-17-Java#:~:text=The%20maximum%20length%20of%20item%20names%20in%20the%20Anvil%20UI%20has%20been%20increased%20from%2035%20to%2050) was increased to 50 from 35