### PR TITLE
harden: sanitize child_process call in extractPcEntityMetadata.js...

### DIFF
--- a/tools/js/extractPcEntityMetadata.js
+++ b/tools/js/extractPcEntityMetadata.js
@@ -93,7 +93,7 @@ function extractPcEntityMetadata (version, mcdataVersion = version, opts = {}) {
     if (!cloneIfMissing) {
       throw new Error(`Version directory "${sourceDir}" does not exist`)
     }
-    cp.execSync(`git clone -b client${version} https://github.com/extremeheat/extracted_minecraft_data.git ${sourceDir} --depth 1`, { stdio: 'inherit' })
+    cp.execFileSync('git', ['clone', '-b', `client${version}`, 'https://github.com/extremeheat/extracted_minecraft_data.git', sourceDir, '--depth', '1'], { stdio: 'inherit' })
   }
 
   const serializers = getEntityMetadataSerializers(sourceDir)


### PR DESCRIPTION
## Summary
Harden input handling in `tools/js/extractPcEntityMetadata.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `tools/js/extractPcEntityMetadata.js:96` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `version`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Changes
- `tools/js/extractPcEntityMetadata.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
