### PR TITLE
pc/protocol: cookie_response value is optional on 1.21.8

### DIFF
--- a/data/pc/1.21.8/proto.yml
+++ b/data/pc/1.21.8/proto.yml
@@ -1273,7 +1273,7 @@
    # MC: ServerboundCookieResponsePacket
    packet_common_cookie_response:
       key: string
-      value: ByteArray
+      value?: ByteArray
    # MC: ServerboundSelectKnownPacks
    # MC: ClientboundSelectKnownPacks
    packet_common_select_known_packs:

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -3403,7 +3403,10 @@
         },
         {
           "name": "value",
-          "type": "ByteArray"
+          "type": [
+            "option",
+            "ByteArray"
+          ]
         }
       ]
     ],


### PR DESCRIPTION
`packet_common_cookie_response.value` is declared as a plain `ByteArray` on 1.21.8 only; 1.21.5, 1.21.6, 1.21.9 and later have `value?: ByteArray`. The 1.21.8 client writes it with `writeNullable` like every other version (`ServerboundCookieResponsePacket.STREAM_CODEC` / `write`), so a client answering a `cookie_request` with a stored cookie serializes it wrong on 1.21.8 and a server-side reader turns vanilla's null into an empty array. Found while adding cookie replies to node-minecraft-protocol (PrismarineJS/node-minecraft-protocol#1522). `proto.yml` and `protocol.json` updated; `tools/js` tests pass.