### PR TITLE
bedrock: fix start_game permission_level type (zigzag32) for 1.19.10+

### DIFF
--- a/data/bedrock/1.19.10/proto.yml
+++ b/data/bedrock/1.19.10/proto.yml
@@ -311,7 +311,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.10/protocol.json
+++ b/data/bedrock/1.19.10/protocol.json
@@ -4845,7 +4845,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.19.20/proto.yml
+++ b/data/bedrock/1.19.20/proto.yml
@@ -311,7 +311,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.20/protocol.json
+++ b/data/bedrock/1.19.20/protocol.json
@@ -4885,7 +4885,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.19.21/proto.yml
+++ b/data/bedrock/1.19.21/proto.yml
@@ -311,7 +311,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.21/protocol.json
+++ b/data/bedrock/1.19.21/protocol.json
@@ -4885,7 +4885,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.19.30/proto.yml
+++ b/data/bedrock/1.19.30/proto.yml
@@ -312,7 +312,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.30/protocol.json
+++ b/data/bedrock/1.19.30/protocol.json
@@ -4984,7 +4984,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.19.40/proto.yml
+++ b/data/bedrock/1.19.40/proto.yml
@@ -312,7 +312,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.40/protocol.json
+++ b/data/bedrock/1.19.40/protocol.json
@@ -5053,7 +5053,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.19.50/proto.yml
+++ b/data/bedrock/1.19.50/proto.yml
@@ -312,7 +312,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.50/protocol.json
+++ b/data/bedrock/1.19.50/protocol.json
@@ -5073,7 +5073,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.19.60/proto.yml
+++ b/data/bedrock/1.19.60/proto.yml
@@ -312,7 +312,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.60/protocol.json
+++ b/data/bedrock/1.19.60/protocol.json
@@ -5110,7 +5110,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.19.62/proto.yml
+++ b/data/bedrock/1.19.62/proto.yml
@@ -312,7 +312,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.62/protocol.json
+++ b/data/bedrock/1.19.62/protocol.json
@@ -5114,7 +5114,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.19.70/proto.yml
+++ b/data/bedrock/1.19.70/proto.yml
@@ -312,7 +312,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.70/protocol.json
+++ b/data/bedrock/1.19.70/protocol.json
@@ -5137,7 +5137,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.19.80/proto.yml
+++ b/data/bedrock/1.19.80/proto.yml
@@ -316,7 +316,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.19.80/protocol.json
+++ b/data/bedrock/1.19.80/protocol.json
@@ -5186,7 +5186,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.20.0/proto.yml
+++ b/data/bedrock/1.20.0/proto.yml
@@ -316,7 +316,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.20.0/protocol.json
+++ b/data/bedrock/1.20.0/protocol.json
@@ -5192,7 +5192,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.20.10/proto.yml
+++ b/data/bedrock/1.20.10/proto.yml
@@ -316,7 +316,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.20.10/protocol.json
+++ b/data/bedrock/1.20.10/protocol.json
@@ -5199,7 +5199,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.20.30/proto.yml
+++ b/data/bedrock/1.20.30/proto.yml
@@ -324,7 +324,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.20.30/protocol.json
+++ b/data/bedrock/1.20.30/protocol.json
@@ -5322,7 +5322,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.20.40/proto.yml
+++ b/data/bedrock/1.20.40/proto.yml
@@ -327,7 +327,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.20.40/protocol.json
+++ b/data/bedrock/1.20.40/protocol.json
@@ -5453,7 +5453,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.20.50/proto.yml
+++ b/data/bedrock/1.20.50/proto.yml
@@ -327,7 +327,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.20.50/protocol.json
+++ b/data/bedrock/1.20.50/protocol.json
@@ -5488,7 +5488,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.20.61/proto.yml
+++ b/data/bedrock/1.20.61/proto.yml
@@ -327,7 +327,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.20.61/protocol.json
+++ b/data/bedrock/1.20.61/protocol.json
@@ -5490,7 +5490,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.20.71/proto.yml
+++ b/data/bedrock/1.20.71/proto.yml
@@ -330,7 +330,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.20.71/protocol.json
+++ b/data/bedrock/1.20.71/protocol.json
@@ -5516,7 +5516,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.20.80/proto.yml
+++ b/data/bedrock/1.20.80/proto.yml
@@ -334,7 +334,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.20.80/protocol.json
+++ b/data/bedrock/1.20.80/protocol.json
@@ -5568,7 +5568,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.0/proto.yml
+++ b/data/bedrock/1.21.0/proto.yml
@@ -335,7 +335,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.0/protocol.json
+++ b/data/bedrock/1.21.0/protocol.json
@@ -5641,7 +5641,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.100/proto.yml
+++ b/data/bedrock/1.21.100/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.100/protocol.json
+++ b/data/bedrock/1.21.100/protocol.json
@@ -6646,7 +6646,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.111/proto.yml
+++ b/data/bedrock/1.21.111/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.111/protocol.json
+++ b/data/bedrock/1.21.111/protocol.json
@@ -6672,7 +6672,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.120/proto.yml
+++ b/data/bedrock/1.21.120/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.120/protocol.json
+++ b/data/bedrock/1.21.120/protocol.json
@@ -6810,7 +6810,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.124/proto.yml
+++ b/data/bedrock/1.21.124/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.124/protocol.json
+++ b/data/bedrock/1.21.124/protocol.json
@@ -6810,7 +6810,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.130/proto.yml
+++ b/data/bedrock/1.21.130/proto.yml
@@ -368,7 +368,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.130/protocol.json
+++ b/data/bedrock/1.21.130/protocol.json
@@ -6905,7 +6905,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.2/proto.yml
+++ b/data/bedrock/1.21.2/proto.yml
@@ -335,7 +335,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.2/protocol.json
+++ b/data/bedrock/1.21.2/protocol.json
@@ -5643,7 +5643,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.20/proto.yml
+++ b/data/bedrock/1.21.20/proto.yml
@@ -339,7 +339,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.20/protocol.json
+++ b/data/bedrock/1.21.20/protocol.json
@@ -5757,7 +5757,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.30/proto.yml
+++ b/data/bedrock/1.21.30/proto.yml
@@ -334,7 +334,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.30/protocol.json
+++ b/data/bedrock/1.21.30/protocol.json
@@ -5742,7 +5742,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.42/proto.yml
+++ b/data/bedrock/1.21.42/proto.yml
@@ -333,7 +333,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.42/protocol.json
+++ b/data/bedrock/1.21.42/protocol.json
@@ -5767,7 +5767,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.50/proto.yml
+++ b/data/bedrock/1.21.50/proto.yml
@@ -341,7 +341,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.50/protocol.json
+++ b/data/bedrock/1.21.50/protocol.json
@@ -5852,7 +5852,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.60/proto.yml
+++ b/data/bedrock/1.21.60/proto.yml
@@ -342,7 +342,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.60/protocol.json
+++ b/data/bedrock/1.21.60/protocol.json
@@ -5878,7 +5878,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.70/proto.yml
+++ b/data/bedrock/1.21.70/proto.yml
@@ -342,7 +342,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.70/protocol.json
+++ b/data/bedrock/1.21.70/protocol.json
@@ -5887,7 +5887,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.80/proto.yml
+++ b/data/bedrock/1.21.80/proto.yml
@@ -344,7 +344,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.80/protocol.json
+++ b/data/bedrock/1.21.80/protocol.json
@@ -6578,7 +6578,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.90/proto.yml
+++ b/data/bedrock/1.21.90/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.90/protocol.json
+++ b/data/bedrock/1.21.90/protocol.json
@@ -6608,7 +6608,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.21.93/proto.yml
+++ b/data/bedrock/1.21.93/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.21.93/protocol.json
+++ b/data/bedrock/1.21.93/protocol.json
@@ -6608,7 +6608,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.26.0/proto.yml
+++ b/data/bedrock/1.26.0/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.26.0/protocol.json
+++ b/data/bedrock/1.26.0/protocol.json
@@ -7237,7 +7237,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.26.10/proto.yml
+++ b/data/bedrock/1.26.10/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.26.10/protocol.json
+++ b/data/bedrock/1.26.10/protocol.json
@@ -7944,7 +7944,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.26.20/proto.yml
+++ b/data/bedrock/1.26.20/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.26.20/protocol.json
+++ b/data/bedrock/1.26.20/protocol.json
@@ -8385,7 +8385,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.26.30/proto.yml
+++ b/data/bedrock/1.26.30/proto.yml
@@ -352,7 +352,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32

