### PR TITLE
Add the useEntityHasLocation feature

### DIFF
--- a/data/pc/common/features.json
+++ b/data/pc/common/features.json
@@ -1292,6 +1292,14 @@
     ]
   },
   {
+    "name": "useEntityHasLocation",
+    "description": "use_entity carries the hit location, replacing the interact_at then interact pair",
+    "versions": [
+      "26.1",
+      "latest"
+    ]
+  },
+  {
     "name": "useItemWithBlockPlace",
     "description": "use item is done with block place packet",
     "versions": [


### PR DESCRIPTION
26.1's \`use_entity\` is the interact packet with the hit \`location\` inside it; the \`interact_at\` then \`interact\` pair of earlier versions no longer exists (attack is its own packet, covered by \`attackUsesOwnPacket\`).

\`\`\`json
{
  "name": "useEntityHasLocation",
  "description": "use_entity carries the hit location, replacing the interact_at then interact pair",
  "versions": ["26.1", "latest"]
}
\`\`\`

Used by PrismarineJS/mineflayer#4089 to pick which packets \`bot.activateEntity\` sends.