### PR TITLE
features: sneakUsesEntityAction for 1.8 through 1.21.5

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -1064,6 +1064,14 @@
     ]
   },
   {
+    "name": "sneakUsesEntityAction",
+    "description": "the server sets the sneak state from entity_action PRESS_SHIFT_KEY / RELEASE_SHIFT_KEY (actionId 0 / 1); from 1.21.6 it reads the shift bit of player_input instead and the entity_action mapper has no shift entries",
+    "versions": [
+      "1.8",
+      "1.21.5"
+    ]
+  },
+  {
     "name": "spawnEggsHaveSpawnedEntityInName",
     "description": "in newer versions, spawn eggs have the entity they spawn in their name, ex: 'squid_spawn_egg'",
     "versions": [


### PR DESCRIPTION
Adds \`sneakUsesEntityAction\` (\`1.8\` through \`1.21.5\`).

Up to 1.21.5 the server sets the player's sneak state from \`entity_action\` \`PRESS_SHIFT_KEY\` / \`RELEASE_SHIFT_KEY\` (\`ServerGamePacketListenerImpl.handlePlayerCommand\`); the shift bit of \`player_input\` (1.21.2+) is only stored as \`lastClientInput\`. From 1.21.6 the server reads the sneak state from \`player_input\` (\`handlePlayerInput\` → \`setShiftKeyDown\`) and the \`entity_action\` mapper no longer has the shift entries (\`0\` is \`leave_bed\` there), so a client that wants server-side sneaking has to send \`entity_action\` up to 1.21.5 and must not from 1.21.6.

The range ends at 1.21.5 rather than starting at 1.21.6 on purpose: a consumer running on a minecraft-data release without this feature gets \`false\` and simply keeps sending nothing, instead of sending a numeric \`actionId\` into the 1.21.6+ string mapper.

Consumer: PrismarineJS/mineflayer#4063, which currently does this with \`registry.version['>=']('1.21.6')\` inline.