### PR TITLE
pc: fix apple drop chance (oak/dark_oak leaves)

### DIFF
--- a/data/pc/1.14.4/blockLoot.json
+++ b/data/pc/1.14.4/blockLoot.json
@@ -2083,7 +2083,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1
@@ -5124,7 +5124,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1

--- a/data/pc/1.15.2/blockLoot.json
+++ b/data/pc/1.15.2/blockLoot.json
@@ -2138,7 +2138,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1
@@ -5213,7 +5213,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1

--- a/data/pc/1.16.1/blockLoot.json
+++ b/data/pc/1.16.1/blockLoot.json
@@ -2499,7 +2499,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1
@@ -5676,7 +5676,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1

--- a/data/pc/1.16.2/blockLoot.json
+++ b/data/pc/1.16.2/blockLoot.json
@@ -2499,7 +2499,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1
@@ -5676,7 +5676,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1

--- a/data/pc/1.17/blockLoot.json
+++ b/data/pc/1.17/blockLoot.json
@@ -2951,7 +2951,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1
@@ -6842,7 +6842,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1

--- a/data/pc/1.18/blockLoot.json
+++ b/data/pc/1.18/blockLoot.json
@@ -2951,7 +2951,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1
@@ -6842,7 +6842,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1

--- a/data/pc/1.19/blockLoot.json
+++ b/data/pc/1.19/blockLoot.json
@@ -2951,7 +2951,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1
@@ -7128,7 +7128,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1

--- a/data/pc/1.20/blockLoot.json
+++ b/data/pc/1.20/blockLoot.json
@@ -3437,7 +3437,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1
@@ -7666,7 +7666,7 @@
       },
       {
         "item": "apple",
-        "dropChance": 1,
+        "dropChance": 0.005,
         "stackSizeRange": [
           1,
           1


### PR DESCRIPTION
Fixes #907

Apple drops from oak/dark_oak leaves were recorded with `dropChance: 1` instead of the vanilla 0.5% (0.005).

Fixed in 8 versions (1.14.4-1.20): 16 entries total. JSON valid; schema passes.