### PR TITLE
bedrock: fix voxel_shapes deserialization - VoxelShape.cells is a single VoxelCells, not an array

### DIFF
--- a/data/bedrock/1.26.0/protocol.json
+++ b/data/bedrock/1.26.0/protocol.json
@@ -5042,13 +5042,7 @@
       [
         {
           "name": "cells",
-          "type": [
-            "array",
-            {
-              "countType": "varint",
-              "type": "VoxelCells"
-            }
-          ]
+          "type": "VoxelCells"
         },
         {
           "name": "x_coordinates",

--- a/data/bedrock/1.26.0/types.yml
+++ b/data/bedrock/1.26.0/types.yml
@@ -2541,7 +2541,7 @@ VoxelCells:
    storage: u8[]varint
 
 VoxelShape:
-   cells: VoxelCells[]varint
+   cells: VoxelCells
    x_coordinates: lf32[]varint
    y_coordinates: lf32[]varint
    z_coordinates: lf32[]varint

--- a/data/bedrock/1.26.10/protocol.json
+++ b/data/bedrock/1.26.10/protocol.json
@@ -5125,13 +5125,7 @@
       [
         {
           "name": "cells",
-          "type": [
-            "array",
-            {
-              "countType": "varint",
-              "type": "VoxelCells"
-            }
-          ]
+          "type": "VoxelCells"
         },
         {
           "name": "x_coordinates",

--- a/data/bedrock/1.26.10/types.yml
+++ b/data/bedrock/1.26.10/types.yml
@@ -2569,7 +2569,7 @@ VoxelCells:
    storage: u8[]varint
 
 VoxelShape:
-   cells: VoxelCells[]varint
+   cells: VoxelCells
    x_coordinates: lf32[]varint
    y_coordinates: lf32[]varint
    z_coordinates: lf32[]varint

--- a/data/bedrock/1.26.20/protocol.json
+++ b/data/bedrock/1.26.20/protocol.json
@@ -5218,13 +5218,7 @@
       [
         {
           "name": "cells",
-          "type": [
-            "array",
-            {
-              "countType": "varint",
-              "type": "VoxelCells"
-            }
-          ]
+          "type": "VoxelCells"
         },
         {
           "name": "x_coordinates",

--- a/data/bedrock/1.26.20/types.yml
+++ b/data/bedrock/1.26.20/types.yml
@@ -2597,7 +2597,7 @@ VoxelCells:
    storage: u8[]varint
 
 VoxelShape:
-   cells: VoxelCells[]varint
+   cells: VoxelCells
    x_coordinates: lf32[]varint
    y_coordinates: lf32[]varint
    z_coordinates: lf32[]varint

--- a/data/bedrock/1.26.30/protocol.json
+++ b/data/bedrock/1.26.30/protocol.json
@@ -5370,13 +5370,7 @@
       [
         {
           "name": "cells",
-          "type": [
-            "array",
-            {
-              "countType": "varint",
-              "type": "VoxelCells"
-            }
-          ]
+          "type": "VoxelCells"
         },
         {
           "name": "x_coordinates",

--- a/data/bedrock/1.26.30/types.yml
+++ b/data/bedrock/1.26.30/types.yml
@@ -2647,7 +2647,7 @@ VoxelCells:
    storage: u8[]varint
 
 VoxelShape:
-   cells: VoxelCells[]varint
+   cells: VoxelCells
    x_coordinates: lf32[]varint
    y_coordinates: lf32[]varint
    z_coordinates: lf32[]varint


### PR DESCRIPTION
## Summary

Fixes a deserialization failure for the bedrock `voxel_shapes` packet (0x151 / 337) on versions 1.26.0 through 1.26.30.

Fixes PrismarineJS/bedrock-protocol#753

## The bug

On bedrock 1.26.30.5, connecting to a server crashes with:

```
Deserialization failure for packet 0xd1 ...
PartialReadError: Read error for undefined : undefined
    at Object.VoxelShape (...)
    at Object.packet_voxel_shapes (...)
```

The `VoxelShape` type defined `cells` as an **array** of `VoxelCells`:

```yaml
VoxelShape:
   cells: VoxelCells[]varint   # <- wrong
```

but the actual packet contains a **single** `VoxelCells` record. This is confirmed by the 1.26.40 / `latest` schema, which correctly uses a single `VoxelCells`:

```yaml
VoxelShape:
   cells: VoxelCells           # <- correct (1.26.40 / latest)
```

## Verification

I decoded the two raw packet captures attached to bedrock-protocol#753 (7173 bytes each) using `protodef` against both schemas:

**Before (array):** `PartialReadError` — the exact error from the issue.

**After (single):**
```
DECODE OK: consumed 7173 of 7173 bytes
packet name: voxel_shapes
shapes: 127
name_map: 59
custom_shape_count: 0
coords in [0,1]: 1062/1062
sample names: minecraft:end_portal_frame_eye=57, minecraft:box_16x4x16=55, minecraft:wall_head_facing_south=54
round-trip identical: true
```

All 1062 voxel coordinates fall in the valid [0,1] range, the 59 name-map entries are valid block identifiers, and re-serializing the decoded value reproduces the original packet byte-for-byte.

## Changes

Changed `cells: VoxelCells[]varint` → `cells: VoxelCells` in the `VoxelShape` type of `types.yml` for the four affected versions, and regenerated each `protocol.json` with `node compileProtocol.js bedrock <version>`:

- `data/bedrock/1.26.0`
- `data/bedrock/1.26.10`
- `data/bedrock/1.26.20`
- `data/bedrock/1.26.30`

1.26.40 (generated from `bedrock/latest`) already had the correct single-`VoxelCells` definition and is unchanged. The `protocolSync` test passes for all versions.
