### PR TITLE
Add chatCommandsQueuedToMainThread feature for 1.19.0

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -729,6 +729,11 @@
     "versions": ["1.19", "1.19.2"]
   },
   {
+    "name": "chatCommandsQueuedToMainThread",
+    "description": "server handles chat_command on the main thread but chat_message on the netty thread, so a chat message sent right after a command can update lastChatTimeStamp first and get the earlier command kicked as out_of_order_chat",
+    "versions": ["1.19", "1.19"]
+  },
+  {
     "name": "profileKeySignatureV2",
     "description": "uses `signatureV2` public key signature",
     "versions": [


### PR DESCRIPTION
Needed by PrismarineJS/mineflayer#4007 (requested in https://github.com/PrismarineJS/mineflayer/pull/4007#discussion_r3868521254): 1.19.0's `ServerGamePacketListenerImpl.handleChatCommand` re-queues to the main thread via `ensureRunningOnSameThread` before `tryHandleChat`, while `handleChat` runs `tryHandleChat` directly on the netty thread. A chat message that follows a command can therefore update `lastChatTimeStamp` first, and the earlier-stamped command is then rejected with `multiplayer.disconnect.out_of_order_chat`. 1.19.1+ replaced this with the ordered signed-message chain; pre-1.19 has no chat timestamps.