### PR TITLE
pc: fix warped_fungus_on_a_stick stack size to 1 (1.16.1-1.18)

### DIFF
--- a/data/pc/1.16.1/items.json
+++ b/data/pc/1.16.1/items.json
@@ -5675,7 +5675,7 @@
     "id": 842,
     "displayName": "Warped Fungus on a Stick",
     "name": "warped_fungus_on_a_stick",
-    "stackSize": 64,
+    "stackSize": 1,
     "maxDurability": 100,
     "enchantCategories": [
       "breakable",

--- a/data/pc/1.16.2/items.json
+++ b/data/pc/1.16.2/items.json
@@ -5681,7 +5681,7 @@
     "id": 843,
     "displayName": "Warped Fungus on a Stick",
     "name": "warped_fungus_on_a_stick",
-    "stackSize": 64,
+    "stackSize": 1,
     "maxDurability": 100,
     "enchantCategories": [
       "breakable",

--- a/data/pc/1.17/items.json
+++ b/data/pc/1.17/items.json
@@ -4014,7 +4014,7 @@
     "id": 668,
     "displayName": "Warped Fungus on a Stick",
     "name": "warped_fungus_on_a_stick",
-    "stackSize": 64,
+    "stackSize": 1,
     "maxDurability": 100,
     "enchantCategories": [
       "breakable",

--- a/data/pc/1.18/items.json
+++ b/data/pc/1.18/items.json
@@ -4014,7 +4014,7 @@
     "id": 668,
     "displayName": "Warped Fungus on a Stick",
     "name": "warped_fungus_on_a_stick",
-    "stackSize": 64,
+    "stackSize": 1,
     "maxDurability": 100,
     "enchantCategories": [
       "breakable",


### PR DESCRIPTION
Fixes #569

The Warped Fungus on a Stick has a max stack size of **1** in vanilla Minecraft (it has durability, maxDurability 100). The data incorrectly listed it with stackSize 64 in versions 1.16.1, 1.16.2, 1.17 and 1.18.

Verified: item entry in each version's items.json now has `"stackSize": 1`. JSON is valid; schema validation passes.