### PR TITLE
Revert the 1.21.6 enum mappers whose ordinals never moved

### DIFF
--- a/data/pc/1.21.11/proto.yml
+++ b/data/pc/1.21.11/proto.yml
@@ -2055,11 +2055,7 @@
          default: void
    # MC: ClientboundChangeDifficultyPacket
    packet_difficulty:
-      difficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      difficulty: u8
       difficultyLocked: bool
    # MC: ClientboundChunkBatchFinishedPacket
    packet_chunk_batch_finished:
@@ -2221,21 +2217,8 @@
       chunkX: i32
    # MC: ClientboundGameEventPacket
    packet_game_state_change:
-      reason: u8 =>
-         0: no_respawn_block_available
-         1: start_raining
-         2: stop_raining
-         3: change_game_mode
-         4: win_game
-         5: demo_event
-         6: play_arrow_hit_sound
-         7: rain_level_change
-         8: thunder_level_change
-         9: puffer_fish_sting
-         10: guardian_elder_effect
-         11: immediate_respawn
-         12: limited_crafting
-         13: level_chunks_load_start
+      #TODO: Should be a mapper
+      reason: u8
       gameMode: f32
    # MC: ClientboundGameTestHighlightPosPacket
    packet_game_test_highlight_pos:
@@ -2268,13 +2251,7 @@
       x: i32
       z: i32
       heightmaps: []varint
-         type: varint =>
-            0: world_surface_wg
-            1: world_surface
-            2: ocean_floor_wg
-            3: ocean_floor
-            4: motion_blocking
-            5: motion_blocking_no_leaves
+         type: varint
          data: i64[]varint
       chunkData: ByteArray
       blockEntities: chunkBlockEntity[]varint
@@ -3340,11 +3317,7 @@
       selectedItemIndex: varint
    # MC: ServerboundChangeDifficultyPacket
    packet_set_difficulty:
-      newDifficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      newDifficulty: u8
    # MC: ServerboundChangeGameModePacket
    packet_change_gamemode:
       mode: varint =>

