### PR TITLE
ci: cache Bedrock dedicated servers in bedrock-ci

### DIFF
--- a/.github/workflows/bedrock-ci.yml
+++ b/.github/workflows/bedrock-ci.yml
@@ -45,6 +45,14 @@ jobs:
       with:
         repository: PrismarineJS/bedrock-protocol
         path: bedrock-protocol
+    # Cache the downloaded+extracted Bedrock Dedicated Servers used by the tests
+    - name: Cache Bedrock dedicated servers
+      uses: actions/cache@v4
+      with:
+        path: bedrock-protocol/tools/bds-*
+        key: bds-servers-${{ hashFiles('node-mcdata/minecraft-data/data/bedrock/common/protocolVersions.json') }}
+        restore-keys: |
+          bds-servers-
     # I forget the correct install order, do both
     - name: Install bedrock-protocol
       run: |
@@ -57,3 +65,6 @@ jobs:
         curl -o node_modules/protodef/src/serializer.js https://raw.githubusercontent.com/extremeheat/node-protodef/refs/heads/dlog/src/serializer.js && curl -o node_modules/protodef/src/compiler.js https://raw.githubusercontent.com/extremeheat/node-protodef/refs/heads/dlog/src/compiler.js
         npm test
       working-directory: bedrock-protocol
+    # The extracted servers are enough for the tests; don't waste cache space on the zips
+    - name: Remove server zips before caching
+      run: rm -f bedrock-protocol/tools/bds-*/bds.zip


### PR DESCRIPTION
bedrock-ci takes ~8.5 minutes per run, ~7 of which is the bedrock-protocol test step. Profiling the step shows each of the 17 tested versions re-downloads its Bedrock Dedicated Server zip from minecraft.net on every run (the `🔻 Downloading` lines), before booting it.

This caches the extracted servers under `bedrock-protocol/tools/bds-*`, keyed on the bedrock `protocolVersions.json` so a version bump refreshes the cache (with a `restore-keys` prefix fallback so only the new version is downloaded). The `bds.zip` archives are deleted before the cache is saved since only the extracted servers are needed.

First run on this PR is a cache miss; re-running the job after it completes shows the cache-hit timing.