### PR TITLE
Bedrock 1.26.40 protocol: Handle malformed PlayerRecord packets

### DIFF
--- a/data/bedrock/1.26.40/protocol.json
+++ b/data/bedrock/1.26.40/protocol.json
@@ -51,6 +51,8 @@
     "bitflags": "native",
     "restBuffer": "native",
     "encapsulated": "native",
+    "maybeIncompleteArray": "native",
+    "optionalOnRemaining": "native",
     "nbt": "native",
     "lnbt": "native",
     "nbtLoop": "native",
@@ -2259,77 +2261,78 @@
         }
       ]
     ],
-    "PlayerRecords": [
-      "array",
-      {
-        "countType": "varint",
-        "type": [
-          "container",
-          [
+    "PlayerRecord": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": [
+            "mapper",
             {
-              "name": "type",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "remove",
-                    "1": "add"
-                  }
-                }
-              ]
-            },
-            {
-              "name": "legacy_type",
-              "type": "u8"
-            },
-            {
-              "anon": true,
-              "type": [
-                "switch",
-                {
-                  "compareTo": "type",
-                  "fields": {
-                    "add": [
-                      "container",
-                      [
-                        {
-                          "name": "uuid",
-                          "type": "uuid"
-                        },
-                        {
-                          "name": "entity_unique_id",
-                          "type": "zigzag64"
-                        },
-                        {
-                          "name": "username",
-                          "type": "string"
-                        },
-                        {
-                          "name": "xbox_user_id",
-                          "type": "string"
-                        },
-                        {
-                          "name": "platform_chat_id",
-                          "type": "string"
-                        }
-                      ]
-                    ],
-                    "remove": [
-                      "container",
-                      [
-                        {
-                          "name": "uuid",
-                          "type": "uuid"
-                        }
-                      ]
-                    ]
-                  }
-                }
-              ]
+              "type": "varint",
+              "mappings": {
+                "0": "remove",
+                "1": "add"
+              }
             }
           ]