--- a/data/bedrock/1.26.30/protocol.json
+++ b/data/bedrock/1.26.30/protocol.json
@@ -8622,7 +8622,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/1.26.40/protocol.json
+++ b/data/bedrock/1.26.40/protocol.json
@@ -8301,7 +8301,7 @@
         },
         {
           "name": "permission_level",
-          "type": "PermissionLevel"
+          "type": "zigzag32"
         },
         {
           "name": "server_chunk_tick_range",

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -361,7 +361,7 @@ packet_start_game:
    map_enabled: bool
    # The permission level of the player. It is a value from 0-3, with 0 being visitor,
    # 1 being member, 2 being operator and 3 being custom.
-   permission_level: PermissionLevel
+   permission_level: zigzag32
    # The radius around the player in which chunks are ticked. Most servers set this value
    # to a fixed number, as it does not necessarily affect anything client-side.
    server_chunk_tick_range: li32


### PR DESCRIPTION
Fixes #724

As confirmed by @extremeheat, the `player_permissions` field of `packet_start_game` was incorrectly changed from `zigzag32` to `PermissionLevel` (u8) in PR #588 (starting 1.19.10), breaking the permission level read on all later versions.

Verified against [pmmp LevelSettings](https://github.com/pmmp/BedrockProtocol/blob/master/src/types/LevelSettings.php): `defaultPlayerPermission` uses `VarInt::readSignedInt` (zigzag32). Versions up to 1.19.1 already used `zigzag32`.

This reverts `permission_level: PermissionLevel` to `permission_level: zigzag32` in start_game for all 39 affected versions (1.19.10 → latest). Other packets using PermissionLevel are unchanged.

Verified: protocol regenerated for all versions; only the one field line changed per version.