### PR TITLE
bedrock: fix camera_instruction fade structure (time_data/color_rgb optional prefixes) 1.20.30+

### DIFF
--- a/data/bedrock/1.20.30/proto.yml
+++ b/data/bedrock/1.20.30/proto.yml
@@ -4062,10 +4062,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
 
 
 packet_compressed_biome_definitions:

--- a/data/bedrock/1.20.30/protocol.json
+++ b/data/bedrock/1.20.30/protocol.json
@@ -11737,20 +11737,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.20.40/proto.yml
+++ b/data/bedrock/1.20.40/proto.yml
@@ -4066,10 +4066,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
 
 
 packet_compressed_biome_definitions:

--- a/data/bedrock/1.20.40/protocol.json
+++ b/data/bedrock/1.20.40/protocol.json
@@ -11869,20 +11869,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.20.50/proto.yml
+++ b/data/bedrock/1.20.50/proto.yml
@@ -4071,10 +4071,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
 
 
 packet_compressed_biome_definitions:

--- a/data/bedrock/1.20.50/protocol.json
+++ b/data/bedrock/1.20.50/protocol.json
@@ -11916,20 +11916,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.20.61/proto.yml
+++ b/data/bedrock/1.20.61/proto.yml
@@ -4059,10 +4059,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
 
 
 packet_compressed_biome_definitions:

--- a/data/bedrock/1.20.61/protocol.json
+++ b/data/bedrock/1.20.61/protocol.json
@@ -11922,20 +11922,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.20.71/proto.yml
+++ b/data/bedrock/1.20.71/proto.yml
@@ -4066,10 +4066,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
 
 
 packet_compressed_biome_definitions:

--- a/data/bedrock/1.20.71/protocol.json
+++ b/data/bedrock/1.20.71/protocol.json
@@ -11961,20 +11961,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.20.80/proto.yml
+++ b/data/bedrock/1.20.80/proto.yml
@@ -4077,10 +4077,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
 
 
 packet_compressed_biome_definitions:

--- a/data/bedrock/1.20.80/protocol.json
+++ b/data/bedrock/1.20.80/protocol.json
@@ -12043,20 +12043,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.0/proto.yml
+++ b/data/bedrock/1.21.0/proto.yml
@@ -4094,10 +4094,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
 
 
 packet_compressed_biome_definitions:

--- a/data/bedrock/1.21.0/protocol.json
+++ b/data/bedrock/1.21.0/protocol.json
@@ -12149,20 +12149,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.100/proto.yml
+++ b/data/bedrock/1.21.100/proto.yml
@@ -4165,10 +4165,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.100/protocol.json
+++ b/data/bedrock/1.21.100/protocol.json
@@ -13312,20 +13312,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.111/proto.yml
+++ b/data/bedrock/1.21.111/proto.yml
@@ -4156,10 +4156,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.111/protocol.json
+++ b/data/bedrock/1.21.111/protocol.json
@@ -13308,20 +13308,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.120/proto.yml
+++ b/data/bedrock/1.21.120/proto.yml
@@ -4158,10 +4158,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.120/protocol.json
+++ b/data/bedrock/1.21.120/protocol.json
@@ -13451,20 +13451,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.124/proto.yml
+++ b/data/bedrock/1.21.124/proto.yml
@@ -4158,10 +4158,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.124/protocol.json
+++ b/data/bedrock/1.21.124/protocol.json
@@ -13451,20 +13451,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.130/proto.yml
+++ b/data/bedrock/1.21.130/proto.yml
@@ -4136,10 +4136,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.130/protocol.json
+++ b/data/bedrock/1.21.130/protocol.json
@@ -13472,20 +13472,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.2/proto.yml
+++ b/data/bedrock/1.21.2/proto.yml
@@ -4094,10 +4094,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
 
 
 packet_compressed_biome_definitions:

--- a/data/bedrock/1.21.2/protocol.json
+++ b/data/bedrock/1.21.2/protocol.json
@@ -12151,20 +12151,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.20/proto.yml
+++ b/data/bedrock/1.21.20/proto.yml
@@ -4114,10 +4114,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    target?:
       offset?: vec3f
       entity_unique_id: li64

--- a/data/bedrock/1.21.20/protocol.json
+++ b/data/bedrock/1.21.20/protocol.json
@@ -12331,20 +12331,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.30/proto.yml
+++ b/data/bedrock/1.21.30/proto.yml
@@ -4121,10 +4121,14 @@ packet_camera_instruction:
       default?: bool
    clear?: bool
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    target?:
       offset?: vec3f
       entity_unique_id: li64

--- a/data/bedrock/1.21.30/protocol.json
+++ b/data/bedrock/1.21.30/protocol.json
@@ -12336,20 +12336,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.42/proto.yml
+++ b/data/bedrock/1.21.42/proto.yml
@@ -4136,10 +4136,14 @@ packet_camera_instruction:
    clear?: bool
    # Clear can be set to true to clear all the current camera instructions.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.42/protocol.json
