### PR TITLE
Fix packet_enchant_item enchantment field type for 1.21.11

### DIFF
--- a/data/pc/1.21.11/proto.yml
+++ b/data/pc/1.21.11/proto.yml
@@ -3429,7 +3429,7 @@
    # MC: ServerboundContainerButtonClickPacket
    packet_enchant_item:
       windowId: ContainerID
-      enchantment: i8
+      enchantment: varint
    # MC: ServerboundContainerClickPacket
    packet_window_click:
       windowId: ContainerID

--- a/data/pc/1.21.11/protocol.json
+++ b/data/pc/1.21.11/protocol.json
@@ -10547,7 +10547,7 @@
             },
             {
               "name": "enchantment",
-              "type": "i8"
+              "type": "varint"
             }
           ]
         ],


### PR DESCRIPTION
The enchantment (button ID) field in packet_enchant_item was declared as i8 for 1.21.11 only, an isolated regression relative to every other version (1.21.1-1.21.9, and later 26.1), all of which declare it as varint.

Confirmed against 1.21.11's own decompiled source: net/minecraft/network/packet/c2s/play/ButtonClickC2SPacket.java encodes buttonId with PacketCodecs.VAR_INT, matching every other checked version. There was no real protocol change here.
