### PR TITLE
pc: fix intangible_projectile NBT and 26.1 item stack templates

### DIFF
--- a/data/pc/1.21.11/proto.yml
+++ b/data/pc/1.21.11/proto.yml
@@ -247,7 +247,7 @@
          if repair_cost: varint
          if creative_slot_lock: void
          if enchantment_glint_override: bool
-         if intangible_projectile: void
+         if intangible_projectile: anonymousNbt
          if blocks_attacks:
             blockDelaySeconds: f32
             disableCooldownScale: f32

--- a/data/pc/1.21.11/protocol.json
+++ b/data/pc/1.21.11/protocol.json
@@ -614,7 +614,7 @@
                 "repair_cost": "varint",
                 "creative_slot_lock": "void",
                 "enchantment_glint_override": "bool",
-                "intangible_projectile": "void",
+                "intangible_projectile": "anonymousNbt",
                 "blocks_attacks": [
                   "container",
                   [

--- a/data/pc/1.21.5/proto.yml
+++ b/data/pc/1.21.5/proto.yml
@@ -220,7 +220,7 @@
          if repair_cost: varint
          if creative_slot_lock: void
          if enchantment_glint_override: bool
-         if intangible_projectile: void
+         if intangible_projectile: anonymousNbt
          if blocks_attacks:
             blockDelaySeconds: f32
             disableCooldownScale: f32

--- a/data/pc/1.21.5/protocol.json
+++ b/data/pc/1.21.5/protocol.json
@@ -487,7 +487,7 @@
                 "repair_cost": "varint",
                 "creative_slot_lock": "void",
                 "enchantment_glint_override": "bool",
-                "intangible_projectile": "void",
+                "intangible_projectile": "anonymousNbt",
                 "blocks_attacks": [
                   "container",
                   [

--- a/data/pc/1.21.6/proto.yml
+++ b/data/pc/1.21.6/proto.yml
@@ -227,7 +227,7 @@
          if repair_cost: varint
          if creative_slot_lock: void
          if enchantment_glint_override: bool
-         if intangible_projectile: void
+         if intangible_projectile: anonymousNbt
          if blocks_attacks:
             blockDelaySeconds: f32
             disableCooldownScale: f32

--- a/data/pc/1.21.6/protocol.json
+++ b/data/pc/1.21.6/protocol.json
@@ -548,7 +548,7 @@
                 "repair_cost": "varint",
                 "creative_slot_lock": "void",
                 "enchantment_glint_override": "bool",
-                "intangible_projectile": "void",
+                "intangible_projectile": "anonymousNbt",
                 "blocks_attacks": [
                   "container",
                   [

--- a/data/pc/1.21.8/proto.yml
+++ b/data/pc/1.21.8/proto.yml
@@ -227,7 +227,7 @@
          if repair_cost: varint
          if creative_slot_lock: void
          if enchantment_glint_override: bool
-         if intangible_projectile: void
+         if intangible_projectile: anonymousNbt
          if blocks_attacks:
             blockDelaySeconds: f32
             disableCooldownScale: f32

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -548,7 +548,7 @@
                 "repair_cost": "varint",
                 "creative_slot_lock": "void",
                 "enchantment_glint_override": "bool",
-                "intangible_projectile": "void",
+                "intangible_projectile": "anonymousNbt",
                 "blocks_attacks": [
                   "container",
                   [

--- a/data/pc/1.21.9/proto.yml
+++ b/data/pc/1.21.9/proto.yml
@@ -228,7 +228,7 @@
          if repair_cost: varint
          if creative_slot_lock: void
          if enchantment_glint_override: bool
-         if intangible_projectile: void
+         if intangible_projectile: anonymousNbt
          if blocks_attacks:
             blockDelaySeconds: f32
             disableCooldownScale: f32

--- a/data/pc/1.21.9/protocol.json
+++ b/data/pc/1.21.9/protocol.json
@@ -549,7 +549,7 @@
                 "repair_cost": "varint",
                 "creative_slot_lock": "void",
                 "enchantment_glint_override": "bool",
-                "intangible_projectile": "void",
+                "intangible_projectile": "anonymousNbt",
                 "blocks_attacks": [
                   "container",
                   [

--- a/data/pc/26.1/protocol.json
+++ b/data/pc/26.1/protocol.json
@@ -612,7 +612,7 @@
                 "repair_cost": "varint",
                 "creative_slot_lock": "void",
                 "enchantment_glint_override": "bool",
-                "intangible_projectile": "void",
+                "intangible_projectile": "anonymousNbt",
                 "blocks_attacks": [
                   "container",
                   [
@@ -766,7 +766,7 @@
                     }
                   ]
                 ],
-                "use_remainder": "Slot",
+                "use_remainder": "ItemStackTemplate",
                 "use_cooldown": [
                   "container",
                   [
@@ -1098,7 +1098,7 @@
                         "array",
                         {
                           "countType": "varint",
-                          "type": "Slot"
+                          "type": "ItemStackTemplate"
                         }
                       ]
                     }
@@ -1113,7 +1113,7 @@
                         "array",
                         {
                           "countType": "varint",
-                          "type": "Slot"
+                          "type": "ItemStackTemplate"
                         }
                       ]
                     }
@@ -1468,7 +1468,10 @@
                         "array",
                         {
                           "countType": "varint",
-                          "type": "Slot"
+                          "type": [
+                            "option",
+                            "ItemStackTemplate"
+                          ]
                         }
                       ]
                     }
@@ -2317,6 +2320,55 @@
                         ]
                       }
                     ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    ],
+    "ItemStackTemplate": [
+      "container",
+      [
+        {
+          "name": "itemId",
+          "type": "varint"
+        },
+        {
+          "name": "itemCount",
+          "type": "varint"
+        },
+        {
+          "name": "addedComponentCount",
+          "type": "varint"
+        },
+        {
+          "name": "removedComponentCount",
+          "type": "varint"
+        },
+        {
+          "name": "components",
+          "type": [
+            "array",
+            {
+              "count": "addedComponentCount",
+              "type": "SlotComponent"
+            }
+          ]
+        },
+        {
+          "name": "removeComponents",
+          "type": [
+            "array",
+            {
+              "count": "removedComponentCount",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "type",
+                    "type": "SlotComponentType"
                   }
                 ]
               ]
@@ -3467,7 +3519,7 @@
                   ]
                 ],
                 "entity_effect": "i32",
-                "item": "Slot",
+                "item": "ItemStackTemplate",
                 "sculk_charge": "f32",
                 "shriek": "varint",
                 "vibration": [
@@ -3744,7 +3796,7 @@
                   "option",
                   "anonymousNbt"
                 ],
-                "item_stack": "Slot",
+                "item_stack": "ItemStackTemplate",
                 "boolean": "bool",
                 "rotations": [
                   "container",
@@ -5831,7 +5883,7 @@
                       ]
                     ],
                     "item": "varint",
-                    "item_stack": "Slot",
+                    "item_stack": "ItemStackTemplate",
                     "tag": "string",
                     "dyed_slot_demo": [
                       "container",
@@ -9593,7 +9645,7 @@
                                     },
                                     {
                                       "name": "icon",
-                                      "type": "Slot"
+                                      "type": "ItemStackTemplate"
                                     },
                                     {
                                       "name": "frameType",

--- a/data/pc/26.1/protocol.json
+++ b/data/pc/26.1/protocol.json
@@ -3796,7 +3796,7 @@
                   "option",
                   "anonymousNbt"
                 ],
-                "item_stack": "ItemStackTemplate",
+                "item_stack": "Slot",
                 "boolean": "bool",
                 "rotations": [
                   "container",

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -686,8 +686,7 @@
             removeComponents: []$removedComponentCount
                type: SlotComponentType
 
-   # 26.1 sends non-empty stacks (item stack templates) with the item id
-   # first; the optional, count-first Slot form is unchanged.
+   # Intentionally id-first, unlike the count-first Slot above — vanilla has both codecs.
    ItemStackTemplate:
       itemId: varint
       itemCount: varint

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -1183,7 +1183,7 @@
          if string: string
          if component: anonymousNbt
          if optional_component: ["option", "anonymousNbt"]
-         if item_stack: ItemStackTemplate
+         if item_stack: Slot
          if boolean: bool
          if rotations:
             pitch: f32

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -252,7 +252,7 @@
          if repair_cost: varint
          if creative_slot_lock: void
          if enchantment_glint_override: bool
-         if intangible_projectile: void
+         if intangible_projectile: anonymousNbt
          if blocks_attacks:
             blockDelaySeconds: f32
             disableCooldownScale: f32
@@ -291,7 +291,7 @@
             sound: ItemSoundHolder
             makes_particles: bool
             effects: ItemConsumeEffect[]varint
-         if use_remainder: Slot
+         if use_remainder: ItemStackTemplate
          if use_cooldown:
             seconds: f32
             cooldownGroup?: string
@@ -375,9 +375,9 @@
          if map_post_processing: varint
          if potion_duration_scale: f32
          if charged_projectiles:
-            projectiles: Slot[]varint
+            projectiles: ItemStackTemplate[]varint
          if bundle_contents:
-            contents: Slot[]varint
+            contents: ItemStackTemplate[]varint
          if potion_contents:
             # True if this potion has an ID in the potion registry--it has the default effects associated with the potion type.
             potionId?: varint
@@ -445,7 +445,7 @@
             # The ID of the items in the item registry.
             decorations: varint[]varint
          if container:
-            contents: Slot[]varint
+            contents: ["array", { "countType": "varint", "type": ["option", "ItemStackTemplate"] }]
          if block_state:
             properties: []varint
                name: string
@@ -685,6 +685,17 @@
             components: SlotComponent[]$addedComponentCount
             removeComponents: []$removedComponentCount
                type: SlotComponentType
+
+   # 26.1 sends non-empty stacks (item stack templates) with the item id
+   # first; the optional, count-first Slot form is unchanged.
+   ItemStackTemplate:
+      itemId: varint
+      itemCount: varint
+      addedComponentCount: varint
+      removedComponentCount: varint
+      components: SlotComponent[]$addedComponentCount
+      removeComponents: []$removedComponentCount
+         type: SlotComponentType
 
    HashedSlot:
       itemId: varint
@@ -1048,7 +1059,7 @@
             toGreen: f32
             toBlue: f32
          if entity_effect: i32
-         if item: Slot
+         if item: ItemStackTemplate
          if sculk_charge: f32
          if shriek: varint
          if vibration:
@@ -1172,7 +1183,7 @@
          if string: string
          if component: anonymousNbt
          if optional_component: ["option", "anonymousNbt"]
-         if item_stack: Slot
+         if item_stack: ItemStackTemplate
          if boolean: bool
          if rotations:
             pitch: f32
@@ -1976,7 +1987,7 @@
             source: SlotDisplay
             component: SlotComponentType
          if item: varint
-         if item_stack: Slot
+         if item_stack: ItemStackTemplate
          if tag: string
          if dyed_slot_demo:
             dye: SlotDisplay
@@ -2980,7 +2991,7 @@
             displayData?:
                title: anonymousNbt
                description: anonymousNbt
-               icon: Slot
+               icon: ItemStackTemplate
                frameType: varint
                flags: ["bitfield", [
                   { "name": "unused", "size": 29, "signed": false },


### PR DESCRIPTION
Two protocol fixes found by PrismarineJS/prismarine-item#184's live vanilla tests.

### intangible_projectile is NBT, not void (1.21.5–26.1)

The component has no dedicated network codec, so vanilla syncs it through its NBT codec — an empty compound (`0a 00`) on the wire. 1.20.5–1.21.4 correctly had `anonymousNbt` and 1.21.5 onward regressed to `void`, leaving two bytes unread in any slot carrying the component (protodef PartialReadError on `set_slot`). `unbreakable` and `glider` stay `void`: they have real unit stream codecs and decode cleanly today.

### 26.1 sends non-empty stacks as item stack templates (item id first)

26.1 changed the non-optional stack codec to item id, count, components; the optional count-first `Slot` form (`set_slot`, `window_items`, cursor, equipment, merchant offers, entity metadata) is unchanged. Before this fix, nested stacks decode with `itemId`/`itemCount` swapped — giving `bundle[bundle_contents=[{id:stone,count:3},{id:dirt}]]` parsed as item 3 ×1 and item 1 ×28.

This adds an `ItemStackTemplate` type and uses it where vanilla uses the template codec (cross-checked against MCProtocolLib's `readItemStackTemplate` call sites):

- `use_remainder`, `charged_projectiles`, `bundle_contents` components
- `container` component — now a **prefixed-optional** template per entry, preserving empty slots
- the `item` particle
- the `item_stack` slot display
- the advancement display icon

### Verification

Each site was checked against real vanilla servers (1.21.5, 1.21.6, 1.21.8, 1.21.9, 1.21.11, 26.1) by giving items carrying each component, granting an advancement and spawning item particles, then confirming the decoded ids and counts match what was given, with zero parse errors. On 26.1: stone(1)×3 + dirt(28)×1 bundle, shulker `container` decoding `[null, diamond(899)×5]`, advancement icons and `minecraft:item` particle all correct. prismarine-item#184's 78 live window_click hash tests still pass against 1.21.5/1.21.11 with these files, now with no PartialReadErrors.

`protocol.json` files are regenerated from the edited `proto.yml`s via `npm run build`; `tools/js` tests pass (the only local failure is the 40s suite-duration gate, from running Minecraft servers concurrently on the same machine).