### PR TITLE
Fix pc/26.1 client_command actionId: plain varint, not a mapper

### DIFF
--- a/data/pc/26.1/protocol.json
+++ b/data/pc/26.1/protocol.json
@@ -10645,17 +10645,7 @@
           [
             {
               "name": "actionId",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "perform_respawn",
-                    "1": "request_stats",
-                    "2": "request_gamerule_values"
-                  }
-                }
-              ]
+              "type": "varint"
             }
           ]
         ],

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -3478,10 +3478,7 @@
       chunksPerTick: f32
    # MC: ServerboundClientCommandPacket
    packet_client_command:
-      actionId: varint =>
-         - perform_respawn
-         - request_stats
-         - request_gamerule_values
+      actionId: varint
    # MC: ServerboundClientTickEndPacket
    packet_tick_end:
       # Empty


### PR DESCRIPTION
- `packet_client_command.actionId` in pc/26.1 is a `varint`, as in every other pc protocol.json (1.9 through 1.21.11).
- The wire format is unchanged: vanilla 26.1 writes the `Action` enum ordinal (`writeEnum`), so 0 = perform_respawn, 1 = request_stats, 2 = request_gamerule_values.
- A client that writes `actionId: 0` serializes on 26.1; with the mapper it threw `SizeOf error for undefined : 0 is not in the mappings value`, the serializer stream errored and the server timed the connection out (`disconnect.timeout`).

Verified against a local vanilla 26.1 server: `/kill` on a mineflayer bot now ends in a clean auto-respawn (health 20, alive, no serializer error). The protocol passes `protodef-validator` with the repo's extra types.

Sibling of #1278, which does the same for `use_entity.hand`, the only other 26.1-only mapper in toServer.
