### PR TITLE
pc 1.21.5-1.21.8: fix entity metadata chicken_variant to varint (backport from 1.21.9)

### DIFF
--- a/data/pc/1.21.5/proto.yml
+++ b/data/pc/1.21.5/proto.yml
@@ -883,7 +883,7 @@
          if wolf_sound_variant: varint
          if frog_variant: varint
          if pig_variant: varint
-         if chicken_variant: ["registryEntryHolder", { "baseName": "variantId", "otherwise": { "name": "variantData", "type": "string" } }]
+         if chicken_variant: varint
          if optional_global_pos: ["option", "string"]
          if painting_variant: ["registryEntryHolder", {
             "baseName": "variantId",

--- a/data/pc/1.21.5/protocol.json
+++ b/data/pc/1.21.5/protocol.json
@@ -2540,16 +2540,7 @@
                 "wolf_sound_variant": "varint",
                 "frog_variant": "varint",
                 "pig_variant": "varint",
-                "chicken_variant": [
-                  "registryEntryHolder",
-                  {
-                    "baseName": "variantId",
-                    "otherwise": {
-                      "name": "variantData",
-                      "type": "string"
-                    }
-                  }
-                ],
+                "chicken_variant": "varint",
                 "optional_global_pos": [
                   "option",
                   "string"

--- a/data/pc/1.21.6/proto.yml
+++ b/data/pc/1.21.6/proto.yml
@@ -888,7 +888,7 @@
          if wolf_sound_variant: varint
          if frog_variant: varint
          if pig_variant: varint
-         if chicken_variant: ["registryEntryHolder", { "baseName": "variantId", "otherwise": { "name": "variantData", "type": "string" } }]
+         if chicken_variant: varint
          if optional_global_pos: ["option", "string"]
          if painting_variant: ["registryEntryHolder", {
             "baseName": "variantId",

--- a/data/pc/1.21.6/protocol.json
+++ b/data/pc/1.21.6/protocol.json
@@ -2583,16 +2583,7 @@
                 "wolf_sound_variant": "varint",
                 "frog_variant": "varint",
                 "pig_variant": "varint",
-                "chicken_variant": [
-                  "registryEntryHolder",
-                  {
-                    "baseName": "variantId",
-                    "otherwise": {
-                      "name": "variantData",
-                      "type": "string"
-                    }
-                  }
-                ],
+                "chicken_variant": "varint",
                 "optional_global_pos": [
                   "option",
                   "string"

--- a/data/pc/1.21.8/proto.yml
+++ b/data/pc/1.21.8/proto.yml
@@ -888,7 +888,7 @@
          if wolf_sound_variant: varint
          if frog_variant: varint
          if pig_variant: varint
-         if chicken_variant: ["registryEntryHolder", { "baseName": "variantId", "otherwise": { "name": "variantData", "type": "string" } }]
+         if chicken_variant: varint
          if optional_global_pos: ["option", "string"]
          if painting_variant: ["registryEntryHolder", {
             "baseName": "variantId",

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -2583,16 +2583,7 @@
                 "wolf_sound_variant": "varint",
                 "frog_variant": "varint",
                 "pig_variant": "varint",
-                "chicken_variant": [
-                  "registryEntryHolder",
-                  {
-                    "baseName": "variantId",
-                    "otherwise": {
-                      "name": "variantData",
-                      "type": "string"
-                    }
-                  }
-                ],
+                "chicken_variant": "varint",
                 "optional_global_pos": [
                   "option",
                   "string"


### PR DESCRIPTION
## Problem

In `data/pc/1.21.5`, `1.21.6`, and `1.21.8` (`protocol.json` + `proto.yml`), the entity-metadata entry `chicken_variant` (metadataType 28) is declared as:

```json
["registryEntryHolder", {"baseName": "variantId", "otherwise": {"name": "variantData", "type": "string"}}]
```

But the actual wire format is a **plain varint registry id**. Vanilla syncs `Holder<ChickenVariant>` with `ByteBufCodecs.holderRegistry`, which is registry-id-only — no inline-data branch and no +1 offset. The [minecraft.wiki entity metadata reference](https://minecraft.wiki/w/Java_Edition_protocol/Entity_metadata) agrees: "Chicken Variant: VarInt — an ID in the `minecraft:chicken_variant` registry". This matches `cow_variant`, `pig_variant`, `frog_variant`, and `wolf_sound_variant`, which these same files already declare as `varint`.

The newer data files already have it right: `data/pc/1.21.9/protocol.json`, `1.21.11`, and `data/pc/latest/proto.yml` all say `chicken_variant: varint`. The 1.21.5–1.21.8 files were never regenerated, so this PR is a backport of that definition.

## Symptom

The default chicken variant (`temperate`) has registry id 0. `registryEntryHolder` treats varint 0 as "inline data follows" and then reads a string whose "length" byte is actually the `0xff` metadata terminator, so parsing over-reads the packet:

```
PartialReadError: Unexpected buffer end while reading VarInt
```

on virtually every chicken `entity_metadata` packet. Real-world example (13 bytes, 1.21.6):

```
5c f7 02 09 03 40 80 00 00 11 1c 00 ff
```

= `entity_metadata { entityId 375, [key 9 float 4.0 (health), key 17 type 28 chicken_variant value 0] }` + `0xff` terminator. This parses correctly with `varint` and over-reads with `registryEntryHolder`. Non-zero variant ids would silently "parse" but be misinterpreted (id off by one, or bogus inline data).

Reported by mineflayer users on 1.21.5–1.21.8 servers: 

Fix PrismarineJS/mineflayer#3756, 
Fix PrismarineJS/mineflayer#3760, 
Fix PrismarineJS/mineflayer#3785.

Related but distinct: #1195 fixed the analogous EitherHolder off-by-one for the `chicken/variant` **item component**, but left this entity-metadata entry untouched.

## Change

For each of 1.21.5, 1.21.6, 1.21.8, in both `protocol.json` and `proto.yml`:

```
"chicken_variant": ["registryEntryHolder", {...}]  →  "chicken_variant": "varint"
```

Verified with `tools/js/compileProtocol.js` `validate()` that each edited `protocol.json` still compiles byte-identically from its edited `proto.yml`. Bedrock data and item components are untouched.

Made with [Cursor](https://cursor.com)