### PR TITLE
Remove uniqueItems from blockStates schema

### DIFF
--- a/schemas/blockStates_schema.json
+++ b/schemas/blockStates_schema.json
@@ -1,7 +1,6 @@
 {
   "title": "blockStates",
   "type": "array",
-  "uniqueItems": true,
   "items": {
     "title": "blockState",
     "type": "object",

--- a/tools/js/test/test.js
+++ b/tools/js/test/test.js
@@ -24,8 +24,6 @@ require('./version_iterator')(function (p, versionString) {
       }
       if (instance) {
         it(dataName + '.json is valid', function () {
-          // blockStates.json files are large (10k+ entries); give them more time
-          if (dataName === 'blockStates') this.timeout(180 * 1000)
           // Skip tints schema validation for PC 1.21.4, as it doesn't meet the
           // maxItems: 1 check for the constant tints.
           if (dataName === 'tints' && versionString === 'pc 1.21.4') {


### PR DESCRIPTION
## Problem

`npm test` takes ~9 minutes. ~425s of that is the 29 `blockStates.json is valid` tests (12–36s each).

The cause is `"uniqueItems": true` on the top-level array in `blockStates_schema.json`. Ajv 6 implements `uniqueItems` for object items with a pairwise deep-equal loop, so with ~17k entries per file it does ~140M comparisons.

Measured on `bedrock/1.26.30/blockStates.json` (16,913 entries) with ajv 6.15.0:

| | time |
|---|---|
| `uniqueItems: true` | 71,316 ms |
| `uniqueItems: false` | 11 ms |

## Change

- Drop `uniqueItems` from the schema. The data is generated and uniqueness of state entries isn't an invariant anything relies on (I checked all 29 distinct files: 0 duplicates).
- Remove the 180s per-test timeout bump in `test.js` that was added to accommodate this.

Expected effect: CI drops from ~10 min to ~2 min. The remaining time is dominated by `protocol.json is valid`, which is fixed upstream in ProtoDef-io/node-protodef-validator#18 and just needs a release + bump.