### PR TITLE
Add features for 26.1's string-mapped client_command and use_entity ids

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -56,6 +56,22 @@
     ]
   },
   {
+    "name": "clientCommandUsesStringMapper",
+    "description": "client_command packet uses string mappings instead of a numeric actionId",
+    "versions": [
+      "26.1",
+      "latest"
+    ]
+  },
+  {
+    "name": "useEntityUsesStringMapper",
+    "description": "use_entity packet uses string mappings instead of a numeric hand",
+    "versions": [
+      "26.1",
+      "latest"
+    ]
+  },
+  {
     "name": "attributeSnakeCase",
     "description": "entity attributes are in snake case",
     "versions": [


### PR DESCRIPTION
26.1's protocol maps two more serverbound action ids to strings, the way `entity_action` already does since 1.21.6:

```json
"packet_client_command": ["container", [{"name": "actionId", "type": ["mapper", {"type": "varint", "mappings": {"0": "perform_respawn", "1": "request_stats", "2": "request_gamerule_values"}}]}]]
"packet_use_entity":     ["container", [{"name": "target", "type": "varint"}, {"name": "hand", "type": ["mapper", {"type": "varint", "mappings": {"0": "main_hand", "1": "off_hand"}}]}, ...]]
```

A client that keeps writing the numeric id gets `SizeOf error for undefined : 0 is not in the mappings value` and the packet is never sent, so on 26.1 mineflayer currently cannot respawn or right-click an entity at all. These two features let it pick the right shape the same way `entityActionUsesStringMapper` does.

Checked against every `pc` protocol.json in this repo: `client_command.actionId` and `use_entity.hand` are mappers on 26.1 only.

Data only, no code changes. Consumed by PrismarineJS/mineflayer#4077.