### PR TITLE
Add hasDataCommand and furnaceNbtUsesSnakeCase features

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -545,6 +545,14 @@
     ]
   },
   {
+    "name": "furnaceNbtUsesSnakeCase",
+    "description": "furnace block entity NBT keys are snake_case (cooking_time_spent) instead of PascalCase (CookTime)",
+    "versions": [
+      "1.21.4",
+      "latest"
+    ]
+  },
+  {
     "name": "gameRuleUsesResourceLocation",
     "description": "gamerule names use resource location syntax",
     "versions": [
@@ -573,6 +581,14 @@
     "description": "in 1.20.2, a new configuration state was added to allow configuration after login",
     "versions": [
       "1.20.2",
+      "latest"
+    ]
+  },
+  {
+    "name": "hasDataCommand",
+    "description": "has the /data command; block entity NBT is edited with /data merge block instead of /blockdata",
+    "versions": [
+      "1.13",
       "latest"
     ]
   },


### PR DESCRIPTION
Two features needed by PrismarineJS/mineflayer#3990 so the furnace test can use `bot.supportFeature` instead of hardcoded version comparisons:

- `hasDataCommand` (1.13+): `/blockdata` was replaced by `/data merge block` in 1.13.
- `furnaceNbtUsesSnakeCase` (1.21.4+): the furnace block entity's `CookTime` key became `cooking_time_spent` in 1.21.4 (1.21.3 still accepts `CookTime`; 1.21.4 does not).

Both boundaries were verified against real servers across all 28 versions in mineflayer's CI matrix in that PR.