### PR TITLE
pc: remove 1.16-only items from repairWith in 1.7-1.15.2

### DIFF
--- a/data/pc/1.10/items.json
+++ b/data/pc/1.10/items.json
@@ -1136,14 +1136,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1158,14 +1151,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1180,14 +1166,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1202,14 +1181,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1224,8 +1196,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1240,8 +1211,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1256,8 +1226,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1272,8 +1241,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1444,14 +1412,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1466,8 +1427,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -2813,14 +2773,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -2834,9 +2787,7 @@
       "wearable",
       "vanishable"
     ],
-    "repairWith": [
-      "phantom_membrane"
-    ]
+    "repairWith": []
   },
   {
     "id": 444,

--- a/data/pc/1.11/items.json
+++ b/data/pc/1.11/items.json
@@ -1238,14 +1238,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1260,14 +1253,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1282,14 +1268,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1304,14 +1283,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1326,8 +1298,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1342,8 +1313,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1358,8 +1328,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1374,8 +1343,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1546,14 +1514,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1568,8 +1529,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -2915,14 +2875,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -2936,9 +2889,7 @@
       "wearable",
       "vanishable"
     ],
-    "repairWith": [
-      "phantom_membrane"
-    ]
+    "repairWith": []
   },
   {
     "id": 444,

--- a/data/pc/1.12/items.json
+++ b/data/pc/1.12/items.json
@@ -1346,14 +1346,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1368,14 +1361,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1390,14 +1376,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1412,14 +1391,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1434,8 +1406,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1450,8 +1421,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1466,8 +1436,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1482,8 +1451,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1654,14 +1622,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1676,8 +1637,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3023,14 +2983,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -3044,9 +2997,7 @@
       "wearable",
       "vanishable"
     ],
-    "repairWith": [
-      "phantom_membrane"
-    ]
+    "repairWith": []
   },
   {
     "id": 444,

--- a/data/pc/1.13.2/items.json
+++ b/data/pc/1.13.2/items.json
@@ -2982,9 +2982,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3004,9 +3002,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3026,9 +3022,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3048,9 +3042,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3065,8 +3057,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3081,8 +3072,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3097,8 +3087,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3113,8 +3102,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3290,9 +3278,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3307,8 +3293,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -5119,9 +5104,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {

--- a/data/pc/1.13/items.json
+++ b/data/pc/1.13/items.json
@@ -2952,9 +2952,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -2974,9 +2972,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -2996,9 +2992,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3018,9 +3012,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3035,8 +3027,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3051,8 +3042,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3067,8 +3057,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3083,8 +3072,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3260,9 +3248,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3277,8 +3263,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -5089,9 +5074,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {

--- a/data/pc/1.14.4/items.json
+++ b/data/pc/1.14.4/items.json
@@ -3270,9 +3270,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3292,9 +3290,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3314,9 +3310,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3336,9 +3330,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3353,8 +3345,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3369,8 +3360,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3385,8 +3375,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3401,8 +3390,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3578,9 +3566,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3595,8 +3581,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -5515,9 +5500,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {

--- a/data/pc/1.15.2/items.json
+++ b/data/pc/1.15.2/items.json
@@ -3270,9 +3270,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3292,9 +3290,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3314,9 +3310,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3336,9 +3330,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3353,8 +3345,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3369,8 +3360,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3385,8 +3375,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3401,8 +3390,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -3578,9 +3566,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {
@@ -3595,8 +3581,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -5521,9 +5506,7 @@
       "birch_planks",
       "jungle_planks",
       "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "dark_oak_planks"
     ]
   },
   {

--- a/data/pc/1.7/items.json
+++ b/data/pc/1.7/items.json
@@ -926,14 +926,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -948,14 +941,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -970,14 +956,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -992,14 +971,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1014,8 +986,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1030,8 +1001,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1046,8 +1016,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1062,8 +1031,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1234,14 +1202,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1256,8 +1217,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {

--- a/data/pc/1.8/items.json
+++ b/data/pc/1.8/items.json
@@ -1806,14 +1806,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1828,14 +1821,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1850,14 +1836,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1872,14 +1851,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1894,8 +1866,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1910,8 +1881,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1926,8 +1896,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1942,8 +1911,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -2114,14 +2082,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -2136,8 +2097,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {

--- a/data/pc/1.9/items.json
+++ b/data/pc/1.9/items.json
@@ -1100,14 +1100,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1122,14 +1115,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1144,14 +1130,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1166,14 +1145,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1188,8 +1160,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1204,8 +1175,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1220,8 +1190,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1236,8 +1205,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -1408,14 +1376,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -1430,8 +1391,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "cobblestone",
-      "blackstone"
+      "cobblestone"
     ]
   },
   {
@@ -2777,14 +2737,7 @@
       "vanishable"
     ],
     "repairWith": [
-      "oak_planks",
-      "spruce_planks",
-      "birch_planks",
-      "jungle_planks",
-      "acacia_planks",
-      "dark_oak_planks",
-      "crimson_planks",
-      "warped_planks"
+      "planks"
     ]
   },
   {
@@ -2798,9 +2751,7 @@
       "wearable",
       "vanishable"
     ],
-    "repairWith": [
-      "phantom_membrane"
-    ]
+    "repairWith": []
   },
   {
     "id": 444,


### PR DESCRIPTION
Fixes #544

In versions 1.7-1.15.2, `repairWith` lists referenced items that don't exist in those versions: `crimson_planks`/`warped_planks` (added 1.16) on wooden tools, `blackstone` (1.16) on stone tools, and `phantom_membrane` (not present in these data files) on elytra.

- 1.7-1.12: wooden tools now repair with `planks` (the only plank item in those versions)
- 1.13-1.15.2: wooden tools repair with the 6 existing plank items
- stone tools: repair with `cobblestone` only
- elytra (1.9-1.12): repairWith emptied since phantom_membrane isn't in those version files

Verified: no repairWith entry references an item missing from its version's items.json. JSON valid; schema passes.