### PR TITLE
bedrock: fix legacy conditional packet payloads

### DIFF
--- a/data/bedrock/1.16.201/proto.yml
+++ b/data/bedrock/1.16.201/proto.yml
@@ -1283,7 +1283,7 @@ packet_boss_event:
    _: type?
       if register_player or unregister_player:
          player_id: zigzag64
-      if show:
+      if show_bar:
          title: string
          bar_progress: lf32
       if update_properties:

--- a/data/bedrock/1.16.201/protocol.json
+++ b/data/bedrock/1.16.201/protocol.json
@@ -1846,7 +1846,7 @@
                       {
                         "compareTo": "type",
                         "fields": {
-                          "remove": [
+                          "change": [
                             "container",
                             [
                               {
@@ -5248,7 +5248,7 @@
                     }
                   ]
                 ],
-                "show": [
+                "show_bar": [
                   "container",
                   [
                     {

--- a/data/bedrock/1.16.201/types.yml
+++ b/data/bedrock/1.16.201/types.yml
@@ -565,7 +565,7 @@ ScoreEntries:
       objective_name: string
       score: li32
       _: type?
-         if remove:
+         if change:
             entry_type: i8 =>
                1: player
                2: entity

--- a/data/bedrock/1.16.210/proto.yml
+++ b/data/bedrock/1.16.210/proto.yml
@@ -1322,7 +1322,7 @@ packet_boss_event:
    _: type?
       if register_player or unregister_player:
          player_id: zigzag64
-      if show:
+      if show_bar:
          title: string
          bar_progress: lf32
       if update_properties:

--- a/data/bedrock/1.16.210/protocol.json
+++ b/data/bedrock/1.16.210/protocol.json
@@ -1986,7 +1986,7 @@
                       {
                         "compareTo": "type",
                         "fields": {
-                          "remove": [
+                          "change": [
                             "container",
                             [
                               {
@@ -5547,7 +5547,7 @@
                     }
                   ]
                 ],
-                "show": [
+                "show_bar": [
                   "container",
                   [
                     {

--- a/data/bedrock/1.16.210/types.yml
+++ b/data/bedrock/1.16.210/types.yml
@@ -707,7 +707,7 @@ ScoreEntries:
       objective_name: string
       score: li32
       _: type?
-         if remove:
+         if change:
             entry_type: i8 =>
                1: player
                2: entity


### PR DESCRIPTION
- select the 1.16.201 and 1.16.210 boss-event payload using the mapped `show_bar` value;
- decode score identity fields for `change` entries instead of `remove`;
- regenerate protocol JSON and add regression coverage for both versions.

The released schemas decode boss IDs but discard title/progress, while score changes lose the identity fields required to associate scores with players or custom names. Bedrock 1.16.220 already uses the corrected boss selector.