### PR TITLE
test: fail if the suite takes over 40s

### DIFF
--- a/tools/js/package.json
+++ b/tools/js/package.json
@@ -14,7 +14,7 @@
     "ajv": "^6.5.4",
     "glob": "^10.2.6",
     "mocha": "^10.2.0",
-    "protodef-validator": "^1.2.2",
+    "protodef-validator": "^1.5.0",
     "standard": "^17.1.2"
   },
   "devDependencies": {

--- a/tools/js/test/test.js
+++ b/tools/js/test/test.js
@@ -11,6 +11,13 @@ const Validator = require('protodef-validator')
 
 Error.stackTraceLimit = 0
 
+// The suite used to take ~3min, almost all of it in protodef-validator < 1.5.0 (quadratic
+// dataType validation) and Ajv's O(n^2) uniqueItems. Fail if it ever gets that slow again.
+after('the test suite stays fast', function () {
+  const ms = performance.now() // measured from process start
+  assert.ok(ms < 40 * 1000, `the test suite took ${Math.round(ms)}ms, expected < 40s`)
+})
+
 const data = ['attributes', 'biomes', 'commands', 'instruments', 'items', 'materials', 'blocks', 'blockCollisionShapes', 'recipes', 'windows', 'entities', 'protocol', 'version', 'effects', 'enchantments', 'language', 'foods', 'particles', 'blockLoot', 'entityLoot', 'mapIcons', 'tints', 'blockMappings', 'sounds', 'blockStates']
 
 require('./version_iterator')(function (p, versionString) {


### PR DESCRIPTION
## Problem

The suite used to take ~3min. Almost all of that was protodef-validator < 1.5.0 validating `dataType` in time quadratic in the number of registered types (ProtoDef-io/node-protodef-validator#18), plus Ajv's O(n²) `uniqueItems` (removed in #1259). It now runs in ~20s, but nothing guards against that coming back.

## Change

- Require `protodef-validator@^1.5.0`.
- Root `after` hook asserts total suite wall-clock (`performance.now()`, measured from process start) stays under 40s — ~2x the current ~20s, while the old behaviour overshoots it by ~4x.

## Verification

- With 1.5.0: 1849 passing, suite in ~20s.
- With 1.4.0 installed the suite takes ~2m40s locally and the hook fails.