### PR TITLE
pc: fix custom_click_action NBT to use a VarInt length prefix

### DIFF
--- a/data/pc/1.21.11/proto.yml
+++ b/data/pc/1.21.11/proto.yml
@@ -1638,7 +1638,7 @@
    # MC: ServerboundCustomClickActionPacket
    packet_common_custom_click_action:
       id: string
-      nbt?: anonymousNbt
+      nbt: ["buffer", { "countType": "varint" }]
 
 ^handshaking.toClient.types:
    packet:

--- a/data/pc/1.21.11/protocol.json
+++ b/data/pc/1.21.11/protocol.json
@@ -4937,8 +4937,10 @@
         {
           "name": "nbt",
           "type": [
-            "option",
-            "anonymousNbt"
+            "buffer",
+            {
+              "countType": "varint"
+            }
           ]
         }
       ]

--- a/data/pc/1.21.6/proto.yml
+++ b/data/pc/1.21.6/proto.yml
@@ -1330,7 +1330,7 @@
    # MC: ServerboundCustomClickActionPacket
    packet_common_custom_click_action:
       id: string
-      nbt?: anonymousNbt
+      nbt: ["buffer", { "countType": "varint" }]
 
 ^handshaking.toClient.types:
    packet:

--- a/data/pc/1.21.6/protocol.json
+++ b/data/pc/1.21.6/protocol.json
@@ -3611,8 +3611,10 @@
         {
           "name": "nbt",
           "type": [
-            "option",
-            "anonymousNbt"
+            "buffer",
+            {
+              "countType": "varint"
+            }
           ]
         }
       ]

--- a/data/pc/1.21.8/proto.yml
+++ b/data/pc/1.21.8/proto.yml
@@ -1330,7 +1330,7 @@
    # MC: ServerboundCustomClickActionPacket
    packet_common_custom_click_action:
       id: string
-      nbt?: anonymousNbt
+      nbt: ["buffer", { "countType": "varint" }]
 
 ^handshaking.toClient.types:
    packet:

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -3608,8 +3608,10 @@
         {
           "name": "nbt",
           "type": [
-            "option",
-            "anonymousNbt"
+            "buffer",
+            {
+              "countType": "varint"
+            }
           ]
         }
       ]

--- a/data/pc/1.21.9/proto.yml
+++ b/data/pc/1.21.9/proto.yml
@@ -1560,7 +1560,7 @@
    # MC: ServerboundCustomClickActionPacket
    packet_common_custom_click_action:
       id: string
-      nbt?: anonymousNbt
+      nbt: ["buffer", { "countType": "varint" }]
 
 ^handshaking.toClient.types:
    packet:

--- a/data/pc/1.21.9/protocol.json
+++ b/data/pc/1.21.9/protocol.json
@@ -4639,8 +4639,10 @@
         {
           "name": "nbt",
           "type": [
-            "option",
-            "anonymousNbt"
+            "buffer",
+            {
+              "countType": "varint"
+            }
           ]
         }
       ]

--- a/data/pc/26.1/protocol.json
+++ b/data/pc/26.1/protocol.json
@@ -4997,8 +4997,10 @@
         {
           "name": "nbt",
           "type": [
-            "option",
-            "anonymousNbt"
+            "buffer",
+            {
+              "countType": "varint"
+            }
           ]
         }
       ]

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -1680,7 +1680,7 @@
    # MC: ServerboundCustomClickActionPacket
    packet_common_custom_click_action:
       id: string
-      nbt?: anonymousNbt
+      nbt: ["buffer", { "countType": "varint" }]
 
 ^handshaking.toClient.types:
    packet:


### PR DESCRIPTION
Fixes #1222

## Problem
`packet_common_custom_click_action` declared its NBT field as:

```yml
packet_common_custom_click_action:
    id: string
    nbt?: anonymousNbt
```

which encodes it as an *optional* value with a boolean prefix. The actual wire format used by the vanilla client (and expected by BungeeCord) is:

```
resource location + VarInt payload length + unnamed NBT payload
```

BungeeCord reads it via `readLengthPrefixed(...)` (`CustomClickAction.java`), i.e. a VarInt length followed by the NBT bytes — there is no optional sentinel. With the old schema the client wrote `01 0A 0B ...` (BungeeCord read `01` as the payload length and the NBT decoder failed with `Exception reading tag`), and writing the NBT without any prefix (`0A 0B ...`) is also invalid.

## Fix
Changed the field to a VarInt-length-prefixed buffer in every affected version — the exact representation verified in the issue to produce byte-identical output to the vanilla client:

```yml
packet_common_custom_click_action:
    id: string
    nbt: ["buffer", { "countType": "varint" }]
```

Applied to `data/pc/1.21.6`, `1.21.8`, `1.21.9`, `1.21.11` and `latest` (all of which carried the same incorrect definition), and regenerated the corresponding `protocol.json` files (`1.21.6`, `1.21.8`, `1.21.9`, `1.21.11`, `26.1`) with `npm run build`.

## Verified
- Cross-checked against BungeeCord's `CustomClickAction` (`readLengthPrefixed`/`writeLengthPrefixed` → VarInt length + NBT, always present).
- `protocolSync` test passes: all proto.yml files are valid and in sync with their protocol.json.
- The regenerated `protocol.json` diffs contain only the `nbt` field change.