### PR TITLE
pc/26.1: use_entity.hand and client_command.actionId are varints, as on every other version

### DIFF
--- a/data/pc/26.1/protocol.json
+++ b/data/pc/26.1/protocol.json
@@ -10645,17 +10645,7 @@
           [
             {
               "name": "actionId",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "perform_respawn",
-                    "1": "request_stats",
-                    "2": "request_gamerule_values"
-                  }
-                }
-              ]
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/26.1/protocol.json
+++ b/data/pc/26.1/protocol.json
@@ -10852,16 +10852,7 @@
             },
             {
               "name": "hand",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "main_hand",
-                    "1": "off_hand"
-                  }
-                }
-              ]
+              "type": "varint"
             },
             {
               "name": "location",


### PR DESCRIPTION
Two serverbound fields are declared as `mapper` on 26.1 and as plain `varint` on every other version, including 1.21.11 immediately before it. Neither packet changed on the wire; only the JS value a client has to supply did.

- `play.toServer.packet_use_entity.hand` — the only `hand` field in any version or direction that is not a `varint`. `edit_book`, `arm_animation`, `block_place`, `use_item` and `open_book` are all `varint` on 26.1 itself.
- `play.toServer.packet_client_command.actionId` — `varint` on 1.21.8, 1.21.9 and 1.21.11.

A client that writes the numeric value — what every other version and every sibling field takes — hits `SizeOf error for undefined : 0 is not in the mappings value` in protodef, which errors the serializer stream and drops the connection. In mineflayer that is every `bot.activateEntity` (villager shops, NPCs, mounts) and every `bot.respawn`, so on 26.1 a bot loses its connection the first time it interacts with an entity or dies.

Round trip after the change, through mineflayer's 26.1 serializer:

```
use_entity     {target: 1234, hand: 0, location: {x: 0.1, y: 1.2, z: 0.3}, sneaking: false}
               1a d2 09 00 92 19 93 31 99 96 00   -> parses back to the same values
client_command {actionId: 0}
               0c 00
```

Verified against a live 26.1 server: before the change `bot.activateEntity(villager)` threw in `Serializer._transform` and the socket closed; after it, the shop window opens.