-        ]
+        },
+        {
+          "name": "legacy_type",
+          "type": "u8"
+        },
+        {
+          "anon": true,
+          "type": [
+            "switch",
+            {
+              "compareTo": "type",
+              "fields": {
+                "add": [
+                  "container",
+                  [
+                    {
+                      "name": "uuid",
+                      "type": "uuid"
+                    },
+                    {
+                      "name": "entity_unique_id",
+                      "type": "zigzag64"
+                    },
+                    {
+                      "name": "username",
+                      "type": "string"
+                    },
+                    {
+                      "name": "xbox_user_id",
+                      "type": "string"
+                    },
+                    {
+                      "name": "platform_chat_id",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "remove": [
+                  "container",
+                  [
+                    {
+                      "name": "uuid",
+                      "type": "uuid"
+                    }
+                  ]
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    ],
+    "PlayerRecords": [
+      "maybeIncompleteArray",
+      {
+        "countType": "varint",
+        "type": "PlayerRecord"
       }
     ],
     "Enchant": [
@@ -5277,21 +5280,32 @@
           "119": "realms_timeline_required",
           "120": "guest_withough_host",
           "121": "failed_to_join_experience",
-          "122": "host_signed_out",
-          "123": "script_watchdog_exception",
-          "124": "script_memory_limit_exceeded",
-          "125": "storage_low_during_gameplay",
-          "126": "storage_full_during_gameplay",
-          "127": "level_storage_corruption",
-          "128": "edition_mismatch_vanilla_to_edu",
-          "129": "edition_mismatch_edu_to_vanilla",
-          "130": "editor_mismatch_editor_to_vanilla",
-          "131": "editor_mismatch_vanilla_to_editor",
-          "132": "deny_listed",
-          "133": "nonce_missing",
-          "134": "nonce_not_found",
-          "135": "nonce_expired",
-          "136": "nonce_not_valid"
+          "122": "nethernet_data_channel_closed",
+          "123": "discovery_environment_mismatch",
+          "124": "host_without_keys",
+          "125": "host_signed_out",
+          "126": "script_watchdog_exception",
+          "127": "script_memory_limit_exceeded",
+          "128": "storage_low_during_gameplay",
+          "129": "storage_full_during_gameplay",
+          "130": "level_storage_corruption",
+          "131": "edition_mismatch_vanilla_to_edu",
+          "132": "edition_mismatch_edu_to_vanilla",
+          "133": "editor_mismatch_editor_to_vanilla",
+          "134": "editor_mismatch_vanilla_to_editor",
+          "135": "deny_listed",
+          "136": "nonce_missing",
+          "137": "nonce_not_found",
+          "138": "nonce_expired",
+          "139": "nonce_not_valid",
+          "140": "host_disconnected",
+          "141": "editor_join_intent_policy_failure",
+          "142": "nethernet_identity_not_allowed",
+          "143": "invalid_name",
+          "144": "expired_token",
+          "145": "host_accepts_no_type_of_auth",
+          "146": "not_authenticated_fast_fail",
+          "147": "editor_not_allowed"
         }
       }
     ],
@@ -8552,7 +8566,12 @@
         },
         {
           "name": "device_os",
-          "type": "DeviceOS"
+          "type": [
+            "optionalOnRemaining",
+            {
+              "type": "DeviceOS"
+            }
+          ]
         }
       ]
     ],

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -19,6 +19,8 @@ byterot: native
 bitflags: native
 restBuffer: native
 encapsulated: native
+maybeIncompleteArray: native
+optionalOnRemaining: native
 nbt: native                                           # NBT
 lnbt: native
 nbtLoop: native
@@ -534,7 +536,7 @@ packet_add_player:
    device_id: string
    # BuildPlatform is the build platform/device OS of the player that is about to be added, as it sent in
    # the Login packet when joining.
-   device_os: DeviceOS
+   device_os: '["optionalOnRemaining", { "type": "DeviceOS" }]'
 
 packet_add_entity:
    !id: 0x0d

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -931,7 +931,7 @@ Skin:
 # As of 1.26.40 the packet-wide action is gone: every record carries its own action, written first as an
 # unsigned varint (1 = add, 0 = remove) and then again as the legacy action ordinal byte (0 = add,
 # 1 = remove). The trailing array of skin-verified booleans was removed as well.
-PlayerRecords: []varint
+PlayerRecord:
    type: varint =>
       0: remove
       1: add
@@ -945,6 +945,10 @@ PlayerRecords: []varint
          platform_chat_id: string
       if remove:
          uuid: uuid
+
+# BDS 1.26.40 may declare more records than it actually writes. Player List is a packet-bounded payload, so
+# treat the declared count as an upper bound and stop decoding once the packet buffer is exhausted.
+PlayerRecords: '["maybeIncompleteArray", { "countType": "varint", "type": "PlayerRecord" }]'
 
 Enchant:
    id: u8
@@ -2807,6 +2811,9 @@ DisconnectFailReason: zigzag32 =>
    - realms_timeline_required
    - guest_withough_host
    - failed_to_join_experience
+   - nethernet_data_channel_closed
+   - discovery_environment_mismatch
+   - host_without_keys
    - host_signed_out
    - script_watchdog_exception
    - script_memory_limit_exceeded
@@ -2822,6 +2829,14 @@ DisconnectFailReason: zigzag32 =>
    - nonce_not_found
    - nonce_expired
    - nonce_not_valid
+   - host_disconnected
+   - editor_join_intent_policy_failure
+   - nethernet_identity_not_allowed
+   - invalid_name
+   - expired_token
+   - host_accepts_no_type_of_auth
+   - not_authenticated_fast_fail
+   - editor_not_allowed
 
 FullContainerName:
    container_id: ContainerSlotType


### PR DESCRIPTION
## Summary

- decode Bedrock 1.26.40 `PlayerList` records with `maybeIncompleteArray`, treating the declared count as an upper bound when the packet ends early
- decode the terminal `AddPlayer.device_os` only when bytes remain
- add the missing disconnect reasons at IDs 122-124 and the 1.26.40 reasons at IDs 140-147
- regenerate `data/bedrock/1.26.40/protocol.json` from the YAML source

## Root cause

BDS 1.26.40.8 emits malformed server-to-client packets for offline players:

- a `PlayerList` packet can declare two records while containing only one
- `AddPlayer` can end after `device_id`, omitting the terminal `device_os`

Ordinary ProtoDef arrays require exactly the declared number of elements, so the player-list packet previously failed with `Unexpected buffer end while reading VarInt`. The new opt-in datatypes from PrismarineJS/bedrock-protocol#766 allow this schema to accept packet EOF without weakening normal arrays or fields globally.

## Impact

Bedrock-protocol clients can accept the malformed BDS packets while normal serialization continues to write accurate array counts and present fields. This applies to protocol 2168, shared by BDS 1.26.40 and 1.26.43.

Related: PrismarineJS/bedrock-protocol#764.

## Validation

- `npm run lint`
- `npx mocha --exit --reporter spec test/protocolSync.js`
- regenerated JSON is in sync with the YAML source
- local BDS 1.26.40.8 two-client reproduction: both clients spawned with zero packet decode errors