--- a/data/pc/1.21.11/protocol.json
+++ b/data/pc/1.21.11/protocol.json
@@ -6246,18 +6246,7 @@
           [
             {
               "name": "difficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "difficultyLocked",
@@ -6854,28 +6843,7 @@
           [
             {
               "name": "reason",
-              "type": [
-                "mapper",
-                {
-                  "type": "u8",
-                  "mappings": {
-                    "0": "no_respawn_block_available",
-                    "1": "start_raining",
-                    "2": "stop_raining",
-                    "3": "change_game_mode",
-                    "4": "win_game",
-                    "5": "demo_event",
-                    "6": "play_arrow_hit_sound",
-                    "7": "rain_level_change",
-                    "8": "thunder_level_change",
-                    "9": "puffer_fish_sting",
-                    "10": "guardian_elder_effect",
-                    "11": "immediate_respawn",
-                    "12": "limited_crafting",
-                    "13": "level_chunks_load_start"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "gameMode",
@@ -6994,20 +6962,7 @@
                     [
                       {
                         "name": "type",
-                        "type": [
-                          "mapper",
-                          {
-                            "type": "varint",
-                            "mappings": {
-                              "0": "world_surface_wg",
-                              "1": "world_surface",
-                              "2": "ocean_floor_wg",
-                              "3": "ocean_floor",
-                              "4": "motion_blocking",
-                              "5": "motion_blocking_no_leaves"
-                            }
-                          }
-                        ]
+                        "type": "varint"
                       },
                       {
                         "name": "data",
@@ -10290,18 +10245,7 @@
           [
             {
               "name": "newDifficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/1.21.6/proto.yml
+++ b/data/pc/1.21.6/proto.yml
@@ -1739,11 +1739,7 @@
          default: void
    # MC: ClientboundChangeDifficultyPacket
    packet_difficulty:
-      difficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      difficulty: u8
       difficultyLocked: bool
    # MC: ClientboundChunkBatchFinishedPacket
    packet_chunk_batch_finished:
@@ -1882,21 +1878,8 @@
       chunkX: i32
    # MC: ClientboundGameEventPacket
    packet_game_state_change:
-      reason: u8 =>
-         0: no_respawn_block_available
-         1: start_raining
-         2: stop_raining
-         3: change_game_mode
-         4: win_game
-         5: demo_event
-         6: play_arrow_hit_sound
-         7: rain_level_change
-         8: thunder_level_change
-         9: puffer_fish_sting
-         10: guardian_elder_effect
-         11: immediate_respawn
-         12: limited_crafting
-         13: level_chunks_load_start
+      #TODO: Should be a mapper
+      reason: u8
       gameMode: f32
    # MC: ClientboundHorseScreenOpenPacket
    packet_open_horse_window:
@@ -1925,13 +1908,7 @@
       x: i32
       z: i32
       heightmaps: []varint
-         type: varint =>
-            0: world_surface_wg
-            1: world_surface
-            2: ocean_floor_wg
-            3: ocean_floor
-            4: motion_blocking
-            5: motion_blocking_no_leaves
+         type: varint
          data: i64[]varint
       chunkData: ByteArray
       blockEntities: chunkBlockEntity[]varint
@@ -2988,11 +2965,7 @@
       selectedItemIndex: varint
    # MC: ServerboundChangeDifficultyPacket
    packet_set_difficulty:
-      newDifficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      newDifficulty: u8
    # MC: ServerboundChangeGameModePacket
    packet_change_gamemode:
       mode: varint =>

--- a/data/pc/1.21.6/protocol.json
+++ b/data/pc/1.21.6/protocol.json
@@ -4923,18 +4923,7 @@
           [
             {
               "name": "difficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "difficultyLocked",
@@ -5443,28 +5432,7 @@
           [
             {
               "name": "reason",
-              "type": [
-                "mapper",
-                {
-                  "type": "u8",
-                  "mappings": {
-                    "0": "no_respawn_block_available",
-                    "1": "start_raining",
-                    "2": "stop_raining",
-                    "3": "change_game_mode",
-                    "4": "win_game",
-                    "5": "demo_event",
-                    "6": "play_arrow_hit_sound",
-                    "7": "rain_level_change",
-                    "8": "thunder_level_change",
-                    "9": "puffer_fish_sting",
-                    "10": "guardian_elder_effect",
-                    "11": "immediate_respawn",
-                    "12": "limited_crafting",
-                    "13": "level_chunks_load_start"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "gameMode",
@@ -5570,20 +5538,7 @@
                     [
                       {
                         "name": "type",
-                        "type": [
-                          "mapper",
-                          {
-                            "type": "varint",
-                            "mappings": {
-                              "0": "world_surface_wg",
-                              "1": "world_surface",
-                              "2": "ocean_floor_wg",
-                              "3": "ocean_floor",
-                              "4": "motion_blocking",
-                              "5": "motion_blocking_no_leaves"
-                            }
-                          }
-                        ]
+                        "type": "varint"
                       },
                       {
                         "name": "data",
@@ -8860,18 +8815,7 @@
           [
             {
               "name": "newDifficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/1.21.8/proto.yml
+++ b/data/pc/1.21.8/proto.yml
@@ -1739,11 +1739,7 @@
          default: void
    # MC: ClientboundChangeDifficultyPacket
    packet_difficulty:
-      difficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      difficulty: u8
       difficultyLocked: bool
    # MC: ClientboundChunkBatchFinishedPacket
    packet_chunk_batch_finished:
@@ -1882,21 +1878,8 @@
       chunkX: i32
    # MC: ClientboundGameEventPacket
    packet_game_state_change:
-      reason: u8 =>
-         0: no_respawn_block_available
-         1: start_raining
-         2: stop_raining
-         3: change_game_mode
-         4: win_game
-         5: demo_event
-         6: play_arrow_hit_sound
-         7: rain_level_change
-         8: thunder_level_change
-         9: puffer_fish_sting
-         10: guardian_elder_effect
-         11: immediate_respawn
-         12: limited_crafting
-         13: level_chunks_load_start
+      #TODO: Should be a mapper
+      reason: u8
       gameMode: f32
    # MC: ClientboundHorseScreenOpenPacket
    packet_open_horse_window:
@@ -1925,13 +1908,7 @@
       x: i32
       z: i32
       heightmaps: []varint
-         type: varint =>
-            0: world_surface_wg
-            1: world_surface
-            2: ocean_floor_wg
-            3: ocean_floor
-            4: motion_blocking
-            5: motion_blocking_no_leaves
+         type: varint
          data: i64[]varint
       chunkData: ByteArray
       blockEntities: chunkBlockEntity[]varint
@@ -2988,11 +2965,7 @@
       selectedItemIndex: varint
    # MC: ServerboundChangeDifficultyPacket
    packet_set_difficulty:
-      newDifficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      newDifficulty: u8
    # MC: ServerboundChangeGameModePacket
    packet_change_gamemode:
       mode: varint =>

--- a/data/pc/1.21.8/protocol.json
+++ b/data/pc/1.21.8/protocol.json
@@ -4923,18 +4923,7 @@
           [
             {
               "name": "difficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "difficultyLocked",
@@ -5443,28 +5432,7 @@
           [
             {
               "name": "reason",
-              "type": [
-                "mapper",
-                {
-                  "type": "u8",
-                  "mappings": {
-                    "0": "no_respawn_block_available",
-                    "1": "start_raining",
-                    "2": "stop_raining",
-                    "3": "change_game_mode",
-                    "4": "win_game",
-                    "5": "demo_event",
-                    "6": "play_arrow_hit_sound",
-                    "7": "rain_level_change",
-                    "8": "thunder_level_change",
-                    "9": "puffer_fish_sting",
-                    "10": "guardian_elder_effect",
-                    "11": "immediate_respawn",
-                    "12": "limited_crafting",
-                    "13": "level_chunks_load_start"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "gameMode",
@@ -5570,20 +5538,7 @@
                     [
                       {
                         "name": "type",
-                        "type": [
-                          "mapper",
-                          {
-                            "type": "varint",
-                            "mappings": {
-                              "0": "world_surface_wg",
-                              "1": "world_surface",
-                              "2": "ocean_floor_wg",
-                              "3": "ocean_floor",
-                              "4": "motion_blocking",
-                              "5": "motion_blocking_no_leaves"
-                            }
-                          }
-                        ]
+                        "type": "varint"
                       },
                       {
                         "name": "data",
@@ -8860,18 +8815,7 @@
           [
             {
               "name": "newDifficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/1.21.9/proto.yml
+++ b/data/pc/1.21.9/proto.yml
@@ -1977,11 +1977,7 @@
          default: void
    # MC: ClientboundChangeDifficultyPacket
    packet_difficulty:
-      difficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      difficulty: u8
       difficultyLocked: bool
    # MC: ClientboundChunkBatchFinishedPacket
    packet_chunk_batch_finished:
@@ -2143,21 +2139,8 @@
       chunkX: i32
    # MC: ClientboundGameEventPacket
    packet_game_state_change:
-      reason: u8 =>
-         0: no_respawn_block_available
-         1: start_raining
-         2: stop_raining
-         3: change_game_mode
-         4: win_game
-         5: demo_event
-         6: play_arrow_hit_sound
-         7: rain_level_change
-         8: thunder_level_change
-         9: puffer_fish_sting
-         10: guardian_elder_effect
-         11: immediate_respawn
-         12: limited_crafting
-         13: level_chunks_load_start
+      #TODO: Should be a mapper
+      reason: u8
       gameMode: f32
    # MC: ClientboundGameTestHighlightPosPacket
    packet_game_test_highlight_pos:
@@ -2190,13 +2173,7 @@
       x: i32
       z: i32
       heightmaps: []varint
-         type: varint =>
-            0: world_surface_wg
-            1: world_surface
-            2: ocean_floor_wg
-            3: ocean_floor
-            4: motion_blocking
-            5: motion_blocking_no_leaves
+         type: varint
          data: i64[]varint
       chunkData: ByteArray
       blockEntities: chunkBlockEntity[]varint
@@ -3262,11 +3239,7 @@
       selectedItemIndex: varint
    # MC: ServerboundChangeDifficultyPacket
    packet_set_difficulty:
-      newDifficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      newDifficulty: u8
    # MC: ServerboundChangeGameModePacket
    packet_change_gamemode:
       mode: varint =>

--- a/data/pc/1.21.9/protocol.json
+++ b/data/pc/1.21.9/protocol.json
@@ -5956,18 +5956,7 @@
           [
             {
               "name": "difficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "difficultyLocked",
@@ -6564,28 +6553,7 @@
           [
             {
               "name": "reason",
-              "type": [
-                "mapper",
-                {
-                  "type": "u8",
-                  "mappings": {
-                    "0": "no_respawn_block_available",
-                    "1": "start_raining",
-                    "2": "stop_raining",
-                    "3": "change_game_mode",
-                    "4": "win_game",
-                    "5": "demo_event",
-                    "6": "play_arrow_hit_sound",
-                    "7": "rain_level_change",
-                    "8": "thunder_level_change",
-                    "9": "puffer_fish_sting",
-                    "10": "guardian_elder_effect",
-                    "11": "immediate_respawn",
-                    "12": "limited_crafting",
-                    "13": "level_chunks_load_start"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "gameMode",
@@ -6704,20 +6672,7 @@
                     [
                       {
                         "name": "type",
-                        "type": [
-                          "mapper",
-                          {
-                            "type": "varint",
-                            "mappings": {
-                              "0": "world_surface_wg",
-                              "1": "world_surface",
-                              "2": "ocean_floor_wg",
-                              "3": "ocean_floor",
-                              "4": "motion_blocking",
-                              "5": "motion_blocking_no_leaves"
-                            }
-                          }
-                        ]
+                        "type": "varint"
                       },
                       {
                         "name": "data",
@@ -10000,18 +9955,7 @@
           [
             {
               "name": "newDifficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/26.1/protocol.json
+++ b/data/pc/26.1/protocol.json
@@ -6352,18 +6352,7 @@
           [
             {
               "name": "difficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "difficultyLocked",
@@ -6960,28 +6949,7 @@
           [
             {
               "name": "reason",
-              "type": [
-                "mapper",
-                {
-                  "type": "u8",
-                  "mappings": {
-                    "0": "no_respawn_block_available",
-                    "1": "start_raining",
-                    "2": "stop_raining",
-                    "3": "change_game_mode",
-                    "4": "win_game",
-                    "5": "demo_event",
-                    "6": "play_arrow_hit_sound",
-                    "7": "rain_level_change",
-                    "8": "thunder_level_change",
-                    "9": "puffer_fish_sting",
-                    "10": "guardian_elder_effect",
-                    "11": "immediate_respawn",
-                    "12": "limited_crafting",
-                    "13": "level_chunks_load_start"
-                  }
-                }
-              ]
+              "type": "u8"
             },
             {
               "name": "gameMode",
@@ -7115,20 +7083,7 @@
                     [
                       {
                         "name": "type",
-                        "type": [
-                          "mapper",
-                          {
-                            "type": "varint",
-                            "mappings": {
-                              "0": "world_surface_wg",
-                              "1": "world_surface",
-                              "2": "ocean_floor_wg",
-                              "3": "ocean_floor",
-                              "4": "motion_blocking",
-                              "5": "motion_blocking_no_leaves"
-                            }
-                          }
-                        ]
+                        "type": "varint"
                       },
                       {
                         "name": "data",
@@ -10450,18 +10405,7 @@
           [
             {
               "name": "newDifficulty",
-              "type": [
-                "mapper",
-                {
-                  "type": "varint",
-                  "mappings": {
-                    "0": "peaceful",
-                    "1": "easy",
-                    "2": "normal",
-                    "3": "hard"
-                  }
-                }
-              ]
+              "type": "u8"
             }
           ]
         ],

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -2108,11 +2108,7 @@
          default: void
    # MC: ClientboundChangeDifficultyPacket
    packet_difficulty:
-      difficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      difficulty: u8
       difficultyLocked: bool
    # MC: ClientboundChunkBatchFinishedPacket
    packet_chunk_batch_finished:
@@ -2274,21 +2270,8 @@
       chunkX: i32
    # MC: ClientboundGameEventPacket
    packet_game_state_change:
-      reason: u8 =>
-         0: no_respawn_block_available
-         1: start_raining
-         2: stop_raining
-         3: change_game_mode
-         4: win_game
-         5: demo_event
-         6: play_arrow_hit_sound
-         7: rain_level_change
-         8: thunder_level_change
-         9: puffer_fish_sting
-         10: guardian_elder_effect
-         11: immediate_respawn
-         12: limited_crafting
-         13: level_chunks_load_start
+      #TODO: Should be a mapper
+      reason: u8
       gameMode: f32
    # MC: ClientboundGameRuleValuesPacket
    packet_game_rule_values:
@@ -2324,13 +2307,7 @@
       x: i32
       z: i32
       heightmaps: []varint
-         type: varint =>
-            0: world_surface_wg
-            1: world_surface
-            2: ocean_floor_wg
-            3: ocean_floor
-            4: motion_blocking
-            5: motion_blocking_no_leaves
+         type: varint
          data: i64[]varint
       chunkData: ByteArray
       blockEntities: chunkBlockEntity[]varint
@@ -3409,11 +3386,7 @@
       selectedItemIndex: varint
    # MC: ServerboundChangeDifficultyPacket
    packet_set_difficulty:
-      newDifficulty: varint =>
-         0: peaceful
-         1: easy
-         2: normal
-         3: hard
+      newDifficulty: u8
    # MC: ServerboundChangeGameModePacket
    packet_change_gamemode:
       mode: varint =>


### PR DESCRIPTION
Reverts four fields that became `mapper`s in 1.21.6 while staying plain numbers in every earlier protocol, back to their exact pre-1.21.6 types:

| field | pre-1.21.6 | 1.21.6+ | this PR |
|---|---|---|---|
| `difficulty.difficulty` | `u8` | `mapper(varint)` | `u8` |
| `set_difficulty.newDifficulty` | `u8` | `mapper(varint)` | `u8` |
| `game_state_change.reason` | `u8` | `mapper(u8)` | `u8` |
| `map_chunk.heightmaps[].type` | `varint` | `mapper(varint)` | `varint` |

The wire values behind all four have never moved, so the mapper buys none of the insertion-stability a mapper is for, and it is currently breaking consumers in both directions:

- **Read.** `difficulty` now yields a string, so mineflayer's `difficultyNames[packet.difficulty]` is `undefined` and `bot.game.difficulty` is unset on 1.21.6+.
- **Write.** A numeric value throws since ProtoDef-io/node-protodef#176 made the compiled mapper reject values that aren't in the mappings. Before that it fell through to the raw value, which is why these went unnoticed for four releases. It breaks flying-squid's `game_state_change { reason: 2 }` and `difficulty { difficulty: 0..3 }`, and any client writing `set_difficulty { newDifficulty: 0..3 }`.

`difficulty`/`newDifficulty` go back to `u8` rather than the `varint` they were given here: vanilla writes the enum ordinal, and for a 4-value enum that is byte-identical to a varint, so `u8` matches the other 52 pc versions exactly.

Touches `data/pc/{1.21.6,1.21.8,1.21.9,1.21.11}/proto.yml` and `data/pc/latest/proto.yml`, with `protocol.json` regenerated via `npm run build`. `npm test` passes (1860 passing).

### Deliberately not reverted

- **`entity_action.actionId` keeps its mapper.** The two sneak actions moved to `player_input` in 1.21.6, so every ordinal after them shifted by 2 (`start_elytra_flying` went 8 → 6). Here a bare number really does mean different things per version, which is exactly the argument in #1284 for naming these — reverting it would turn mineflayer's `actionId: 2` in `bed.js` from a loud throw into a silent `stop_sprinting`. Its `entityActionUsesStringMapper` feature flag stays valid.
- **`teams.mode`** is entangled with a real 1.21.6 packet restructure (flat `mode ? if 0:` switches → an anonymous `_` switch, `friendlyFire: i8` → a `flags` bitflags). Not a revertable line.
- **`update_structure_block.flags`** landed in 1.21.5, not 1.21.6, and is mismodelled independently of this: a bitfield expressed as a 4-entry enum mapper.
- **`client_command.actionId`** (#1284) and **`use_entity.hand`** (#1278) are already in flight.

After this, those four are the only remaining fields in the pc data that are a `mapper` in some versions and a raw number in others.

### On the wider direction

@extremeheat — this cuts against your suggestion on #1284 of mapper-ising everything, so to be explicit about where I think the line is: I agree names are the right long-run representation, and the insertion-stability argument is real (`entity_action` above is a live example of it). What makes the 1.21.6 batch a problem isn't the direction, it's that it landed per-version on fields whose numbers were never unstable, which means consumers pay a migration for no stability gain and end up with version-gated branches like mineflayer's `entityActionUsesStringMapper`.

If we do want to go wide, the sequencing that would make it painless is worth doing first:

1. Teach ProtoDef's `mapper` to accept the underlying wire value on write as well as the name — i.e. after the name lookup fails, accept the value if it is itself a key of `mappings`. An unmapped *name* still throws, so #176's guarantee is untouched, but mapper-ising a field stops being a breaking change on the write side.
2. Source the names from the game rather than by hand, so new versions arrive correct — the decompiled `writeEnum`/`readEnum` call sites give ordinal order mechanically, and minecraft-data-generator could emit an `enums.json`.
3. Add a CI audit: a field that is a mapper in any version must be a mapper in every version where it exists. That both prevents another per-version drift and gives the exact field list downstream needs to grep for.

Happy to do (1) and (3) as follow-ups if that sounds right.
