### PR TITLE
Add enchantmentsComponentIsFlat and fishingBiteDelayMaxTicks features

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -940,5 +940,24 @@
     "name": "attackUsesOwnPacket",
     "description": "attack uses its own packet instead of interact",
     "versions": ["26.1", "latest"]
+  },
+  {
+    "name": "enchantmentsComponentIsFlat",
+    "description": "the minecraft:enchantments item component is a plain enchantment-to-level map instead of being wrapped in a levels key",
+    "versions": ["1.21.5", "latest"]
+  },
+  {
+    "name": "fishingBiteDelayMaxTicks",
+    "description": "inclusive upper bound of the random tick wait rolled before a fishing hook bites (lower bound is 100); each Lure level subtracts 100 ticks and a non-positive roll is rerolled next tick",
+    "values": [
+      {
+        "value": 900,
+        "versions": ["1.8_major", "1.8_major"]
+      },
+      {
+        "value": 600,
+        "versions": ["1.9", "latest"]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Needed by PrismarineJS/mineflayer#3997 so the fishing test can gate on features instead of version compares.

- `enchantmentsComponentIsFlat` (1.21.5+): the `minecraft:enchantments` component lost its `levels` wrapper in 1.21.5.
- `fishingBiteDelayMaxTicks` (900 on 1.8, 600 on 1.9+): the server rolls the bite wait as `nextInt(100, max)` and subtracts 100 ticks per Lure level, so the maximum viable Lure level per version derives from this.