### PR TITLE
pc: remove frost_walker/mending from 1.7-1.8 enchantment excludes

### DIFF
--- a/data/pc/1.7/enchantments.json
+++ b/data/pc/1.7/enchantments.json
@@ -196,9 +196,7 @@
       "a": 10,
       "b": 15
     },
-    "exclude": [
-      "frost_walker"
-    ],
+    "exclude": [],
     "category": "armor_feet",
     "weight": 2,
     "treasureOnly": false,
@@ -505,9 +503,7 @@
       "a": 0,
       "b": 50
     },
-    "exclude": [
-      "mending"
-    ],
+    "exclude": [],
     "category": "bow",
     "weight": 1,
     "treasureOnly": false,

--- a/data/pc/1.8/enchantments.json
+++ b/data/pc/1.8/enchantments.json
@@ -196,9 +196,7 @@
       "a": 10,
       "b": 15
     },
-    "exclude": [
-      "frost_walker"
-    ],
+    "exclude": [],
     "category": "armor_feet",
     "weight": 2,
     "treasureOnly": false,
@@ -505,9 +503,7 @@
       "a": 0,
       "b": 50
     },
-    "exclude": [
-      "mending"
-    ],
+    "exclude": [],
     "category": "bow",
     "weight": 1,
     "treasureOnly": false,


### PR DESCRIPTION
Fixes #582

In 1.7 and 1.8, `depth_strider.exclude` referenced `frost_walker` and `infinity.exclude` referenced `mending` — enchantments that were only added in 1.9.

Both exclude arrays are now empty. JSON valid; schema passes.