### PR TITLE
Fix player_list + add new DisconnectFailReasons for v1.26.40

### DIFF
--- a/data/bedrock/1.26.40/protocol.json
+++ b/data/bedrock/1.26.40/protocol.json
@@ -2165,7 +2165,7 @@
         },
         {
           "name": "skin_color",
-          "type": "i32"
+          "type": "li32"
         },
         {
           "name": "personal_pieces",

--- a/data/bedrock/1.26.40/protocol.json
+++ b/data/bedrock/1.26.40/protocol.json
@@ -2165,7 +2165,7 @@
         },
         {
           "name": "skin_color",
-          "type": "li32"
+          "type": "i32"
         },
         {
           "name": "personal_pieces",
@@ -2312,6 +2312,30 @@
                         {
                           "name": "platform_chat_id",
                           "type": "string"
+                        },
+                        {
+                          "name": "build_platform",
+                          "type": "DeviceOS"
+                        },
+                        {
+                          "name": "skin_data",
+                          "type": "Skin"
+                        },
+                        {
+                          "name": "is_teacher",
+                          "type": "bool"
+                        },
+                        {
+                          "name": "is_host",
+                          "type": "bool"
+                        },
+                        {
+                          "name": "is_subclient",
+                          "type": "bool"
+                        },
+                        {
+                          "name": "player_color",
+                          "type": "li32"
                         }
                       ]
                     ],
@@ -5291,7 +5315,15 @@
           "133": "nonce_missing",
           "134": "nonce_not_found",
           "135": "nonce_expired",
-          "136": "nonce_not_valid"
+          "136": "nonce_not_valid",
+          "140": "host_disconnected",
+          "141": "editor_join_intent_policy_failure",
+          "142": "nethernet_identity_not_allowed",
+          "143": "invalid_name",
+          "144": "expired_token",
+          "145": "host_accepts_no_type_of_auth",
+          "146": "not_authenticated_fast_fail",
+          "147": "editor_not_allowed"
         }
       }
     ],

--- a/data/bedrock/1.26.40/protocol.json
+++ b/data/bedrock/1.26.40/protocol.json
@@ -2315,7 +2315,7 @@
                         },
                         {
                           "name": "build_platform",
-                          "type": "DeviceOS"
+                          "type": "li32"
                         },
                         {
                           "name": "skin_data",


### PR DESCRIPTION
Last PR for v1.26.40 removed player_list data that still exists on this version, plus I updated the DisconnectFailReasons.

Tests will fail because the bot doesn't have a DeviceOS field and this bug only exists on 1.26.40.8 of BDS, as they blindly accepted the DeviceOS field at the time without any validation until version 1.26.43.1 of BDS.