### PR TITLE
Add sendsPlayerLoadedPacket feature flag for 1.21.4+

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -927,6 +927,11 @@
     "versions": ["1.21.2", "latest"]
   },
   {
+    "name": "sendsPlayerLoadedPacket",
+    "description": "client sends a player_loaded packet after loading terrain or respawning",
+    "versions": ["1.21.4", "latest"]
+  },
+  {
     "name": "attackUsesOwnPacket",
     "description": "attack uses its own packet instead of interact",
     "versions": ["26.1", "latest"]


### PR DESCRIPTION
## Summary

Adds the PC feature flag `sendsPlayerLoadedPacket` for Minecraft 1.21.4 and later.

```json
{
  "name": "sendsPlayerLoadedPacket",
  "description": "client sends a player_loaded packet after loading terrain or respawning",
  "versions": ["1.21.4", "latest"]
}
```

## Provenance

Mojang's [Java Edition 1.21.4 release notes](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-4) document that the client sends `minecraft:player_loaded` after the initial loading-terrain screen closes and again after the respawn loading screen closes. The packet was first announced with the same lifecycle in [snapshot 24w45a](https://www.minecraft.net/en-us/article/minecraft-snapshot-24w45a).

The existing protocol data has the same version boundary: [`player_loaded` is declared in the 1.21.4 serverbound protocol](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/1.21.4/proto.yml#L3005-L3007) and is absent from 1.21.3.

## Motivation

This is the corresponding data change for [PrismarineJS/mineflayer#3960](https://github.com/PrismarineJS/mineflayer/pull/3960), allowing Mineflayer to send `player_loaded` at those lifecycle points through `supportFeature` instead of a hard-coded version comparison.

This follows the feature naming and paired minecraft-data/Mineflayer workflow used by #1208.

## Verification

- `npm run lint`
- `npx mocha --exit --reporter spec --grep "features.json"` (4 passing)
- Verified the feature range and protocol boundary: 1.21.3 absent, 1.21.4 present