+++ b/data/bedrock/1.21.42/protocol.json
@@ -12368,20 +12368,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.50/proto.yml
+++ b/data/bedrock/1.21.50/proto.yml
@@ -4157,10 +4157,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.50/protocol.json
+++ b/data/bedrock/1.21.50/protocol.json
@@ -12467,20 +12467,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.60/proto.yml
+++ b/data/bedrock/1.21.60/proto.yml
@@ -4190,10 +4190,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.60/protocol.json
+++ b/data/bedrock/1.21.60/protocol.json
@@ -12548,20 +12548,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.70/proto.yml
+++ b/data/bedrock/1.21.70/proto.yml
@@ -4194,10 +4194,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.70/protocol.json
+++ b/data/bedrock/1.21.70/protocol.json
@@ -12561,20 +12561,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.80/proto.yml
+++ b/data/bedrock/1.21.80/proto.yml
@@ -4201,10 +4201,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.80/protocol.json
+++ b/data/bedrock/1.21.80/protocol.json
@@ -13268,20 +13268,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.90/proto.yml
+++ b/data/bedrock/1.21.90/proto.yml
@@ -4198,10 +4198,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.90/protocol.json
+++ b/data/bedrock/1.21.90/protocol.json
@@ -13325,20 +13325,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.21.93/proto.yml
+++ b/data/bedrock/1.21.93/proto.yml
@@ -4198,10 +4198,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.21.93/protocol.json
+++ b/data/bedrock/1.21.93/protocol.json
@@ -13325,20 +13325,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.26.0/proto.yml
+++ b/data/bedrock/1.26.0/proto.yml
@@ -4124,10 +4124,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.26.0/protocol.json
+++ b/data/bedrock/1.26.0/protocol.json
@@ -13820,20 +13820,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.26.10/proto.yml
+++ b/data/bedrock/1.26.10/proto.yml
@@ -4121,10 +4121,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.26.10/protocol.json
+++ b/data/bedrock/1.26.10/protocol.json
@@ -14523,20 +14523,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.26.20/proto.yml
+++ b/data/bedrock/1.26.20/proto.yml
@@ -4124,10 +4124,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.26.20/protocol.json
+++ b/data/bedrock/1.26.20/protocol.json
@@ -14987,20 +14987,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.26.30/proto.yml
+++ b/data/bedrock/1.26.30/proto.yml
@@ -4115,10 +4115,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f

--- a/data/bedrock/1.26.30/protocol.json
+++ b/data/bedrock/1.26.30/protocol.json
@@ -15144,20 +15144,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/1.26.40/protocol.json
+++ b/data/bedrock/1.26.40/protocol.json
@@ -14637,20 +14637,50 @@
               "container",
               [
                 {
-                  "name": "fade_in_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "wait_duration",
-                  "type": "lf32"
-                },
-                {
-                  "name": "fade_out_duration",
-                  "type": "lf32"
+                  "name": "time_data",
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "fade_in_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "wait_duration",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "fade_out_duration",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 },
                 {
                   "name": "color_rgb",
-                  "type": "vec3f"
+                  "type": [
+                    "option",
+                    [
+                      "container",
+                      [
+                        {
+                          "name": "red",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "green",
+                          "type": "lf32"
+                        },
+                        {
+                          "name": "blue",
+                          "type": "lf32"
+                        }
+                      ]
+                    ]
+                  ]
                 }
               ]
             ]

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -4067,10 +4067,14 @@ packet_camera_instruction:
    clear?: bool
    # Fade is a camera instruction that fades the screen to a specified colour.
    fade?:
-      fade_in_duration: lf32
-      wait_duration: lf32
-      fade_out_duration: lf32
-      color_rgb: vec3f
+      time_data?:
+         fade_in_duration: lf32
+         wait_duration: lf32
+         fade_out_duration: lf32
+      color_rgb?:
+         red: lf32
+         green: lf32
+         blue: lf32
    # Target is a camera instruction that targets a specific entity.
    target?:
       offset?: vec3f


### PR DESCRIPTION
Fixes #1109

**Root cause:** In `packet_camera_instruction`, the `fade` instruction was defined without the optional prefixes that each of its fields has on the wire. Per [pmmp/BedrockProtocol](https://github.com/pmmp/BedrockProtocol/blob/master/src/types/camera/CameraFadeInstruction.php), `CameraFadeInstruction` is: `Optional<CameraFadeTimeData>` (bool + 3×f32) followed by `Optional<CameraFadeInstructionColor>` (bool + 3×f32 RGB).

minecraft-data had:
```yaml
fade?:
   fade_in_duration: lf32
   wait_duration: lf32
   fade_out_duration: lf32
   color_rgb: vec3f
```
which misses the two per-field presence booleans, so any real-world packet using both time and color fails to parse (`PartialReadError` on all versions from 1.20.30).

**Fix (all versions 1.20.30 → latest):**
```yaml
fade?:
   time_data?:
      fade_in_duration: lf32
      wait_duration: lf32
      fade_out_duration: lf32
   color_rgb?:
      red: lf32
      green: lf32
      blue: lf32
```

**Verification:** the reporter's 34-byte sample (`rAIAAAEBAAAAPwAAwD8AAAA/AeHgYD3BwMA90dBQPgAAAA==`, pid 300) previously failed with PartialReadError on every version; with this fix it decodes fully (34/34 bytes) via protodef:
```json
{"name":"camera_instruction","params":{"fade":{"time_data":{"fade_in_duration":0.5,"wait_duration":1.5,"fade_out_duration":0.5},"color_rgb":{"red":0.05490196,"green":0.09411764,"blue":0.20392157}}}}
```
All affected protocol.json files regenerated via `compileProtocol.js`.