### PR TITLE
pc/protocol: entity_teleport layout for 1.21.2+ (velocity, f32 rotation, relative flags)

### DIFF
--- a/data/pc/1.21.11/proto.yml
+++ b/data/pc/1.21.11/proto.yml
@@ -2889,8 +2889,12 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      dx: f64
+      dy: f64
+      dz: f64
+      yaw: f32
+      pitch: f32
+      flags: PositionUpdateRelatives
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.11/protocol.json
+++ b/data/pc/1.21.11/protocol.json
@@ -9334,12 +9334,28 @@
               "type": "f64"
             },
             {
+              "name": "dx",
+              "type": "f64"
+            },
+            {
+              "name": "dy",
+              "type": "f64"
+            },
+            {
+              "name": "dz",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": "PositionUpdateRelatives"
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.3/proto.yml
+++ b/data/pc/1.21.3/proto.yml
@@ -2388,8 +2388,12 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      dx: f64
+      dy: f64
+      dz: f64
+      yaw: f32
+      pitch: f32
+      flags: PositionUpdateRelatives
       onGround: bool
    # MC: ClientboundTickingStatePacket
    packet_set_ticking_state:

--- a/data/pc/1.21.3/protocol.json
+++ b/data/pc/1.21.3/protocol.json
@@ -7344,12 +7344,28 @@
               "type": "f64"
             },
             {
+              "name": "dx",
+              "type": "f64"
+            },
+            {
+              "name": "dy",
+              "type": "f64"
+            },
+            {
+              "name": "dz",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": "PositionUpdateRelatives"
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.4/proto.yml
+++ b/data/pc/1.21.4/proto.yml
@@ -2394,8 +2394,12 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      dx: f64
+      dy: f64
+      dz: f64
+      yaw: f32
+      pitch: f32
+      flags: PositionUpdateRelatives
       onGround: bool
    # MC: ClientboundTickingStatePacket
    packet_set_ticking_state:

--- a/data/pc/1.21.4/protocol.json
+++ b/data/pc/1.21.4/protocol.json
@@ -7370,12 +7370,28 @@
               "type": "f64"
             },
             {
+              "name": "dx",
+              "type": "f64"
+            },
+            {
+              "name": "dy",
+              "type": "f64"
+            },
+            {
+              "name": "dz",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": "PositionUpdateRelatives"
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.5/proto.yml
+++ b/data/pc/1.21.5/proto.yml
@@ -2502,8 +2502,12 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      dx: f64
+      dy: f64
+      dz: f64
+      yaw: f32
+      pitch: f32
+      flags: PositionUpdateRelatives
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.5/protocol.json
+++ b/data/pc/1.21.5/protocol.json
@@ -7727,12 +7727,28 @@
               "type": "f64"
             },
             {
+              "name": "dx",
+              "type": "f64"
+            },
+            {
+              "name": "dy",
+              "type": "f64"
+            },
+            {
+              "name": "dz",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": "PositionUpdateRelatives"
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.6/proto.yml
+++ b/data/pc/1.21.6/proto.yml
@@ -2545,8 +2545,12 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      dx: f64
+      dy: f64
+      dz: f64
+      yaw: f32
+      pitch: f32
+      flags: PositionUpdateRelatives
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.6/protocol.json
+++ b/data/pc/1.21.6/protocol.json
@@ -7906,12 +7906,28 @@
               "type": "f64"
             },
             {
+              "name": "dx",
+              "type": "f64"
+            },
+            {
+              "name": "dy",
+              "type": "f64"
+            },
+            {
+              "name": "dz",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": "PositionUpdateRelatives"
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.8/proto.yml
+++ b/data/pc/1.21.8/proto.yml
@@ -2545,8 +2545,12 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      dx: f64
+      dy: f64
+      dz: f64
+      yaw: f32
+      pitch: f32
+      flags: PositionUpdateRelatives
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -7903,12 +7903,28 @@
               "type": "f64"
             },
             {
+              "name": "dx",
+              "type": "f64"
+            },
+            {
+              "name": "dy",
+              "type": "f64"
+            },
+            {
+              "name": "dz",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": "PositionUpdateRelatives"
             },
             {
               "name": "onGround",

--- a/data/pc/1.21.9/proto.yml
+++ b/data/pc/1.21.9/proto.yml
@@ -2810,8 +2810,12 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      dx: f64
+      dy: f64
+      dz: f64
+      yaw: f32
+      pitch: f32
+      flags: PositionUpdateRelatives
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:

--- a/data/pc/1.21.9/protocol.json
+++ b/data/pc/1.21.9/protocol.json
@@ -9036,12 +9036,28 @@
               "type": "f64"
             },
             {
+              "name": "dx",
+              "type": "f64"
+            },
+            {
+              "name": "dy",
+              "type": "f64"
+            },
+            {
+              "name": "dz",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": "PositionUpdateRelatives"
             },
             {
               "name": "onGround",

--- a/data/pc/26.1/protocol.json
+++ b/data/pc/26.1/protocol.json
@@ -9473,12 +9473,28 @@
               "type": "f64"
             },
             {
+              "name": "dx",
+              "type": "f64"
+            },
+            {
+              "name": "dy",
+              "type": "f64"
+            },
+            {
+              "name": "dz",
+              "type": "f64"
+            },
+            {
               "name": "yaw",
-              "type": "i8"
+              "type": "f32"
             },
             {
               "name": "pitch",
-              "type": "i8"
+              "type": "f32"
+            },
+            {
+              "name": "flags",
+              "type": "PositionUpdateRelatives"
             },
             {
               "name": "onGround",

--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -437,6 +437,14 @@
     ]
   },
   {
+    "name": "entityTeleportHasRelativeFlags",
+    "description": "entity_teleport carries velocity, float rotation and relative flags like the player position packet",
+    "versions": [
+      "1.21.3",
+      "latest"
+    ]
+  },
+  {
     "name": "entityVelocityIsLpVec3",
     "description": "entity velocity packets use length-prefixed vectors in blocks per tick",
     "versions": [

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -2950,8 +2950,12 @@
       x: f64
       y: f64
       z: f64
-      yaw: i8
-      pitch: i8
+      dx: f64
+      dy: f64
+      dz: f64
+      yaw: f32
+      pitch: f32
+      flags: PositionUpdateRelatives
       onGround: bool
    # MC: ClientboundTestInstanceBlockStatusPacket
    packet_test_instance_block_status:


### PR DESCRIPTION
Since 1.21.2 `ClientboundTeleportEntityPacket` has the same layout as the player position packet: `PositionMoveRotation` (position, delta movement, f32 yaw/pitch), a `Set<Relative>` written as a 32-bit int, then `onGround`. minecraft-data still described the pre-1.21.2 layout (i8 rotation, no velocity, no flags), so every `entity_teleport` on 1.21.3+ fails to parse (`Chunk size is 67 but only 33 was read`, PrismarineJS/mineflayer#3759).

Verified against a captured 1.21.4 packet from a Velocity/ViaVersion network:

```
77                         packet id
97 80 80 80 04             entityId varint (5 bytes)
c02fef0a40000000 ... x3    x y z
0000000000000000 ... x3    dx dy dz
c2b40000 00000000          yaw pitch (f32)
00000000                   relatives (i32)
01                         onGround
```

1 + 5 + 24 + 24 + 8 + 4 + 1 = 67, which is the chunk size in the error. The flags field reuses `PositionUpdateRelatives` (already defined for `packet_position` on these versions), so consumers can treat both packets the same way.

Applied to 1.21.3 through 1.21.11 (`proto.yml`, `protocol.json` rebuilt with `npm run build`) and 26.1 (`protocol.json` only, it has no `proto.yml`). Decompiled 26.1 `ClientboundTeleportEntityPacket` / `Relative.SET_STREAM_CODEC = ByteBufCodecs.INT` confirm the same layout there.

Relation to the open PRs: #1154 covers only 1.21.3; #1251 covers 1.21.4–1.21.11 but encodes the relatives as a 9-bit `bitfield`, which protodef reads as 2 bytes, not the 4 bytes vanilla writes, so those packets would still be partial reads. This PR supersedes both.

The mineflayer side (consuming the relative flags in the `entity_teleport` handler) is in a separate PR.