### PR TITLE
features: clientCommandUsesStringMapper from 26.1

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -381,6 +381,14 @@
     ]
   },
   {
+    "name": "clientCommandUsesStringMapper",
+    "description": "client_command packet uses string mappings instead of numeric actionId",
+    "versions": [
+      "26.1",
+      "latest"
+    ]
+  },
+  {
     "name": "entityCamelCase",
     "description": "entity names are in camel case",
     "versions": [


### PR DESCRIPTION
26.1 declares `packet_client_command.actionId` as a string mapper (`perform_respawn`/`request_stats`/`request_gamerule_values`), where 1.21.11 and earlier declare a plain varint. Consumers need to know which one to write: protodef's interpreted mapper writer, and the compiled one since ProtoDef-io/node-protodef#176, throw `0 is not in the mappings value` on the numeric form.

This mirrors `entityActionUsesStringMapper`, which covers the same change to `entity_action` in 1.21.6.