### PR TITLE
pc: fix entity_teleport packet structure for 1.21.4-1.21.11 (velocity, f32 yaw/pitch, relative flags)

### DIFF
--- a/data/pc/1.21.11/proto.yml
+++ b/data/pc/1.21.11/proto.yml
@@ -2894,8 +2894,22 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      velocityX: f64
+      velocityY: f64
+      velocityZ: f64
+      yaw: f32
+      pitch: f32
+      flags: ["bitfield", [
+         { "name": "relative_x", "size": 1, "signed": false },
+         { "name": "relative_y", "size": 1, "signed": false },
+         { "name": "relative_z", "size": 1, "signed": false },
+         { "name": "relative_yaw", "size": 1, "signed": false },
+         { "name": "relative_pitch", "size": 1, "signed": false },
+         { "name": "relative_velocity_x", "size": 1, "signed": false },
+         { "name": "relative_velocity_y", "size": 1, "signed": false },
+         { "name": "relative_velocity_z", "size": 1, "signed": false },
+         { "name": "rotate_velocity", "size": 1, "signed": false }
+      ]]
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.11/protocol.json
+++ b/data/pc/1.21.11/protocol.json
@@ -9354,12 +9354,77 @@
               "type": "f64"
             },
             {
+              "name": "velocityX",
+              "type": "f64"
+            },
+            {
+              "name": "velocityY",
+              "type": "f64"
+            },
+            {
+              "name": "velocityZ",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": [
+                "bitfield",
+                [
+                  {
+                    "name": "relative_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_yaw",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_pitch",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "rotate_velocity",
+                    "size": 1,
+                    "signed": false
+                  }
+                ]
+              ]
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.4/proto.yml
+++ b/data/pc/1.21.4/proto.yml
@@ -2399,8 +2399,22 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      velocityX: f64
+      velocityY: f64
+      velocityZ: f64
+      yaw: f32
+      pitch: f32
+      flags: ["bitfield", [
+         { "name": "relative_x", "size": 1, "signed": false },
+         { "name": "relative_y", "size": 1, "signed": false },
+         { "name": "relative_z", "size": 1, "signed": false },
+         { "name": "relative_yaw", "size": 1, "signed": false },
+         { "name": "relative_pitch", "size": 1, "signed": false },
+         { "name": "relative_velocity_x", "size": 1, "signed": false },
+         { "name": "relative_velocity_y", "size": 1, "signed": false },
+         { "name": "relative_velocity_z", "size": 1, "signed": false },
+         { "name": "rotate_velocity", "size": 1, "signed": false }
+      ]]
       onGround: bool
    # MC: ClientboundTickingStatePacket
    packet_set_ticking_state:

--- a/data/pc/1.21.4/protocol.json
+++ b/data/pc/1.21.4/protocol.json
@@ -7390,12 +7390,77 @@
               "type": "f64"
             },
             {
+              "name": "velocityX",
+              "type": "f64"
+            },
+            {
+              "name": "velocityY",
+              "type": "f64"
+            },
+            {
+              "name": "velocityZ",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": [
+                "bitfield",
+                [
+                  {
+                    "name": "relative_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_yaw",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_pitch",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "rotate_velocity",
+                    "size": 1,
+                    "signed": false
+                  }
+                ]
+              ]
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.5/proto.yml
+++ b/data/pc/1.21.5/proto.yml
@@ -2507,8 +2507,22 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      velocityX: f64
+      velocityY: f64
+      velocityZ: f64
+      yaw: f32
+      pitch: f32
+      flags: ["bitfield", [
+         { "name": "relative_x", "size": 1, "signed": false },
+         { "name": "relative_y", "size": 1, "signed": false },
+         { "name": "relative_z", "size": 1, "signed": false },
+         { "name": "relative_yaw", "size": 1, "signed": false },
+         { "name": "relative_pitch", "size": 1, "signed": false },
+         { "name": "relative_velocity_x", "size": 1, "signed": false },
+         { "name": "relative_velocity_y", "size": 1, "signed": false },
+         { "name": "relative_velocity_z", "size": 1, "signed": false },
+         { "name": "rotate_velocity", "size": 1, "signed": false }
+      ]]
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.5/protocol.json
+++ b/data/pc/1.21.5/protocol.json
@@ -7747,12 +7747,77 @@
               "type": "f64"
             },
             {
+              "name": "velocityX",
+              "type": "f64"
+            },
+            {
+              "name": "velocityY",
+              "type": "f64"
+            },
+            {
+              "name": "velocityZ",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": [
+                "bitfield",
+                [
+                  {
+                    "name": "relative_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_yaw",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_pitch",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "rotate_velocity",
+                    "size": 1,
+                    "signed": false
+                  }
+                ]
+              ]
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.6/proto.yml
+++ b/data/pc/1.21.6/proto.yml
@@ -2550,8 +2550,22 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      velocityX: f64
+      velocityY: f64
+      velocityZ: f64
+      yaw: f32
+      pitch: f32
+      flags: ["bitfield", [
+         { "name": "relative_x", "size": 1, "signed": false },
+         { "name": "relative_y", "size": 1, "signed": false },
+         { "name": "relative_z", "size": 1, "signed": false },
+         { "name": "relative_yaw", "size": 1, "signed": false },
+         { "name": "relative_pitch", "size": 1, "signed": false },
+         { "name": "relative_velocity_x", "size": 1, "signed": false },
+         { "name": "relative_velocity_y", "size": 1, "signed": false },
+         { "name": "relative_velocity_z", "size": 1, "signed": false },
+         { "name": "rotate_velocity", "size": 1, "signed": false }
+      ]]
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.6/protocol.json
+++ b/data/pc/1.21.6/protocol.json
@@ -7926,12 +7926,77 @@
               "type": "f64"
             },
             {
+              "name": "velocityX",
+              "type": "f64"
+            },
+            {
+              "name": "velocityY",
+              "type": "f64"
+            },
+            {
+              "name": "velocityZ",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": [
+                "bitfield",
+                [
+                  {
+                    "name": "relative_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_yaw",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_pitch",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "rotate_velocity",
+                    "size": 1,
+                    "signed": false
+                  }
+                ]
+              ]
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.8/proto.yml
+++ b/data/pc/1.21.8/proto.yml
@@ -2550,8 +2550,22 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      velocityX: f64
+      velocityY: f64
+      velocityZ: f64
+      yaw: f32
+      pitch: f32
+      flags: ["bitfield", [
+         { "name": "relative_x", "size": 1, "signed": false },
+         { "name": "relative_y", "size": 1, "signed": false },
+         { "name": "relative_z", "size": 1, "signed": false },
+         { "name": "relative_yaw", "size": 1, "signed": false },
+         { "name": "relative_pitch", "size": 1, "signed": false },
+         { "name": "relative_velocity_x", "size": 1, "signed": false },
+         { "name": "relative_velocity_y", "size": 1, "signed": false },
+         { "name": "relative_velocity_z", "size": 1, "signed": false },
+         { "name": "rotate_velocity", "size": 1, "signed": false }
+      ]]
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -7923,12 +7923,77 @@
               "type": "f64"
             },
             {
+              "name": "velocityX",
+              "type": "f64"
+            },
+            {
+              "name": "velocityY",
+              "type": "f64"
+            },
+            {
+              "name": "velocityZ",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": [
+                "bitfield",
+                [
+                  {
+                    "name": "relative_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_yaw",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_pitch",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "rotate_velocity",
+                    "size": 1,
+                    "signed": false
+                  }
+                ]
+              ]
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.9/proto.yml
+++ b/data/pc/1.21.9/proto.yml
@@ -2815,8 +2815,22 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      velocityX: f64
+      velocityY: f64
+      velocityZ: f64
+      yaw: f32
+      pitch: f32
+      flags: ["bitfield", [
+         { "name": "relative_x", "size": 1, "signed": false },
+         { "name": "relative_y", "size": 1, "signed": false },
+         { "name": "relative_z", "size": 1, "signed": false },
+         { "name": "relative_yaw", "size": 1, "signed": false },
+         { "name": "relative_pitch", "size": 1, "signed": false },
+         { "name": "relative_velocity_x", "size": 1, "signed": false },
+         { "name": "relative_velocity_y", "size": 1, "signed": false },
+         { "name": "relative_velocity_z", "size": 1, "signed": false },
+         { "name": "rotate_velocity", "size": 1, "signed": false }
+      ]]
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.9/protocol.json
+++ b/data/pc/1.21.9/protocol.json
@@ -9056,12 +9056,77 @@
               "type": "f64"
             },
             {
+              "name": "velocityX",
+              "type": "f64"
+            },
+            {
+              "name": "velocityY",
+              "type": "f64"
+            },
+            {
+              "name": "velocityZ",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": [
+                "bitfield",
+                [
+                  {
+                    "name": "relative_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_yaw",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_pitch",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_x",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_y",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "relative_velocity_z",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "rotate_velocity",
+                    "size": 1,
+                    "signed": false
+                  }
+                ]
+              ]
             },
             {
               "name": "onGround",


### PR DESCRIPTION
Fixes partial packet errors for `entity_teleport` on versions **1.21.4 through 1.21.11** (reported in [mineflayer#3759](https://github.com/PrismarineJS/mineflayer/issues/3759): "Chunk size is 67 but only 33 was read" on 1.21.8).

The packet structure changed in 1.21.2 (per [minecraft.wiki Synchronize Vehicle Position](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Synchronize_Vehicle_Position) and confirmed against the NeoForge 1.21.5 javadoc for `ClientboundTeleportEntityPacket`): yaw/pitch became **f32** (previously i8), and three new `velocityX/Y/Z` doubles plus a **relative flags** bitfield were added before `onGround`.

**Verification:** the reporter's actual packet buffer (`768080808004c0...`) previously decoded with only 33 of 67 bytes read; with this fix it decodes the full vanilla structure (`entityId`, `x/y/z`, `velocityX/Y/Z`, `yaw/pitch`, `flags`, `onGround`) — the remaining 2 bytes are a non-standard server (Wolfx) extension.

Complements [PR #1154](https://github.com/PrismarineJS/minecraft-data/pull/1154) (which covers 1.21.3) by applying the same fix to all later versions: 1.21.4, 1.21.5, 1.21.6, 1.21.8, 1.21.9, 1.21.11.

Verified: all 6 versions regenerate cleanly (yaml/json in sync); protocolSync passes.