### PR TITLE
test: validate all JSON schemas against the draft-07 meta-schema

### DIFF
--- a/tools/js/test/audit_schema_meta.js
+++ b/tools/js/test/audit_schema_meta.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+
+const fs = require('fs')
+const path = require('path')
+const assert = require('assert')
+
+const Ajv = require('ajv')
+const ajv = new Ajv({ meta: false }) // don't auto-add meta schemas; we add draft-07 explicitly
+ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-07.json'))
+
+// Validate that all schemas in the schemas/ directory are themselves valid JSON Schemas
+// (draft-07, since ajv@6 uses draft-07).
+// ref: https://github.com/PrismarineJS/minecraft-data/issues/1057
+
+describe('JSON schemas are valid against the JSON Schema meta-schema', function () {
+  const schemasDir = path.join(__dirname, '../../../schemas')
+  const files = fs.readdirSync(schemasDir).filter(f => f.endsWith('_schema.json'))
+  files.forEach(function (file) {
+    it(file + ' is a valid JSON Schema', function () {
+      const schema = require(path.join(schemasDir, file))
+      const valid = ajv.validateSchema(schema)
+      assert.ok(valid, JSON.stringify(ajv.errors, null, 2))
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1057

Adds an audit test that validates every schema in `schemas/` against the [JSON Schema draft-07 meta-schema](https://json-schema.org/draft-07/schema), preventing typos in the schemas themselves (ajv@6 uses draft-07).

Verified: all 25 schemas pass meta-schema validation.