### PR TITLE
schemas: add blockStates_schema.json and validate bedrock blockStates data

### DIFF
--- a/schemas/blockStates_schema.json
+++ b/schemas/blockStates_schema.json
@@ -1,0 +1,38 @@
+{
+  "title": "blockStates",
+  "type": "array",
+  "uniqueItems": true,
+  "items": {
+    "title": "blockState",
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "The block name (e.g. acacia_button)",
+        "type": "string",
+        "pattern": "\\S+"
+      },
+      "states": {
+        "description": "Map of state name to its type and value",
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "The type of the state (byte, int, bool, string...)",
+              "type": "string"
+            },
+            "value": {}
+          },
+          "required": ["type", "value"],
+          "additionalProperties": false
+        }
+      },
+      "version": {
+        "description": "The block state version (present in newer versions)",
+        "type": "integer"
+      }
+    },
+    "required": ["name", "states"],
+    "additionalProperties": false
+  }
+}

--- a/tools/js/test/test.js
+++ b/tools/js/test/test.js
@@ -11,7 +11,7 @@ const Validator = require('protodef-validator')
 
 Error.stackTraceLimit = 0
 
-const data = ['attributes', 'biomes', 'commands', 'instruments', 'items', 'materials', 'blocks', 'blockCollisionShapes', 'recipes', 'windows', 'entities', 'protocol', 'version', 'effects', 'enchantments', 'language', 'foods', 'particles', 'blockLoot', 'entityLoot', 'mapIcons', 'tints', 'blockMappings', 'sounds']
+const data = ['attributes', 'biomes', 'commands', 'instruments', 'items', 'materials', 'blocks', 'blockCollisionShapes', 'recipes', 'windows', 'entities', 'protocol', 'version', 'effects', 'enchantments', 'language', 'foods', 'particles', 'blockLoot', 'entityLoot', 'mapIcons', 'tints', 'blockMappings', 'sounds', 'blockStates']
 
 require('./version_iterator')(function (p, versionString) {
   describe('minecraft-data schemas ' + versionString, function () {
@@ -24,6 +24,8 @@ require('./version_iterator')(function (p, versionString) {
       }
       if (instance) {
         it(dataName + '.json is valid', function () {
+          // blockStates.json files are large (10k+ entries); give them more time
+          if (dataName === 'blockStates') this.timeout(180 * 1000)
           // Skip tints schema validation for PC 1.21.4, as it doesn't meet the
           // maxItems: 1 check for the constant tints.
           if (dataName === 'tints' && versionString === 'pc 1.21.4') {


### PR DESCRIPTION
Fixes #1060

Adds `schemas/blockStates_schema.json` describing the structure of Bedrock `blockStates.json` files (array of `{name, states, version}`) and registers `blockStates` in the schema validation test.

Notes:
- `version` is optional (older versions like 1.16.220 don't have it)
- Large files (10k+ entries) get an extended validation timeout

Verified: 888 tests pass, all Bedrock blockStates.json files validate against the new schema.