### PR TITLE
bedrock protocol: Fix 1.26.40/1.26.44 player records packet

### DIFF
--- a/data/bedrock/1.26.40/protocol.json
+++ b/data/bedrock/1.26.40/protocol.json
@@ -2167,7 +2167,7 @@
         },
         {
           "name": "skin_color",
-          "type": "li32"
+          "type": "i32"
         },
         {
           "name": "personal_pieces",
@@ -2222,7 +2222,7 @@
                       "array",
                       {
                         "count": 4,
-                        "type": "li32"
+                        "type": "i32"
                       }
                     ]
                   }
@@ -2310,6 +2310,30 @@
                     {
                       "name": "platform_chat_id",
                       "type": "string"
+                    },
+                    {
+                      "name": "build_platform",
+                      "type": "li32"
+                    },
+                    {
+                      "name": "skin_data",
+                      "type": "Skin"
+                    },
+                    {
+                      "name": "is_teacher",
+                      "type": "bool"
+                    },
+                    {
+                      "name": "is_host",
+                      "type": "bool"
+                    },
+                    {
+                      "name": "is_subclient",
+                      "type": "bool"
+                    },
+                    {
+                      "name": "player_color",
+                      "type": "i32"
                     }
                   ]
                 ],

--- a/data/bedrock/latest/types.yml
+++ b/data/bedrock/latest/types.yml
@@ -905,7 +905,7 @@ Skin:
    arm_size: u8 =>
       0: slim
       1: wide
-   skin_color: li32
+   skin_color: i32
    personal_pieces: []varint
       piece_id: string
       piece_type: PersonaPieceType
@@ -915,7 +915,7 @@ Skin:
    piece_tint_colors: []varint
       # The piece type is still sent by name here, unlike in the persona pieces above.
       piece_type: string
-      colors: '["array", { "count": 4, "type": "li32" }]'
+      colors: '["array", { "count": 4, "type": "i32" }]'
    premium: bool
    persona: bool
    # PersonaCapeOnClassicSkin specifies if the skin had a Persona cape (in-game skin creator cape) equipped
@@ -943,11 +943,19 @@ PlayerRecord:
          username: string
          xbox_user_id: string
          platform_chat_id: string
+         build_platform: li32
+         skin_data: Skin
+         is_teacher: bool
+         is_host: bool
+         is_subclient: bool
+         # PlayerColour is the colour of the player that is shown in UI elements, currently only used for the
+         # player locator bar. Since 1.26.40 this is encoded as big-endian ARGB.
+         player_color: i32
       if remove:
          uuid: uuid
 
-# BDS 1.26.40 may declare more records than it actually writes. Player List is a packet-bounded payload, so
-# treat the declared count as an upper bound and stop decoding once the packet buffer is exhausted.
+# BDS 1.26.40 may truncate the final record. Player List is a packet-bounded payload, so treat the declared
+# count as an upper bound and stop decoding when the packet ends, including midway through the final record.
 PlayerRecords: '["maybeIncompleteArray", { "countType": "varint", "type": "PlayerRecord" }]'
 
 Enchant:


### PR DESCRIPTION
## What changed

- restore the complete per-entry Player List add fields removed during the 1.26.40 update
- encode SkinColour, persona tint colours, and PlayerColour as big-endian ARGB
- retain `maybeIncompleteArray` for BDS packets that truncate their final record

## Why

The incomplete schema decoded only the first 41 bytes of a normal Player List add record. Consumers that re-encode packets, including bedrock-protocol Relay, consequently discarded the skin and all trailing player data. Vanilla 1.26.44 then disconnected during world generation.

BDS 1.26.40.8 also sometimes ends the final Player List record early. The coordinated bedrock-protocol change makes `maybeIncompleteArray` treat that final PartialReadError as packet EOF.

## Validation

- generated `data/bedrock/1.26.40/protocol.json` from the YAML source
- verified a BDS 1.26.43.1 Player List packet decodes and re-encodes byte-for-byte
- connected a vanilla 1.26.44 client through Relay to BDS 1.26.43.1 and reached the world

Depends on PrismarineJS/bedrock-protocol#772.