### PR TITLE
pc: remove duplicate DolphinsGrace effect and fix BadOmen id (1.14.4-1.16.1)

### DIFF
--- a/data/pc/1.14.4/effects.json
+++ b/data/pc/1.14.4/effects.json
@@ -181,12 +181,6 @@
   },
   {
     "id": 31,
-    "name": "DolphinsGrace",
-    "displayName": "Dolphin's Grace",
-    "type": "good"
-  },
-  {
-    "id": 32,
     "name": "BadOmen",
     "displayName": "Bad Omen",
     "type": "good"

--- a/data/pc/1.15.2/effects.json
+++ b/data/pc/1.15.2/effects.json
@@ -181,12 +181,6 @@
   },
   {
     "id": 31,
-    "name": "DolphinsGrace",
-    "displayName": "Dolphin's Grace",
-    "type": "good"
-  },
-  {
-    "id": 32,
     "name": "BadOmen",
     "displayName": "Bad Omen",
     "type": "good"

--- a/data/pc/1.16.1/effects.json
+++ b/data/pc/1.16.1/effects.json
@@ -181,12 +181,6 @@
   },
   {
     "id": 31,
-    "name": "DolphinsGrace",
-    "displayName": "Dolphin's Grace",
-    "type": "good"
-  },
-  {
-    "id": 32,
     "name": "BadOmen",
     "displayName": "Bad Omen",
     "type": "good"


### PR DESCRIPTION
Fixes #529

The effects.json for 1.14.4, 1.15.2 and 1.16.1 contained a duplicate `DolphinsGrace` at id 31, which pushed `BadOmen` onto id 32 where it collided with `HeroOfTheVillage`.

Correct registry (matching 1.17):
- id 30 = DolphinsGrace
- id 31 = BadOmen
- id 32 = HeroOfTheVillage

Verified: after the fix all three versions have 32 entries, no duplicate names, no duplicate ids, and the tail registry is `30=DolphinsGrace, 31=BadOmen, 32=HeroOfTheVillage` exactly as in 1.17.