### PR TITLE
Add quickMoveClickSendsEmptyItem, hasItemCommand and replaceItemSlotIsPrefixed features

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -601,6 +601,14 @@
     ]
   },
   {
+    "name": "hasItemCommand",
+    "description": "/replaceitem was replaced by /item replace",
+    "versions": [
+      "1.17",
+      "latest"
+    ]
+  },
+  {
     "name": "indexesVillagerRecipes",
     "description": "gives a index for each trade in a villagers metadata",
     "versions": [
@@ -872,6 +880,14 @@
     ]
   },
   {
+    "name": "quickMoveClickSendsEmptyItem",
+    "description": "the server accepts a quick-move (mode 1) window click only if the packet's item is empty; earlier versions expect the moved stack",
+    "versions": [
+      "1.12",
+      "1.16.5"
+    ]
+  },
+  {
     "name": "registryDataIsMandatory",
     "description": "The server needs to send the registry data to the client before sending the finish_configuration packet",
     "versions": [
@@ -885,6 +901,14 @@
     "versions": [
       "1.19.3",
       "latest"
+    ]
+  },
+  {
+    "name": "replaceItemSlotIsPrefixed",
+    "description": "the /replaceitem slot argument is prefixed with slot. (slot.container.0) and item names need the minecraft: namespace",
+    "versions": [
+      "1.8",
+      "1.12.2"
     ]
   },
   {


### PR DESCRIPTION
Three features needed by PrismarineJS/mineflayer#3979 so `lib/plugins/inventory.js` and the useChests test can use `bot.supportFeature` instead of hardcoded version comparisons:

- `quickMoveClickSendsEmptyItem` (1.12–1.16.5): for `actionIdUsed` versions the server accepts a click only if the packet's `item` matches the result of its own `slotClick`; for a quick move (mode 1) that is the moved stack up to 1.11 and empty from 1.12. From 1.17 the packet has no `item` field.
- `hasItemCommand` (1.17+): `/replaceitem` was replaced by `/item replace`.
- `replaceItemSlotIsPrefixed` (1.8–1.12.2): `/replaceitem` takes `slot.container.N` and a `minecraft:`-namespaced item name; 1.13 dropped the `slot.` prefix.

Boundaries verified against real servers on 1.8.8, 1.9.4, 1.11.2, 1.12.2, 1.16.5 and 26.1 locally and the rest of the 28-version matrix in that PR's CI.