### PR TITLE
Fix 26.2 login success/sessionId and play login onlineMode fields

### DIFF
--- a/data/pc/26.2/protocol.json
+++ b/data/pc/26.2/protocol.json
@@ -5217,6 +5217,10 @@
                   ]
                 }
               ]
+            },
+            {
+              "name": "sessionId",
+              "type": "UUID"
             }
           ]
         ],
@@ -7335,6 +7339,10 @@
             {
               "name": "worldState",
               "type": "SpawnInfo"
+            },
+            {
+              "name": "onlineMode",
+              "type": "bool"
             },
             {
               "name": "enforcesSecureChat",


### PR DESCRIPTION
## Summary

Fixes incomplete 26.2 protocol definitions that cause partial packet reads on every join.

Verified against decompiled Spigot/NMS **26.2**:

1. **`login.toClient.success` / `ClientboundLoginFinishedPacket`**
   - Adds `sessionId: UUID` after the GameProfile fields.
   - Without this, protodef leaves **16 bytes** unread (`Chunk size is N but only N-16 was read`).

2. **`play.toClient.login` / `ClientboundLoginPacket`**
   - Adds `onlineMode: bool` immediately before `enforcesSecureChat`.
   - Wire order is `(…, worldState, onlineMode, enforcesSecureChat)`.
   - Without this, `onlineMode` is consumed as `enforcesSecureChat` and **1 byte** is left unread, so clients mis-read whether secure chat is enforced.

## Test plan

- [x] Live join to Spigot 26.2 (protocol 776) with Mineflayer
- [x] Confirm `partial packet` / `Chunk size is … but only … was read` warnings for `success` and `login` go to **zero**
- [x] Confirm parsed `login.onlineMode === true` and `login.enforcesSecureChat` matches server `enforce-secure-profile`

## Notes

Base is `pc_26_2` as requested by the automated 26.2 data PR workflow.