### PR TITLE
Restore PlayerList add fields for 1.26.40

### DIFF
--- a/data/bedrock/1.26.40/protocol.json
+++ b/data/bedrock/1.26.40/protocol.json
@@ -2310,6 +2310,30 @@
                     {
                       "name": "platform_chat_id",
                       "type": "string"
+                    },
+                    {
+                      "name": "build_platform",
+                      "type": "li32"
+                    },
+                    {
+                      "name": "skin_data",
+                      "type": "Skin"
+                    },
+                    {
+                      "name": "is_teacher",
+                      "type": "bool"
+                    },
+                    {
+                      "name": "is_host",
+                      "type": "bool"
+                    },
+                    {
+                      "name": "is_subclient",
+                      "type": "bool"
+                    },
+                    {
+                      "name": "player_color",
+                      "type": "li32"
                     }
                   ]
                 ],

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -931,6 +931,7 @@ Skin:
 # As of 1.26.40 the packet-wide action is gone: every record carries its own action, written first as an
 # unsigned varint (1 = add, 0 = remove) and then again as the legacy action ordinal byte (0 = add,
 # 1 = remove). The trailing array of skin-verified booleans was removed as well.
+# Add records still include build platform, skin, and the host flags. The client reads these fields.
 PlayerRecord:
    type: varint =>
       0: remove
@@ -943,6 +944,12 @@ PlayerRecord:
          username: string
          xbox_user_id: string
          platform_chat_id: string
+         build_platform: li32
+         skin_data: Skin
+         is_teacher: bool
+         is_host: bool
+         is_subclient: bool
+         player_color: li32
       if remove:
          uuid: uuid
 


### PR DESCRIPTION
## Summary
- Restore Build Platform, skin, and host flags on 1.26.40 PlayerList add records.

The client still reads these fields. A short record causes a decode error.

## Test plan
- [ ] Proxy a 1.26.40 client through bedrock-protocol.
- [ ] Confirm PlayerList does not fail on Build Platform.